### PR TITLE
Prepare the OSS repo for launch (v0.1.0 docs + community files)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo. Requested for review on every PR.
+* @bobbykrk

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Something in the topos CLI or the topos-plane server behaves incorrectly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. **Do not report security vulnerabilities here** — use the private channel
+        in [SECURITY.md](https://github.com/topos-sh/topos/security/policy) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: |
+        Steps to reproduce:
+        1. `topos ...`
+        2. ...
+
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - topos (CLI)
+        - topos-plane (server)
+        - installer / packaging
+        - not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `topos --version` (or the plane image tag / commit).
+      placeholder: "topos 0.1.0"
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: OS and architecture (e.g. macOS arm64, Linux x86_64), and the harness if relevant.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: |
+        Relevant output. The CLI logs to `~/.topos/log.jsonl`; `TOPOS_DEBUG=1` prints the full error chain.
+        **Redact any tokens, invite links, or secrets before pasting.**
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/topos-sh/topos/security/advisories/new
+    about: Report a vulnerability privately — please do not open a public issue.
+  - name: Question or discussion
+    url: https://github.com/topos-sh/topos/discussions
+    about: Ask a question, share an idea, or discuss usage.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an improvement or a new capability.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case or the friction, not just the solution you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like Topos to do? Sketch the CLI surface or the behavior if you can.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why they fall short.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thanks for contributing to Topos! Keep PRs focused; open an issue first for anything large. -->
+
+## What & why
+
+<!-- What does this change do, and why? Link any related issue: Closes #123 -->
+
+## Checklist
+
+- [ ] `cargo xtask ci` passes locally (fmt, clippy, doc, drift gates, check-arch)
+- [ ] `cargo test` passes (with a reachable `DATABASE_URL`) — or N/A, explain below
+- [ ] Tests added/updated for behavior changes
+- [ ] If wire types or SQL changed: regenerated the contract (`gen-schema` / `gen-fixtures`) and/or `.sqlx` metadata, and committed the result
+- [ ] Living docs updated in this change (per-folder `CLAUDE.md` status; `CHANGELOG.md` entry for a shipped increment)
+
+## Notes for reviewers
+
+<!-- Anything that helps the review: trade-offs, follow-ups, areas you're unsure about. -->
+
+---
+
+By opening this pull request I agree that my contribution is licensed to the project under the Apache-2.0
+license (inbound = outbound; no CLA — see CONTRIBUTING.md).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,138 @@
+# Architecture
+
+This is the public design doc for the Topos OSS core: the shape of the code, the trust boundaries it
+enforces, and the model behind sharing a behavior byte-exactly. For how to build and contribute, see
+[`CONTRIBUTING.md`](CONTRIBUTING.md); for the security posture, [`SECURITY.md`](SECURITY.md).
+
+## What this repository is
+
+Topos is a layer for AI agents to **share their behaviors** within a team — so every agent stays current
+with the same company processes. A *behavior* (a "skill") is a bundle of files (`SKILL.md` + scripts +
+reference docs); the **whole bundle** is the unit of trust.
+
+The repository is two programs in one Apache-2.0 Cargo workspace:
+
+- **`topos`** — the local CLI an agent drives to add, follow, publish, and update behaviors across harnesses.
+- **`topos-plane`** — the self-hostable sharing server (a library plus a thin binary).
+
+They share one trust kernel, `topos-core`: the single, auditable implementation of the byte-exact digest,
+consent, signing, and sync algorithm. Nothing proprietary lives here.
+
+## The two motions
+
+1. **Distribute.** An author `publish`es a bundle; a teammate `follow`s it and every subsequent `pull`
+   lands the team's `current` version byte-exact, signature-verified. A session-start hook runs the pull, so
+   updates arrive at the start of each agent session — never over the user's local edits.
+2. **Contribute.** Anyone can `publish --propose` a candidate version; a reviewer `review --approve`s it to
+   make it `current` (a PR-like flow). `revert --to` rolls the whole team forward to older bytes without
+   deleting anything.
+
+## The crate graph (acyclic)
+
+Every split is paid for by a real boundary — a testable-authority boundary, a platform-dependency boundary,
+or the storage-privacy boundary — never a crate-per-noun.
+
+```
+topos-types   the shared wire DTOs (the --json envelope, receipts, the signed-pointer envelope). No logic.
+topos-core    the PURE trust kernel — no I/O, no traits, no clock/RNG. Owns the byte-exact digest, the
+   ▲   ▲      consent truth-table, the sync-state transition, the diff3 policy, and the Ed25519
+   │   │      sign-preimage + verify. Every trust invariant is a unit/property test here.
+   │   ├── topos-gitstore ──► topos-core     (git object mechanics; diff/diff3 execution; large objects)
+   │   └── topos-harness  ──► topos-core, topos-types   (the client-side harness port + its impls)
+   │
+plane-store   ──► topos-core, topos-types, topos-gitstore    (the server authority: private SQL + authz + txn)
+topos-plane   ──► plane-store, topos-core, topos-types       (the OSS plane: lib + thin bin)
+topos         ──► topos-core, topos-types, topos-gitstore, topos-harness   (the CLI)
+              └── NO edge to plane-store / sqlx   ◄── enforced architectural layering
+```
+
+Heavy dependencies are placed deliberately and the placement is enforced by `cargo xtask check-arch`:
+`sqlx` is referenced by `plane-store` only (and kept out of the client build); `axum` powers the plane's
+HTTP server, `ureq` the client's blocking transport. The optional OIDC enrollment connector is feature-
+gated **default-off** — a production-tree check asserts a default build resolves none of it.
+
+## Trust boundaries — the load-bearing invariants
+
+- **One trust implementation.** Every trust decision — digest, consent, the sync transition, diff3, the
+  signing preimage — is written once, in `topos-core`, the only crate with no I/O. The plane, the CLI, the
+  fixtures, and the tests all link it, so no second implementation can drift.
+- **The client is never an authority.** `topos` takes no dependency on `plane-store`, `sqlx`, or a SQL
+  driver. It is a thin sync tool; the dependency graph enforces this at build time.
+- **The plane is a library, composed — not a framework with holes.** `topos-plane`'s lib exposes clean
+  authority operations plus a `router(state)` builder, and has no extension or callback hook. A separate
+  product can import and compose this library around the authority, but the authority is never reimplemented
+  and never bypassed.
+- **`plane-store` keeps raw SQL and raw git reads private (`pub(crate)`).** Only authorized authority
+  operations are public — that privacy boundary is what forces every object read through the access check.
+- **Disclosure and integrity, not a second permission system.** The tool guarantees that nothing lands that
+  was not disclosed and pinned. How much a human sits in the loop is the harness's job. See
+  [`SECURITY.md`](SECURITY.md).
+
+## The consent + sync model
+
+- **Bundle digest.** A version's identity is a plain sha256 over the raw bytes of every file in the bundle —
+  no normalization. `<skill>@<hash>` pins the exact bytes. A *version* is an immutable, content-addressed
+  snapshot of the whole bundle.
+- **`current`.** The one movable pointer a team follows. `publish` moves it forward, `review --approve`
+  moves it sideways to a proposal, `revert --to` moves it forward while restoring older bytes.
+- **Signed pointers, monotonic generations.** The plane signs each `current` move with its Ed25519 key.
+  A follower pins the plane key on first follow and verifies every pointer; a pointer's generation only
+  increases, and a follower refuses any pointer at or below the highest it has seen (anti-rollback).
+- **Four-state client transition.** On pull, the client computes where it is (current, behind, diverged,
+  or conflicted) and applies the result with an **atomic directory swap** — a materialization is all-or-
+  nothing, never a half-written bundle. A diverged local draft is resolved with a three-way (diff3) merge
+  and surfaced, never silently overwritten.
+- **Concurrency at the plane.** A pointer move is a serializable `(epoch, seq)` compare-and-set: two authors
+  racing the same skill produce one winner and one honest `CONFLICT`, never a lost write.
+
+## Storage
+
+The plane keeps three kinds of state:
+
+- **A Postgres metadata database** — the authority: rosters, pointers, proposals, receipts, enrollment. All
+  access goes through `plane-store`; raw SQL is private to that crate.
+- **A git object store** — content-addressed bundle bytes, with a verify-on-read check (bytes are
+  re-hashed to their id on every read) and a quarantine/lease/GC lifecycle fence.
+- **A size-routed large-object store** — larger blobs offloaded to the local filesystem beside the git
+  store. (An S3-compatible remote backend is planned and additive.)
+
+Compilation is offline: the compile-time-checked SQL queries read committed `.sqlx` metadata, so
+`cargo build`, `clippy`, and `doc` need no database — only running the test suite does.
+
+## Contracts (generated, never hand-written)
+
+The cross-language contract lives in `contracts/`: a JSON-Schema per wire type, per verb payload, and per
+persisted document; golden `--json` fixtures validated both positively and negatively; and the plane's
+OpenAPI. All of it is **generated** from the Rust types by `xtask` and **drift-gated** in CI — change the
+types, regenerate, review the diff. This is what lets other languages depend on the wire without depending
+on the Rust.
+
+## Harness adapters
+
+A harness is *which directories to read and write* plus *when a currency check fires* — no dialect
+translation in the OSS core (bytes sync exactly within a harness family). The `HarnessAdapter` port in
+`topos-harness` is the one client-side seam; the **Claude Code** adapter is the reference implementation
+(discovery, adopt-in-place, an idempotent session-start currency hook, clean uninstall). Adding a harness
+is a directory map plus a currency trigger, not a refactor.
+
+## The gates
+
+`cargo xtask ci` runs the full non-database gate sequence in CI's order: `fmt --check`, `clippy -D
+warnings`, `doc -D warnings`, the schema / fixture / OpenAPI drift gates, and `check-arch` (which enforces
+the layering, the leaf-crate leanness, the OIDC-default-off claim, and the toolchain/Docker pin pair). The
+Postgres-backed test suite, `cargo-deny`, and a compose smoke run round out CI. A tagged release reuses the
+exact same gate before it builds anything.
+
+## Directory map
+
+| Path | What |
+|---|---|
+| `crates/` | the five library crates — the trust kernel, storage, and the ports |
+| `bins/` | the two programs — the CLI (`topos`) and the plane (`topos-plane`) |
+| `contracts/` | the generated, committed cross-language contract |
+| `xtask/` | codegen plus the invariant gates (`ci`, `check-arch`, the drift gates) |
+| `tests/` | the workspace-level loopback-HTTP end-to-end suites |
+| `scripts/` | the installer, the compose smoke, the ACME rehearsal |
+
+Each folder carries a `CLAUDE.md` (symlinked as `AGENTS.md`) with that unit's contract; the root
+`CLAUDE.md` is the map. `CHANGELOG.md` is the increment-by-increment delivery history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 Delivery history, **newest first** — the increment-by-increment story of how this repository was built.
 This file is *history*, not status: the current state of every area lives in the root `CLAUDE.md` status
-table and in each crate's own `CLAUDE.md`. There are no version numbers yet (nothing is released); each
-entry is one shipped increment.
+table and in each crate's own `CLAUDE.md`. Version **0.1.0** is the first public release; the entries below
+are the increment-by-increment history that leads up to it, each one a shipped increment.
 
 ## The web-session review lane — browser-side approve/reject on a hosted composition
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,109 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free
+experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy
+community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the
+  experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit
+  permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will
+take appropriate and fair corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki
+edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate
+reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially
+representing the community in public spaces. Examples of representing our community include using an official
+email address, posting via an official social media account, or acting as an appointed representative at an
+online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders
+responsible for enforcement at **robert@topos.sh**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any
+action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in
+the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of
+the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time.
+This includes avoiding interactions in community spaces as well as external channels like social media.
+Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for
+a specified period of time. No public or private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms
+may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained
+inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of
+individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to Topos
+
+Thanks for your interest in Topos. This guide covers how to build, test, and propose changes. By
+participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+- **Found a security issue?** Do **not** open a public issue — follow [`SECURITY.md`](SECURITY.md).
+- **Want to understand the design first?** Read [`ARCHITECTURE.md`](ARCHITECTURE.md) and the `CLAUDE.md` in
+  the folder you're working in (each one is that unit's contract).
+
+## Ways to contribute
+
+- **Report a bug** or **request a feature** via the issue templates.
+- **Open a pull request** for a fix, a test, a doc improvement, or a feature.
+- **Improve the docs** — the README, the per-folder `CLAUDE.md`s, or these guides.
+
+For anything larger than a bug fix, please open an issue to discuss the approach first — it saves everyone a
+round-trip.
+
+## Development setup
+
+You need a recent stable Rust and (only for the tests) a reachable Postgres.
+
+- **Rust toolchain.** Pinned in `rust-toolchain.toml` (stable 1.96, edition 2024); `rustup` picks it up
+  automatically. `unsafe` code is forbidden workspace-wide.
+- **Postgres** — only the test suite needs it (compilation is offline). A throwaway one:
+
+  ```sh
+  docker run --rm -e POSTGRES_USER=topos -e POSTGRES_PASSWORD=topos \
+    -e POSTGRES_DB=topos -p 5432:5432 postgres:18
+  export DATABASE_URL="postgres://topos:topos@localhost:5432/topos"
+  ```
+
+## Build, test, lint
+
+```sh
+cargo build
+cargo xtask ci    # the full non-DB gate sequence, in CI's order
+cargo test        # requires DATABASE_URL + a reachable Postgres (above)
+```
+
+**`cargo xtask ci` is the pre-push loop** — one command that matches CI's gate job exactly: `fmt --check`,
+`clippy -D warnings`, `doc -D warnings`, the schema / fixture / OpenAPI drift gates, and `check-arch`. Run
+it before you push and your PR's gate job will pass. (The `xtask` alias lives in the committed
+`.cargo/config.toml`.)
+
+Compilation itself needs no database — the compile-time-checked queries read the committed
+`crates/plane-store/.sqlx` metadata. Only running the tests hits Postgres, which the suite provisions per
+test.
+
+### If you change the wire types or SQL
+
+Two things in this repo are **generated and drift-gated**, so a change there is a two-step:
+
+- **Wire types (`topos-types`).** After editing them, regenerate the contract and commit the result:
+  `cargo xtask gen-schema` and `cargo xtask gen-fixtures`. The drift gate fails if the committed
+  `contracts/` output doesn't match the types.
+- **SQL queries (`plane-store`).** If you add or change a compile-time-checked query, regenerate the offline
+  metadata (`cargo sqlx prepare` against a live `DATABASE_URL`) and commit the `.sqlx/` change, or CI's
+  offline-metadata drift gate will fail.
+
+## Pull request process
+
+1. Fork and branch from `main`.
+2. Keep the change focused; a small PR is reviewed faster than a large one.
+3. Add or update tests for behavior changes. Unit tests live inline (`#[cfg(test)] mod tests`); multi-file
+   suites live in `src/tests/` or the workspace `tests/` crate.
+4. Update the living docs **in the same change**: the per-folder `CLAUDE.md` status lists and, for a shipped
+   increment, a `CHANGELOG.md` entry (newest first). A doc that describes the old behavior is a bug.
+5. Make sure `cargo xtask ci` and `cargo test` are green locally.
+6. Write commit messages that say **what changed and why**, in the imperative mood. Keep them self-contained.
+7. Open the PR against `main` and fill in the template. CI must pass before merge.
+
+Match the surrounding code's idiom, comment density, and naming — a change should read like the code around
+it.
+
+## Licensing of contributions
+
+Topos is licensed under **Apache-2.0**. Contributions are **inbound = outbound**: when you submit a pull
+request, you agree that your contribution is licensed to the project under the same Apache-2.0 license, and
+you affirm you have the right to submit it under that license (this is the effect of Section 5 of the
+Apache License). **There is no separate CLA to sign** — opening the PR is the agreement. Please only submit
+work that is yours to contribute.
+
+## Questions
+
+Open a [discussion or issue](https://github.com/topos-sh/topos/issues). For anything sensitive or
+security-related, use the private channel in [`SECURITY.md`](SECURITY.md).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,7 +3077,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "topos"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "axum",
  "ed25519-dalek",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "diffy",
  "gix",
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "serde_json",
  "topos-core",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "jsonschema",
  "schemars 1.2.1",
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.1.0" # first public release; members inherit via `version.workspace = true`
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Topos
+Copyright 2026 Robert Krajewski
+
+This product is licensed under the Apache License, Version 2.0 (see the LICENSE file).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Topos
 
+[![CI](https://github.com/topos-sh/topos/actions/workflows/ci.yml/badge.svg)](https://github.com/topos-sh/topos/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
 A layer for AI agents to **share their behaviors** across a team — so every agent stays current with the
 same company processes and everyone gets a consistent experience. A *behavior* (a "skill") is a bundle of
 files (`SKILL.md` + scripts + reference docs); the **whole bundle** is the unit of trust.
@@ -309,6 +312,27 @@ bump). Two things to watch:
   pointer's `epoch + 1`), so a repeated restore can never re-issue a generation followers already
   recorded. Keep the helper's printed output with your backup records.
 
+## Trust & security
+
+A behavior you follow is code and prose that runs inside your agent, so integrity and consent are the whole
+point of the tool. In short: a bundle's identity is a **byte-exact sha256** over every file (different bytes
+are never "the same"), the plane **signs** every `current` pointer and a follower **pins the plane key** on
+first follow and verifies every move, and **nothing lands that was not disclosed and pinned** — no silent
+overwrites, ever. What Topos does *not* do is judge whether an approved behavior is safe to run: it
+guarantees disclosure and integrity, not a sandbox or a second permission system. The full trust model —
+what it protects, what it deliberately does not, and how to run a plane safely — is in
+[`SECURITY.md`](SECURITY.md), which is also where you report a vulnerability (privately).
+
+## Project docs
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — the design: crate graph, trust boundaries, the consent + sync model.
+- [`SECURITY.md`](SECURITY.md) — the trust model and how to report a vulnerability.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to build, test, and propose changes.
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — community expectations.
+- [`CHANGELOG.md`](CHANGELOG.md) — the increment-by-increment delivery history.
+
 ## License
 
-Apache-2.0 — see [`LICENSE`](LICENSE).
+Apache-2.0 — see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE). Copyright 2026 Robert Krajewski.
+
+Contributions are inbound = outbound under Apache-2.0 (no CLA); see [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,132 @@
+# Security policy
+
+Topos is infrastructure for sharing the behaviors that drive AI agents. A shared behavior is code and
+prose that runs inside your agent, so integrity and consent are the whole point of the tool. This document
+states what the trust model protects, what it deliberately does **not**, how to run a plane safely, and how
+to report a vulnerability.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security report.** Use GitHub's private vulnerability reporting:
+
+> **[Report a vulnerability](https://github.com/topos-sh/topos/security/advisories/new)**
+> (repository → **Security** → **Advisories** → **Report a vulnerability**)
+
+This opens a private advisory visible only to you and the maintainers. Include, where you can:
+
+- what an attacker gains (the impact), and the trust boundary it crosses;
+- the affected component (`topos` CLI, the `topos-plane` server, or a specific crate) and version;
+- a minimal reproduction — commands, a bundle, or a request sequence.
+
+We aim to acknowledge a report within **72 hours** and to keep you updated as we confirm, fix, and prepare a
+release. We will credit reporters who want credit. Because Topos is pre-1.0, security fixes ship on the
+**latest release** only; there is no back-port line yet.
+
+| Version | Supported |
+|---|---|
+| latest `0.x` release | ✅ |
+| older `0.x` | ❌ (upgrade to latest) |
+
+## The trust model — what Topos guarantees
+
+The unit of trust is the **whole bundle** (`SKILL.md` + scripts + reference docs), because prose can drive
+an agent as surely as a script can. Three mechanisms carry the guarantee, and all three are implemented
+**once**, in the pure `topos-core` kernel — the single, auditable trust implementation that the CLI, the
+plane, the tests, and the generated contracts all link.
+
+- **Byte-exact digest.** A bundle's identity is a plain sha256 over the raw bytes of every file — no
+  normalization, no canonicalization. Different bytes are never "the same" bundle. `<skill>@<hash>` pins
+  that exact digest.
+- **Explicit, end-to-end consent.** Nothing lands that was not first disclosed and pinned. Publishing
+  requires `--approve <skill>@<digest>` against the exact bytes being shipped; following requires approving
+  the disclosed first version. There are no silent overwrites — a follower's local edits (a *diverged
+  draft*) are surfaced, never clobbered.
+- **Signed, monotonic pointers.** A team follows one movable `current` pointer per skill. The plane signs
+  every pointer move with an Ed25519 key; a follower **pins that plane key on first follow** and verifies
+  every subsequent pointer against it. Pointers carry a monotonic generation, and a follower refuses any
+  pointer at or below the highest generation it has already seen (anti-rollback) — a restored-from-backup
+  or replayed older pointer raises an alarm rather than moving a team backward.
+
+The result: what a human (or a delegated reviewer) approved is byte-for-byte what every agent receives,
+and a compromised transport cannot substitute different bytes without failing verification.
+
+### Trust boundaries
+
+- **The client is never an authority.** `topos` is a thin sync tool. It holds no database, computes no
+  authoritative roster, and takes no dependency on the server's storage crate — a dependency-graph check
+  (`cargo xtask check-arch`) enforces this at build time.
+- **The plane is the authority for the pointer and the roster**, and nothing else. It signs pointers and
+  gates who may read or write a workspace's skills.
+- **Integrity and disclosure, not a second permission system.** See below.
+
+## What Topos deliberately does NOT do
+
+Read this part carefully — it is where most misconceptions live.
+
+- **Topos is not a sandbox and not a permission system.** A behavior you follow is code and prose that runs
+  inside your harness with your harness's permissions. Topos guarantees that the bytes are exactly what was
+  disclosed and approved; it does **not** judge whether those bytes are safe to run. *How much a human sits
+  in the loop before an approved behavior executes is the job of your agent/harness setup, never this tool.*
+  Only follow skills from a workspace you trust, and use the **review-required** gate (below) for skills
+  where a second human must approve every change.
+- **The digest proves integrity, not safety.** A signed, byte-exact bundle can still contain a hostile
+  script. Signing and pinning guarantee provenance and consent — that this is the bundle the workspace
+  published and you approved — not that its contents are benign.
+- **The installer checksum proves transit integrity, not origin.** The installer downloads `SHA256SUMS`
+  over TLS from the same origin as the binary and refuses to install on a mismatch. That proves the bytes
+  you got are the bytes the release published; it does not prove *who* published them (whoever controls the
+  release controls both files). For origin integrity, verify the Sigstore build-provenance attestation:
+
+  ```sh
+  gh attestation verify topos-<target>.tar.gz --repo topos-sh/topos
+  ```
+
+### The anti-poisoning lever: review-required
+
+By default a workspace owner can move `current` directly. A plane operator can turn on a **review-required**
+gate per workspace, after which a change must be `publish --propose`d and a **second** party must
+`review --approve` it before it becomes `current` (four-eyes). This is the primary defense against a single
+compromised author poisoning a followed behavior. It is off by default; enabling it is an operator (admin
+token) or hosted-composition action.
+
+## Operating a plane safely
+
+If you self-host the plane, these are the postures to know. Some are deliberate v0 trade-offs, stated
+plainly.
+
+- **TLS terminates at a reverse proxy (the supported default).** The plane serves plain HTTP on `:8787` and
+  is designed to sit behind a TLS-terminating reverse proxy (Caddy, nginx, Traefik, or your platform's load
+  balancer), which owns certificates and renewal. Do not expose `:8787` directly to the internet. An
+  optional, default-off, **experimental** built-in ACME listener exists but is unproven on a real box — the
+  reverse proxy is the documented, supported path. See the README's self-hosting section.
+- **The plane's keys are plaintext `0600` seeds at rest.** On first boot the plane generates its Ed25519
+  signing key and its enrollment HMAC secret as `0600` files on the mounted data volume. At-rest encryption
+  is **not yet implemented**, so the security of those two files is the security of the volume: restrict
+  access to it, back it up like a secret, and never commit or log it. Losing or replacing the signing key
+  is a key-rotation event — every follower that pinned the old key fails closed.
+- **Invite, enrollment, and read tokens are bearer capabilities.** A `/i/<token>` link or a device grant is
+  a secret: anyone holding it can act with its scope. Treat minted links like passwords, and prefer
+  short-lived distribution. The plane derives them deterministically from the enrollment secret, so
+  protecting that seed protects them all.
+- **The admin token gates operator routes.** `TOPOS_PLANE_ADMIN_TOKEN` enables the review-required policy
+  route; while unset that route answers 404. Only its sha256 is retained. Give it the handling of a root
+  credential.
+- **Back up in the right order.** Snapshot the object store **before** the database, and re-issue pointers
+  through the plane after an *older*-than-current restore (anti-rollback will otherwise fail-close
+  followers). The README's "Backups & restore" section is the procedure.
+- **Secrets are never logged.** SMTP credentials, tokens, and keys are kept out of the JSON logs by
+  construction; report any leak into logs as a vulnerability.
+
+## Scope
+
+In scope: the `topos` CLI, the `topos-plane` server and its library crates, the release pipeline, and the
+installer — anything in this repository. Out of scope: misconfiguration of a self-hosted deployment against
+this document's guidance, third-party dependencies (report those upstream; we track advisories with
+`cargo-deny` in CI), and any separate hosted product built on top of this OSS core.
+
+## Supply-chain posture
+
+- The toolchain and the Docker builder image are pinned, and the pin pair is drift-gated in CI.
+- `cargo-deny` runs on every change for advisories **and** license compliance.
+- Releases publish SBOMs and Sigstore build-provenance attestations for every artifact.
+- `unsafe` code is forbidden workspace-wide (`#![forbid(unsafe_code)]`).

--- a/bins/topos-plane/Cargo.toml
+++ b/bins/topos-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-plane"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/bins/topos/Cargo.toml
+++ b/bins/topos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/plane-store/Cargo.toml
+++ b/crates/plane-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-store"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/topos-core/Cargo.toml
+++ b/crates/topos-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-core"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/topos-gitstore/Cargo.toml
+++ b/crates/topos-gitstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-gitstore"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/topos-harness/Cargo.toml
+++ b/crates/topos-harness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-harness"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/topos-types/Cargo.toml
+++ b/crates/topos-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-types"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,12 +5,13 @@ check an item off in the same change that lands it.
 
 ## Launch-gate artifacts (authored fresh, in-repo)
 
-- [ ] `SECURITY.md` — the trust model (what the digest/signature/consent chain does and does not protect
-      against) + a vulnerability-reporting channel.
-- [ ] `ARCHITECTURE.md` — the public design doc: the crate graph, the trust boundaries (client is never an
-      authority; the plane is a composable library), the sync/consent model.
-- [ ] `CONTRIBUTING.md` — how to build (`cargo xtask ci`), run the Postgres-backed suite
-      (`DATABASE_URL` + `cargo test`), and propose changes.
+- [x] `SECURITY.md` — the trust model (what the digest/signature/consent chain does and does not protect
+      against) + a vulnerability-reporting channel (GitHub private advisories). DONE.
+- [x] `ARCHITECTURE.md` — the public design doc: the crate graph, the trust boundaries (client is never an
+      authority; the plane is a composable library), the sync/consent model. DONE.
+- [x] `CONTRIBUTING.md` — how to build (`cargo xtask ci`), run the Postgres-backed suite
+      (`DATABASE_URL` + `cargo test`), and propose changes (inbound = outbound, no CLA). DONE. A
+      `CODE_OF_CONDUCT.md`, a `NOTICE` (copyright), issue/PR templates, and `CODEOWNERS` landed alongside.
 
 ## History hygiene (before the first public push)
 
@@ -30,10 +31,12 @@ check an item off in the same change that lands it.
 - [x] **First-boot workspace standup**: DONE — the binary mints the one-time claim in-band
       (`topos-plane mint-claim` prints the `/i/` link exactly once; the token never enters tracing), and
       one `topos follow <claim-link>` seats the first owner. The README's self-host walkthrough shows it.
-- [ ] **TLS posture**: the plane serves plain HTTP — the reverse-proxy termination pattern must be
-      documented as the supported deployment (it is, in the README; restate it in `SECURITY.md`).
-- [ ] **At-rest key posture**: the plane signing key + enrollment secret are plaintext `0600` seeds;
-      either encrypt at rest or state the posture in `SECURITY.md`.
+- [x] **TLS posture**: the plane serves plain HTTP — the reverse-proxy termination pattern is documented as
+      the supported deployment (in the README, and restated in `SECURITY.md` under "Operating a plane
+      safely"). DONE.
+- [x] **At-rest key posture**: the plane signing key + enrollment secret are plaintext `0600` seeds; the
+      posture is stated plainly in `SECURITY.md` (at-rest encryption is not yet implemented; protect the
+      volume). DONE — stated, not yet encrypted.
 
 ## Already in place (verify green at the gate)
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-e2e"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Everything needed **inside the repo** to make it public as **v0.1.0**. Leaves the actual publishing acts (flip to public, tag, release) for a human — see the runbook below.

## What's in this PR

**Launch-gate docs (authored fresh, in-repo — no private material):**
- `SECURITY.md` — the trust model (what the byte-exact digest, Ed25519 pointer signing, and consent chain protect, and what they deliberately do *not* — it is not a sandbox/permission system), the self-host security posture (reverse-proxy TLS default, plaintext-`0600`-key at-rest posture, bearer-token handling), and a **GitHub private-advisory** reporting channel.
- `ARCHITECTURE.md` — crate graph, trust boundaries (client is never an authority; the plane is a composable library), the consent + sync model, storage, contracts.
- `CONTRIBUTING.md` — build/test (`cargo xtask ci`, the Postgres suite), the generated-contract workflow, and the **inbound = outbound, no-CLA** licensing stance.

**Community-health + attribution:**
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `NOTICE` (`Copyright 2026 Robert Krajewski`), `.github/ISSUE_TEMPLATE/*`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/CODEOWNERS`.

**README + version:**
- README gains a **Trust & security** section, a project-docs index, and CI + license badges.
- Workspace version set to **0.1.0** (all members inherit); `topos --version` → `topos 0.1.0` (release CI smoke-tests this).
- `docs/RELEASE.md` gate items checked off; CHANGELOG intro aligned to 0.1.0.

## Verification
- `cargo xtask ci` — all 6 gates green (fmt, clippy, doc, schema + fixture drift, check-arch).
- `cargo build -p topos` green; `topos --version` prints `0.1.0`.
- Guardrail leak-scan clean over all new/changed files and the commit message (only the allowed AWS `S3-compatible` hit).
- LICENSE left byte-canonical (Apache appendix is the how-to-apply template); copyright asserted via `NOTICE` + README instead.

## Decisions applied (per your sign-off)
- Copyright holder: **Robert Krajewski** (no legal entity yet — easy to reassign later).
- Contribution model: **inbound = outbound, no CLA** (simplest standard stance).
- Distribution: **installer + Docker only** (`publish = false` untouched — no crates.io).
- Version **v0.1.0**; security → **GitHub private advisories**.

## Already applied to the repo settings (safe; invisible until public)
- Topics set: `rust, ai-agents, cli, agents, skills, agent-tools, self-hosted, apache2`.
- Dependabot **vulnerability alerts + automated security fixes** enabled.

## Go-live runbook — the acts left for you (NOT done here, per "don't publish yet")
1. **Merge this PR** to `main`. (Optionally merge PR #1 / team-revert first if you want it in the cut.)
2. **Flip the repo to Public** (Settings → General → Danger Zone). Then, still in Settings → Security, enable **Private vulnerability reporting** (only available once public — the `SECURITY.md` link depends on it) and, if you want, **secret scanning + push protection**.
3. **Add branch protection** on `main` (now available once public): require the `ci` checks to pass, block force-push.
4. **Dry-run the release**: Actions → `release` → Run workflow (`workflow_dispatch`) — builds every artifact but publishes nothing.
5. **Cut the release**: `git tag v0.1.0 && git push origin v0.1.0`. This runs the gate, builds the CLI tarballs + `SHA256SUMS` + `install.sh` asset + the GHCR image + SBOMs + attestation, and creates the GitHub release — making `releases/latest/…/install.sh` live.
6. **Smoke the published install** on a clean box: `curl -fsSL https://github.com/topos-sh/topos/releases/latest/download/install.sh | sh`, then `gh attestation verify …`.
7. Optional: set the repo **homepage URL** (e.g. `https://topos.sh`), enable **Discussions** (the issue-template config links to it), add a social-preview image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)