### PR TITLE
One dev outbox: every suppressed mail accumulates in .outbox.jsonl

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -9,5 +9,6 @@ playwright-report/
 *.tsbuildinfo
 .invite-emails.jsonl
 .magic-links.jsonl
+.outbox.jsonl
 .passcode-emails.jsonl
 tests/e2e/.auth/

--- a/web/app/lib/mail/dev-outbox.server.ts
+++ b/web/app/lib/mail/dev-outbox.server.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { MailMessage } from "@/lib/mail/transport.server";
+
+/**
+ * The ONE accumulating dev outbox — `.outbox.jsonl` in the server's working directory. Outside
+ * production every product mail lands here as one JSON line (`{at, kind, to, subject, text,
+ * html?}`): the exact message production would hand the transport, so a human tester watches a
+ * single file to see everything the app "sent". The per-flow credential files
+ * (`.magic-links.jsonl`, `.passcode-emails.jsonl`, `.invite-emails.jsonl`) stand unchanged —
+ * each flow's reader parses its OWN file; this one is the superset view, read by humans, never
+ * parsed back into a flow.
+ */
+
+export const DEV_OUTBOX_FILE = ".outbox.jsonl";
+
+/** Which product flow produced the mail — a display/filter tag, never branched on. */
+export type DevMailKind = "magic-link" | "passcode" | "invite";
+
+/** Append one full rendered mail to the accumulating dev outbox (non-production callers only). */
+export async function recordDevMail(kind: DevMailKind, message: MailMessage): Promise<void> {
+  const entry = { at: new Date().toISOString(), kind, ...message };
+  const line = `${JSON.stringify(entry)}\n`;
+  await fs.appendFile(path.join(process.cwd(), DEV_OUTBOX_FILE), line, "utf8");
+}

--- a/web/app/lib/mail/invite-mail.server.ts
+++ b/web/app/lib/mail/invite-mail.server.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { serverEnv } from "@/env.server";
+import { recordDevMail } from "@/lib/mail/dev-outbox.server";
 import { escapeHtml, mailDelivery, sendMail } from "@/lib/mail/transport.server";
 
 /**
@@ -14,8 +15,9 @@ import { escapeHtml, mailDelivery, sendMail } from "@/lib/mail/transport.server"
  * unset, production is a deliberate no-op and the honest `mailed` flag stays false. Outside
  * production the notice is recorded to its OWN file, `.invite-emails.jsonl` (NEVER
  * `.magic-links.jsonl`, whose reader parses every line and would hand a sign-in flow the wrong
- * thing), plus the dev-server terminal — the two sanctioned non-email surfaces. A missing or
- * failed send never loses the invite, because the seat + the address already stand.
+ * thing), the full mail to the accumulating dev outbox, plus the dev-server terminal — the
+ * sanctioned non-email surfaces. A missing or failed send never loses the invite, because the
+ * seat + the address already stand.
  */
 
 export interface InviteEmailInput {
@@ -86,10 +88,13 @@ export async function sendInviteEmail(input: InviteEmailInput): Promise<void> {
     return;
   }
   // Dev/test: record the notice to its OWN file so a flow can assert it (never a send, never the
-  // magic-link file). The recorded fields carry the address — a plain slug, not a token.
+  // magic-link file), plus the full mail to the accumulating dev outbox. The recorded fields
+  // carry the address — a plain slug, not a token.
   const { to, workspaceDisplayName, address, invitedBy } = input;
   const line = `${JSON.stringify({ to, workspaceDisplayName, address, invitedBy })}\n`;
   await fs.appendFile(path.join(process.cwd(), ".invite-emails.jsonl"), line, "utf8");
+  const { subject, text, html } = inviteLines(input);
+  await recordDevMail("invite", { to, subject, text, html });
   if (appEnv === "development") {
     // biome-ignore lint/suspicious/noConsole: the deliberate dev-only invite surface.
     console.log(`\n  Invite for ${to} (dev — mail suppressed): follow ${address}\n`);

--- a/web/app/lib/mail/magic-link-mail.server.ts
+++ b/web/app/lib/mail/magic-link-mail.server.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { serverEnv } from "@/env.server";
+import { recordDevMail } from "@/lib/mail/dev-outbox.server";
+import type { MailMessage } from "@/lib/mail/transport.server";
 import { escapeHtml, sendMail } from "@/lib/mail/transport.server";
 
 /**
@@ -13,21 +15,12 @@ import { escapeHtml, sendMail } from "@/lib/mail/transport.server";
  * failure to the login form — a silently-dropped link would read as a broken sign-in); it never
  * lands in a log or an error. Outside production the link is recorded to `.magic-links.jsonl`
  * (its OWN file — the invite notice must never land here, this file's reader hands sign-in flows
- * their link) plus the dev terminal, so the real sign-in flow works with mail suppressed.
+ * their link), the full mail to the accumulating dev outbox, and the dev terminal, so the real
+ * sign-in flow works with mail suppressed.
  */
 export async function sendMagicLinkEmail(args: { email: string; url: string }): Promise<void> {
   const { email, url } = args;
-  const appEnv = serverEnv().APP_ENV;
-  if (appEnv !== "production") {
-    const line = `${JSON.stringify({ email, url })}\n`;
-    await fs.appendFile(path.join(process.cwd(), ".magic-links.jsonl"), line, "utf8");
-    if (appEnv === "development") {
-      // biome-ignore lint/suspicious/noConsole: the deliberate dev-only sign-in surface.
-      console.log(`\n  Magic link for ${email} (dev — mail suppressed): ${url}\n`);
-    }
-    return;
-  }
-  await sendMail({
+  const message: MailMessage = {
     to: email,
     subject: "Sign in to Topos",
     text:
@@ -39,5 +32,17 @@ export async function sendMagicLinkEmail(args: { email: string; url: string }): 
       `<p><a href="${escapeHtml(url)}">Sign in to Topos</a></p>` +
       `<p>The link works for a few minutes and can be used once. ` +
       `If you didn't request it, you can ignore this email.</p>`,
-  });
+  };
+  const appEnv = serverEnv().APP_ENV;
+  if (appEnv !== "production") {
+    const line = `${JSON.stringify({ email, url })}\n`;
+    await fs.appendFile(path.join(process.cwd(), ".magic-links.jsonl"), line, "utf8");
+    await recordDevMail("magic-link", message);
+    if (appEnv === "development") {
+      // biome-ignore lint/suspicious/noConsole: the deliberate dev-only sign-in surface.
+      console.log(`\n  Magic link for ${email} (dev — mail suppressed): ${url}\n`);
+    }
+    return;
+  }
+  await sendMail(message);
 }

--- a/web/app/lib/mail/passcode-mail.server.ts
+++ b/web/app/lib/mail/passcode-mail.server.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { serverEnv } from "@/env.server";
+import { recordDevMail } from "@/lib/mail/dev-outbox.server";
+import type { MailMessage } from "@/lib/mail/transport.server";
 import { mailDelivery, sendMail } from "@/lib/mail/transport.server";
 
 /**
@@ -12,8 +14,9 @@ import { mailDelivery, sendMail } from "@/lib/mail/transport.server";
  * silently (the old vault no-op posture — the ack stays constant-shaped, and a deployment that
  * advertises the passcode method is expected to arm SMTP); a relay failure is the caller's
  * fire-and-forget to swallow. It never lands in a production log or an error. Outside production
- * the code is recorded to its OWN `.passcode-emails.jsonl` (never the magic-link file) plus the
- * dev terminal, so the flow is drivable with mail suppressed.
+ * the code is recorded to its OWN `.passcode-emails.jsonl` (never the magic-link file), the full
+ * mail to the accumulating dev outbox, and the dev terminal, so the flow is drivable with mail
+ * suppressed.
  */
 export interface PasscodeEmailInput {
   to: string;
@@ -27,10 +30,20 @@ export interface PasscodeEmailInput {
 
 export async function sendPasscodeEmail(input: PasscodeEmailInput): Promise<void> {
   const { to, code, workspaceDisplayName, verifyBaseUrl } = input;
+  // TEXT-ONLY on purpose (the old vault mail's shape, kept byte-similar).
+  const message: MailMessage = {
+    to,
+    subject: "Your Topos verification code",
+    text:
+      `Your Topos verification code for ${workspaceDisplayName} is ${code}.\n\n` +
+      `Enter it at ${verifyBaseUrl}/verify to finish connecting your agent.\n` +
+      `If you didn't request this, you can ignore this email.\n`,
+  };
   const appEnv = serverEnv().APP_ENV;
   if (appEnv !== "production") {
     const line = `${JSON.stringify({ to, code, workspaceDisplayName })}\n`;
     await fs.appendFile(path.join(process.cwd(), ".passcode-emails.jsonl"), line, "utf8");
+    await recordDevMail("passcode", message);
     if (appEnv === "development") {
       // biome-ignore lint/suspicious/noConsole: the deliberate dev-only enrollment surface.
       console.log(`\n  Passcode for ${to} (dev — mail suppressed): ${code}\n`);
@@ -42,13 +55,5 @@ export async function sendPasscodeEmail(input: PasscodeEmailInput): Promise<void
     // constant shape holds; the code expires on its own clock.
     return;
   }
-  // TEXT-ONLY on purpose (the old vault mail's shape, kept byte-similar).
-  await sendMail({
-    to,
-    subject: "Your Topos verification code",
-    text:
-      `Your Topos verification code for ${workspaceDisplayName} is ${code}.\n\n` +
-      `Enter it at ${verifyBaseUrl}/verify to finish connecting your agent.\n` +
-      `If you didn't request this, you can ignore this email.\n`,
-  });
+  await sendMail(message);
 }

--- a/web/tests/unit/dev-outbox.test.ts
+++ b/web/tests/unit/dev-outbox.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The accumulating dev outbox — outside production EVERY product mail lands in ONE
+ * `.outbox.jsonl` as the full rendered message, kind-tagged, so a human tester watches a single
+ * file. The per-flow credential files keep their own contracts (their own suites); this suite
+ * pins the superset view: three different mails, one file, three lines, in send order.
+ */
+
+const { sendMailSpy, createTransportSpy } = vi.hoisted(() => {
+  const sendMailSpy = vi.fn(async (_message: unknown) => ({}));
+  const createTransportSpy = vi.fn(() => ({ sendMail: sendMailSpy }));
+  return { sendMailSpy, createTransportSpy };
+});
+vi.mock("nodemailer", () => ({ default: { createTransport: createTransportSpy } }));
+
+const BASE_ENV: Record<string, string> = {
+  DATABASE_URL: "postgres://user:pass@localhost:5439/db",
+  BETTER_AUTH_SECRET: "0123456789abcdef0123456789abcdef",
+  BETTER_AUTH_URL: "http://localhost:3000",
+  PLANE_INTERNAL_URL: "http://vault.internal:8080",
+  PLANE_INTERNAL_TOKEN: "internal-token-value",
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  sendMailSpy.mockClear();
+  createTransportSpy.mockClear();
+});
+
+describe("the dev outbox accumulates across mail kinds", () => {
+  it("collects magic-link, passcode, and invite mails as kind-tagged lines in ONE file", async () => {
+    vi.resetModules();
+    for (const [k, v] of Object.entries(BASE_ENV)) {
+      vi.stubEnv(k, v);
+    }
+    vi.stubEnv("APP_ENV", "test");
+    const magicLink = await import("@/lib/mail/magic-link-mail.server");
+    const passcode = await import("@/lib/mail/passcode-mail.server");
+    const invite = await import("@/lib/mail/invite-mail.server");
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "topos-dev-outbox-"));
+    const previousCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      await magicLink.sendMagicLinkEmail({
+        email: "alice@example.com",
+        url: "https://topos.example/magic?token=abc",
+      });
+      await passcode.sendPasscodeEmail({
+        to: "bob@example.com",
+        code: "424242",
+        workspaceDisplayName: "Acme",
+        verifyBaseUrl: "https://topos.example",
+      });
+      await invite.sendInviteEmail({
+        to: "carol@example.com",
+        workspaceDisplayName: "Acme",
+        address: "acme",
+        invitedBy: "owner@example.com",
+      });
+      const lines = (await fs.readFile(path.join(dir, ".outbox.jsonl"), "utf8")).trim().split("\n");
+      expect(lines).toHaveLength(3);
+      const mails = lines.map((line) => JSON.parse(line));
+      expect(mails.map((m) => m.kind)).toEqual(["magic-link", "passcode", "invite"]);
+      expect(mails.map((m) => m.to)).toEqual([
+        "alice@example.com",
+        "bob@example.com",
+        "carol@example.com",
+      ]);
+      for (const mail of mails) {
+        // Every line is the full rendered message a transport would have been handed.
+        expect(typeof mail.at).toBe("string");
+        expect(typeof mail.subject).toBe("string");
+        expect(mail.subject).not.toBe("");
+        expect(typeof mail.text).toBe("string");
+        expect(mail.text).not.toBe("");
+      }
+      expect(sendMailSpy).not.toHaveBeenCalled();
+    } finally {
+      process.chdir(previousCwd);
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/web/tests/unit/invite-mail.test.ts
+++ b/web/tests/unit/invite-mail.test.ts
@@ -95,6 +95,18 @@ describe("sendInviteEmail in test mode", () => {
       // The address is a plain slug — no tokened link machinery of any kind.
       expect(lines[0]).not.toContain("/i/");
       expect(lines[0]).not.toContain("token");
+      // The accumulating dev outbox carries the FULL rendered mail, kind-tagged.
+      const outbox = (await fs.readFile(path.join(dir, ".outbox.jsonl"), "utf8"))
+        .trim()
+        .split("\n");
+      expect(outbox).toHaveLength(1);
+      const recorded = JSON.parse(outbox[0] as string);
+      expect(recorded.kind).toBe("invite");
+      expect(recorded.to).toBe(INVITE.to);
+      expect(recorded.subject).toBe(
+        `You've been invited to ${INVITE.workspaceDisplayName} on Topos`,
+      );
+      expect(recorded.text).toContain(`follow ${INVITE.address}`);
       await expect(fs.access(path.join(dir, ".magic-links.jsonl"))).rejects.toThrow();
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
@@ -116,6 +128,7 @@ describe("sendInviteEmail in production mode", () => {
       await mail.sendInviteEmail(INVITE);
       // No file is written (the seat + address already stand) and no transport is called.
       await expect(fs.access(path.join(dir, ".invite-emails.jsonl"))).rejects.toThrow();
+      await expect(fs.access(path.join(dir, ".outbox.jsonl"))).rejects.toThrow();
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(sendMailSpy).not.toHaveBeenCalled();
       expect(mail.inviteMailDelivery().canSend).toBe(false);

--- a/web/tests/unit/magic-link-mail.test.ts
+++ b/web/tests/unit/magic-link-mail.test.ts
@@ -64,6 +64,17 @@ describe("sendMagicLinkEmail in test mode", () => {
         .split("\n");
       expect(lines).toHaveLength(1);
       expect(JSON.parse(lines[0] as string)).toEqual(ARGS);
+      // The accumulating dev outbox carries the FULL rendered mail, kind-tagged.
+      const outbox = (await fs.readFile(path.join(dir, ".outbox.jsonl"), "utf8"))
+        .trim()
+        .split("\n");
+      expect(outbox).toHaveLength(1);
+      const recorded = JSON.parse(outbox[0] as string);
+      expect(recorded.kind).toBe("magic-link");
+      expect(recorded.to).toBe(ARGS.email);
+      expect(recorded.subject).toBe("Sign in to Topos");
+      expect(recorded.text).toContain(ARGS.url);
+      expect(recorded.html).toContain('href="https://topos.example/magic?token=abc"');
       await expect(fs.access(path.join(dir, ".invite-emails.jsonl"))).rejects.toThrow();
       expect(sendMailSpy).not.toHaveBeenCalled();
     } finally {

--- a/web/tests/unit/passcode-mail.test.ts
+++ b/web/tests/unit/passcode-mail.test.ts
@@ -73,6 +73,17 @@ describe("sendPasscodeEmail in test mode", () => {
         code: INPUT.code,
         workspaceDisplayName: INPUT.workspaceDisplayName,
       });
+      // The accumulating dev outbox carries the FULL rendered mail, kind-tagged.
+      const outbox = (await fs.readFile(path.join(dir, ".outbox.jsonl"), "utf8"))
+        .trim()
+        .split("\n");
+      expect(outbox).toHaveLength(1);
+      const recorded = JSON.parse(outbox[0] as string);
+      expect(recorded.kind).toBe("passcode");
+      expect(recorded.to).toBe(INPUT.to);
+      expect(recorded.subject).toBe("Your Topos verification code");
+      expect(recorded.text).toContain("Your Topos verification code for Acme is 424242.");
+      expect(recorded.text).toContain("https://topos.example/verify");
       await expect(fs.access(path.join(dir, ".magic-links.jsonl"))).rejects.toThrow();
       expect(sendMailSpy).not.toHaveBeenCalled();
     } finally {
@@ -91,6 +102,7 @@ describe("sendPasscodeEmail in production mode", () => {
     try {
       await expect(mail.sendPasscodeEmail(INPUT)).resolves.toBeUndefined();
       await expect(fs.access(path.join(dir, ".passcode-emails.jsonl"))).rejects.toThrow();
+      await expect(fs.access(path.join(dir, ".outbox.jsonl"))).rejects.toThrow();
       expect(sendMailSpy).not.toHaveBeenCalled();
     } finally {
       process.chdir(previousCwd);


### PR DESCRIPTION
## What

Outside production, every product mail (magic link, enrollment passcode, invite notice) now ALSO lands in **one accumulating `.outbox.jsonl`** in the server's working directory — the full rendered message (`{at, kind, to, subject, text, html?}`), exactly what production would hand the transport. A human tester watches a single file to see everything the app "sent".

## What does NOT change

- The three per-flow credential files (`.magic-links.jsonl`, `.passcode-emails.jsonl`, `.invite-emails.jsonl`) keep their exact contracts — their readers (unit suites, the roster e2e) parse each flow's OWN file, untouched.
- Production send paths are byte-identical: each sender now builds its message once and shares it between the real send and the dev recording (the existing production-mode unit tests pin the bytes).
- The dev-terminal echo lines stay.

## Tests

- New `tests/unit/dev-outbox.test.ts`: three different mails → one file, three kind-tagged lines, in send order, each a full rendered message; never a send.
- The three per-flow suites now also pin the outbox line (full mail, kind-tagged) and that production no-op paths write NO outbox.
- `bun run check` green (biome · tokens · boundary · contract · typegen · tsc); mail suites 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)