### PR TITLE
Redeemable invitations: invite links, the bound accept ceremony, and the reworked device approval

### DIFF
--- a/bins/topos-plane/src/openapi.rs
+++ b/bins/topos-plane/src/openapi.rs
@@ -9,14 +9,15 @@
 use utoipa::OpenApi;
 
 use topos_types::requests::{
-    DeviceAuthPollRequest, DeviceAuthPollResponse, DeviceAuthPollStatus, DeviceAuthStartRequest,
-    DeviceAuthStartResponse, DeviceAuthWorkspace, DeviceRevokeRequest, InvitationData,
-    InvitationRequest, NoticeAckRequest, ProposeRequest, ProtectionSetRequest, PublishRequest,
-    RevertRequest, ReviewRequest, WireAppliedReport, WireAppliedSkill, WireCandidate,
-    WireChannelEntry, WireChannelIndex, WireChannelSkill, WireDelivery, WireDeliverySkill,
-    WireFile, WireFileMode, WireLogProposal, WireLogVersion, WireMe, WireNotice, WireOpenProposal,
-    WireProposalEntry, WireProposalIndex, WireProposalList, WireProtocolCard, WireReach,
-    WireSkillIndex, WireSkillIndexEntry, WireSkillLog, WireVersionFile, WireVersionMeta, WireVia,
+    DeviceAuthHint, DeviceAuthPollRequest, DeviceAuthPollResponse, DeviceAuthPollStatus,
+    DeviceAuthStartRequest, DeviceAuthStartResponse, DeviceAuthWorkspace, DeviceRevokeRequest,
+    InvitationData, InvitationRequest, InviteAcceptData, InviteAcceptRequest, NoticeAckRequest,
+    ProposeRequest, ProtectionSetRequest, PublishRequest, RevertRequest, ReviewRequest,
+    WireAppliedReport, WireAppliedSkill, WireCandidate, WireChannelEntry, WireChannelIndex,
+    WireChannelSkill, WireDelivery, WireDeliverySkill, WireFile, WireFileMode, WireLogProposal,
+    WireLogVersion, WireMe, WireNotice, WireOpenProposal, WireProposalEntry, WireProposalIndex,
+    WireProposalList, WireProtocolCard, WireReach, WireSkillIndex, WireSkillIndexEntry,
+    WireSkillLog, WireVersionFile, WireVersionMeta, WireVia,
 };
 use topos_types::results::{ProposeData, PublishData, RevertData, ReviewData, ReviewDecision};
 use topos_types::{
@@ -63,9 +64,10 @@ use topos_types::{
         crate::routes::door::set_channel_protection,
         crate::routes::door::ack_notices,
         crate::routes::door::invite,
-        // Enrollment: the device-auth flow.
+        // Enrollment: the device-auth flow + the enrolled device's invitation accept.
         crate::routes::door::device_auth_start,
         crate::routes::door::device_auth_poll,
+        crate::routes::door::invite_accept,
         // Governance: the device revoke (the CLI logout wire).
         crate::routes::door::revoke_device,
     ),
@@ -130,13 +132,16 @@ use topos_types::{
         RevertData,
         ReviewData,
         ReviewDecision,
-        // The device-auth flow.
+        // The device-auth flow + the invitation accept.
         DeviceAuthStartRequest,
         DeviceAuthStartResponse,
         DeviceAuthPollRequest,
         DeviceAuthPollResponse,
         DeviceAuthPollStatus,
         DeviceAuthWorkspace,
+        DeviceAuthHint,
+        InviteAcceptRequest,
+        InviteAcceptData,
         // Governance request DTOs.
         DeviceRevokeRequest,
     )),

--- a/bins/topos-plane/src/routes/door.rs
+++ b/bins/topos-plane/src/routes/door.rs
@@ -15,10 +15,10 @@
 
 use topos_types::requests::{
     DeviceAuthPollRequest, DeviceAuthPollResponse, DeviceAuthStartRequest, DeviceAuthStartResponse,
-    DeviceRevokeRequest, InvitationRequest, NoticeAckRequest, ProposeRequest, ProtectionSetRequest,
-    PublishRequest, RevertRequest, ReviewRequest, WireAppliedReport, WireChannelIndex,
-    WireDelivery, WireMe, WireProposalIndex, WireProposalList, WireReach, WireSkillIndex,
-    WireSkillLog, WireVersionMeta,
+    DeviceRevokeRequest, InvitationRequest, InviteAcceptRequest, NoticeAckRequest, ProposeRequest,
+    ProtectionSetRequest, PublishRequest, RevertRequest, ReviewRequest, WireAppliedReport,
+    WireChannelIndex, WireDelivery, WireMe, WireProposalIndex, WireProposalList, WireReach,
+    WireSkillIndex, WireSkillLog, WireVersionMeta,
 };
 use topos_types::{JsonEnvelope, WireCurrentRecord};
 
@@ -271,7 +271,7 @@ pub(crate) fn ack_notices() {}
         ("Authorization" = String, Header, description = "`Bearer <workspace credential>`."),
     ),
     responses(
-        (status = 200, description = "The invitation receipt — OK carries the InvitationData (address + invited + the honest mailed flag); a policy refusal is a 200 DENIED OWNER_ROLE_REQUIRED, an unknown channel a 200 DENIED UNKNOWN_CHANNEL.", body = JsonEnvelope),
+        (status = 200, description = "The invitation receipt — OK carries the InvitationData (address + invited + the honest mailed flag; the tokened invite link travels ONLY in the mail); a policy refusal is a 200 DENIED OWNER_ROLE_REQUIRED, an unresolvable hint a 200 DENIED UNKNOWN_SKILL / UNKNOWN_CHANNEL, an unarmed mail transport a 200 DENIED MAIL_NOT_CONFIGURED.", body = JsonEnvelope),
         (status = 400, description = "Malformed body or a malformed invitee email.", body = JsonEnvelope),
         (status = 404, description = "Missing/blank credential, unknown/revoked one, or non-member (indistinguishable).", body = JsonEnvelope),
         (status = 429, description = "Rate limited (Retry-After header).", body = JsonEnvelope),
@@ -324,7 +324,7 @@ pub(crate) fn put_report() {}
     tag = "enrollment",
     request_body = DeviceAuthStartRequest,
     responses(
-        (status = 200, description = "The device-authorization grant: the secret device_code to poll with (promoted to the device's ONE bearer credential on approval), the human-facing user_code, and the approval URLs.", body = DeviceAuthStartResponse),
+        (status = 200, description = "The device-authorization grant: the secret device_code to poll with (promoted to the device's ONE bearer credential on approval), the human-facing user_code, and the BARE approval URL (the code never rides a URL; the approval page's lookup is a POST). An invite_token in the body is recorded on the flow unvalidated — never a token oracle.", body = DeviceAuthStartResponse),
         (status = 400, description = "Malformed body.", body = JsonEnvelope),
         (status = 429, description = "Rate limited (Retry-After header).", body = JsonEnvelope),
         (status = 500, description = "Internal fault.", body = JsonEnvelope),
@@ -338,13 +338,29 @@ pub(crate) fn device_auth_start() {}
     tag = "enrollment",
     request_body = DeviceAuthPollRequest,
     responses(
-        (status = 200, description = "The poll status; `granted` carries the ONE bearer credential (the promoted device code), the device id, and the joined workspace.", body = DeviceAuthPollResponse),
+        (status = 200, description = "The poll status; `granted` carries the ONE bearer credential (the promoted device code), the device id, the joined workspace, and — when the flow carried an invitation naming one — the first-destination hint.", body = DeviceAuthPollResponse),
         (status = 400, description = "Malformed body.", body = JsonEnvelope),
         (status = 429, description = "Rate limited (Retry-After header).", body = JsonEnvelope),
         (status = 500, description = "Internal fault.", body = JsonEnvelope),
     ),
 )]
 pub(crate) fn device_auth_poll() {}
+
+#[utoipa::path(
+    post,
+    path = "/v1/invitations/accept",
+    tag = "enrollment",
+    request_body = InviteAcceptRequest,
+    params(("Authorization" = String, Header, description = "`Bearer <device credential>` — PERSON-scoped: the caller has no seat in the invitation's workspace yet.")),
+    responses(
+        (status = 200, description = "OK carries the InviteAcceptData (the joined workspace + the optional first-destination hint); the ceremony fences answer 200 DENIED INVITE_OTHER_ACCOUNT / EMAIL_UNVERIFIED (no address is ever echoed).", body = JsonEnvelope),
+        (status = 400, description = "Malformed body.", body = JsonEnvelope),
+        (status = 404, description = "Missing/blank credential, a revoked device, or a dead token — invalid, expired, revoked, or already consumed (indistinguishable).", body = JsonEnvelope),
+        (status = 429, description = "Rate limited (Retry-After header).", body = JsonEnvelope),
+        (status = 500, description = "Integrity / internal store fault.", body = JsonEnvelope),
+    ),
+)]
+pub(crate) fn invite_accept() {}
 
 // ── the writes (publish / propose / revert / review) ─────────────────────────────────────────────
 

--- a/bins/topos/CLAUDE.md
+++ b/bins/topos/CLAUDE.md
@@ -114,6 +114,23 @@ renderer over the SAME typed outcomes (one value, two presentations).
     WAL → arms the auto-update trigger, and the flow CONTINUES into the intent's describe/apply in the
     same invocation. There is no post-grant fence phase: an approved flow re-answers the same
     granted poll, so a crash mid-persist recovers by re-polling;
+  - **the INVITE-URL flow** (`follow <invite-url>` — `<origin>[/<ws>]/invite/<token>`, the
+    invitation mail's terminal line verbatim): an UNENROLLED install starts the ordinary device
+    flow CARRYING the token (`invite_token` on the authorize body; the flow row records its hash)
+    and the browser destination becomes the INVITATION page itself — account/sign-in → accept →
+    the device approval woven into one visit — carrying the flow's device-code CHALLENGE (hex
+    sha256; `ops::device_challenge`) so the approval card resolves with zero typing while the
+    short code never rides a URL; the granted poll's `hint` decoration then steers the
+    post-enrollment subscribe at the invited-to skill/channel through the ordinary two-phase
+    describe. An ENROLLED install accepts DIRECTLY over the device lane
+    (`DirectorySource::accept_invitation`, person-scoped — no browser, no second flow) and
+    continues into the same describe; a different plane keeps the wrong-server refusal. The
+    pending disclosure everywhere is TWO LINES — the bare URL, then the code (`Open:` / `Code:`);
+    and when a wait is interactive with a local browser plausible (`ops/loopback` — a pure,
+    table-tested chooser: never SSH/headless; `TOPOS_NO_BROWSER` opts out) the wait binds an
+    ephemeral 127.0.0.1 listener (std `TcpListener` — no server crate), auto-opens the approval
+    page with state-bound return coordinates, and the page's single-use redirect wakes the next
+    poll — the poll stays the source of truth, so a failed open degrades to the typed wait;
   - **the classic skill path** (`follow <skill>[@<hash>]`) — the I-TOFU accept / the paused-entry
     resume, unchanged.
   The SUBSCRIBE is two-phase: bare = a DESCRIBE (`GET /me` + `/channels` + the catalog + `/delivery`
@@ -458,10 +475,13 @@ are asserted byte-equal in tests.
     a level that does not apply to the kind is a typed usage error. The describe carries the audience — the
     reach (people) for a skill, the channel's member count — plus the pending-proposals-survive note on a
     skill loosening; `OWNER_ROLE_REQUIRED` / `REVIEWER_ROLE_REQUIRED` surface typed, naming the role.
-  - **`invite`** (`ops/invite`) — the roster write is now two-phase, and a BARE `invite` (no emails) is a
-    no-mutation `/me` read (the workspace address + invite policy + "nothing was sent or changed"). Emails
-    without `--yes` describe (who gets seated, the channel pre-placements, the mail-or-paste note); `--yes`
-    POSTs the folded-email invitation. (The `/i/`-link mint is retired — joining is `follow <address>`.)
+  - **`invite`** (`ops/invite`) — two-phase; a BARE `invite` (no emails) is a no-mutation `/me`
+    read (the workspace address + invite policy + "nothing was sent or changed"). Emails without
+    `--yes` describe (who gets invited, the optional first-destination hint, the mailed-link note);
+    `--yes` POSTs the folded emails + at most ONE hint — `--skill <name>` OR `--channel <name>` —
+    and the SERVER mails each address its single-use invite link (the token never appears in the
+    receipt; the mailbox is its one channel). Joining is `follow <invite-url>` (or the plain
+    workspace address).
   - **`review`** (`ops/review`) — a bare `review` is the review INBOX/OUTBOX across every enrolled workspace
     (`GET /proposals` per ws; author-message FIRST; the outbox is your own proposals, split by the
     server-computed `yours` — user-id equality server-side; the `user.json` principal match stays only as

--- a/bins/topos/src/app.rs
+++ b/bins/topos/src/app.rs
@@ -446,26 +446,38 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
             // `follow` by hand), unless this is a headless `--json` run without `--wait` (which must not
             // hang). The interactive block only ever RESUMES (no targets + the pending WAL drives it) —
             // and the resumed invocation keeps THIS invocation's flags, so a `--yes` carries through
-            // the wait into the apply.
-            let policy = WaitPolicy::resolve(json, wait, &clock);
-            // The zero-typing loopback: only for an interactive wait, only when a local browser
-            // is plausible (never over SSH / headless / `TOPOS_NO_BROWSER`), and only when a
-            // pending WAL exists to derive the flow's challenge from. Everything else keeps the
-            // typed-code fallback untouched.
+            // the wait into the apply. A PIPED stdout without an explicit `--wait` never blocks:
+            // the instructions print, the single poll answers, and the exit-0 pending document
+            // carries the resume next-action — an agent harness would otherwise stare at a silent
+            // long poll it cannot see into.
+            let stdout_tty = {
+                use std::io::IsTerminal;
+                std::io::stdout().is_terminal()
+            };
+            let policy = WaitPolicy::resolve(json, wait, stdout_tty, &clock);
+            // The zero-typing loopback: only for an interactive blocking wait (the listener must
+            // outlive the human's click — a TTY, or an explicit `--wait` on a pipe), only when a
+            // local browser is plausible (never over SSH / headless / `TOPOS_NO_BROWSER`), and
+            // only when a pending WAL exists to derive the flow's challenge from. Everything else
+            // keeps the typed-code fallback untouched.
             let loopback_plan = if policy.block && !json {
                 let interactive = {
                     use std::io::IsTerminal;
                     std::io::stderr().is_terminal()
                 };
-                ops::loopback::choose_browser(&ops::loopback::BrowserEnv::detect(interactive))
-                    .and_then(|opener| {
-                        let wal = crate::enroll::read_wal(&fs, &ctx.layout).ok().flatten()?;
-                        Some(LoopbackPlan {
-                            opener,
-                            runner: &fs,
-                            challenge: ops::device_challenge(&wal.device_code),
-                        })
+                ops::loopback::choose_browser(&ops::loopback::BrowserEnv::detect(
+                    interactive,
+                    stdout_tty,
+                    wait.is_some(),
+                ))
+                .and_then(|opener| {
+                    let wal = crate::enroll::read_wal(&fs, &ctx.layout).ok().flatten()?;
+                    Some(LoopbackPlan {
+                        opener,
+                        runner: &fs,
+                        challenge: ops::device_challenge(&wal.device_code),
                     })
+                })
             } else {
                 None
             };
@@ -1018,10 +1030,14 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
                         server_url.as_deref(),
                         workspace.as_deref(),
                     );
-                    // The same blocking idiom as `follow`: interactive (or `--wait`) runs re-poll
-                    // until the browser approval settles; a headless `--json` run without `--wait`
-                    // returns the pending state and never hangs.
-                    let policy = WaitPolicy::resolve(json, wait, &clock);
+                    // The same blocking idiom as `follow`: a TTY (or `--wait`) run re-polls
+                    // until the browser approval settles; a `--json` or PIPED run without
+                    // `--wait` returns the pending state and never hangs.
+                    let stdout_tty = {
+                        use std::io::IsTerminal;
+                        std::io::stdout().is_terminal()
+                    };
+                    let policy = WaitPolicy::resolve(json, wait, stdout_tty, &clock);
                     let result = block_on_pending(
                         &clock,
                         &policy,
@@ -2287,9 +2303,13 @@ fn waiting_line(now_millis: u64, started_millis: u64, expires_at_millis: Option<
 }
 
 /// Whether this invocation blocks on a pending device-authorization, and until when.
-/// - `block == false` — never block (a headless `--json` run without `--wait`): return the first result.
-/// - `deadline_millis == None` — block until the device code's own TTL ends it (interactive default, or a
-///   bare `--wait`).
+/// - `block == false` — never block: print the approval instructions (or emit the `--json`
+///   pending document with its resume next-action) and exit 0 after the single poll the
+///   invocation itself performed. This is the default whenever NOBODY IS WATCHING A TERMINAL —
+///   a `--json` run, or a PIPED stdout (an agent harness surfaces output only when a command
+///   exits, so the human blocking wait would read as a silent quarter-hour hang there).
+/// - `deadline_millis == None` — block until the device code's own TTL ends it (the TTY default,
+///   or a bare `--wait`).
 /// - `deadline_millis == Some(t)` — block until settled or the wall clock passes `t` (`--wait <seconds>`),
 ///   whichever comes first.
 struct WaitPolicy {
@@ -2298,11 +2318,14 @@ struct WaitPolicy {
 }
 
 impl WaitPolicy {
-    /// Derive the policy from `--json` and the `--wait [<seconds>]` flag: block when interactive (`!json`)
-    /// OR when `--wait` was given in any form; a numeric `--wait <seconds>` sets a wall-clock deadline.
-    fn resolve(json: bool, wait: Option<Option<u64>>, clock: &dyn Clock) -> Self {
+    /// Derive the policy from `--json`, the `--wait [<seconds>]` flag, and whether STDOUT is a
+    /// terminal: block when a human watches a TTY (`!json && stdout_tty`) OR when `--wait` was
+    /// given in any form (the explicit opt-in — it works piped, so an agent may choose the
+    /// one-command blocking enrollment deliberately); a numeric `--wait <seconds>` sets a
+    /// wall-clock deadline.
+    fn resolve(json: bool, wait: Option<Option<u64>>, stdout_tty: bool, clock: &dyn Clock) -> Self {
         Self {
-            block: !json || wait.is_some(),
+            block: (!json && stdout_tty) || wait.is_some(),
             deadline_millis: match wait {
                 Some(Some(secs)) => Some(
                     clock
@@ -2768,10 +2791,96 @@ fn list_discovery(tracked: bool) -> Option<ops::DiscoveryRoots> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_WEB_ORIGIN, build_pull_scope, fmt_span, list_page_argv, next_page_action,
-        parse_rfc3339_utc_millis, resolve_web_origin, waiting_line,
+        DEFAULT_WEB_ORIGIN, PendingDisclosure, WaitPolicy, block_on_pending, build_pull_scope,
+        fmt_span, list_page_argv, next_page_action, parse_rfc3339_utc_millis, resolve_web_origin,
+        waiting_line,
     };
+    use crate::ids::Clock;
     use crate::ops::{PullScope, RowPage, TargetMode, VersionRef};
+
+    struct TestClock(u64);
+    impl Clock for TestClock {
+        fn now_unix_millis(&self) -> u64 {
+            self.0
+        }
+    }
+
+    #[test]
+    fn the_wait_policy_blocks_only_for_a_watched_terminal_or_an_explicit_wait() {
+        let clock = TestClock(1_000);
+        // The human default: a TTY without --json blocks until the code's own expiry.
+        assert!(WaitPolicy::resolve(false, None, true, &clock).block);
+        // The agent default: a PIPED stdout without --wait never blocks — the harness only
+        // surfaces output on exit, so the long poll would read as a silent hang.
+        assert!(!WaitPolicy::resolve(false, None, false, &clock).block);
+        // --json inherits the same non-blocking default on both faces.
+        assert!(!WaitPolicy::resolve(true, None, false, &clock).block);
+        assert!(!WaitPolicy::resolve(true, None, true, &clock).block);
+        // --wait is the explicit opt-in and works piped, bare or capped.
+        assert!(WaitPolicy::resolve(false, Some(None), false, &clock).block);
+        assert!(WaitPolicy::resolve(true, Some(Some(30)), false, &clock).block);
+        // The numeric cap sets the wall-clock deadline; the bare form has none.
+        assert_eq!(
+            WaitPolicy::resolve(false, Some(Some(30)), false, &clock).deadline_millis,
+            Some(31_000)
+        );
+        assert_eq!(
+            WaitPolicy::resolve(false, Some(None), false, &clock).deadline_millis,
+            None
+        );
+    }
+
+    #[test]
+    fn a_non_blocking_wait_returns_the_first_pending_result_without_a_single_repoll() {
+        let clock = TestClock(0);
+        let policy = WaitPolicy {
+            block: false,
+            deadline_millis: None,
+        };
+        let pending = Ok::<_, crate::error::ClientError>("pending-marker");
+        let out = block_on_pending(
+            &clock,
+            &policy,
+            pending,
+            |_| {
+                Some(PendingDisclosure {
+                    verification_uri: "https://x/verify".into(),
+                    user_code: "AB12-CD34".into(),
+                    interval_secs: Some(5),
+                    expires_at_millis: None,
+                })
+            },
+            None,
+            || panic!("a non-blocking wait must never re-poll"),
+        );
+        assert_eq!(out.unwrap(), "pending-marker");
+    }
+
+    #[test]
+    fn a_zero_second_wait_cap_returns_the_pending_result_at_the_deadline() {
+        // `--wait 0`: block resolves true, the deadline is already NOW — the loop's top check
+        // returns the last pending result without sleeping a poll interval.
+        let clock = TestClock(5_000);
+        let policy = WaitPolicy::resolve(true, Some(Some(0)), false, &clock);
+        assert!(policy.block);
+        let pending = Ok::<_, crate::error::ClientError>("still-pending");
+        let out = block_on_pending(
+            &clock,
+            &policy,
+            pending,
+            |_| {
+                Some(PendingDisclosure {
+                    verification_uri: "https://x/verify".into(),
+                    user_code: "AB12-CD34".into(),
+                    interval_secs: Some(5),
+                    expires_at_millis: None,
+                })
+            },
+            None,
+            || panic!("the elapsed deadline never re-polls"),
+        );
+        assert_eq!(out.unwrap(), "still-pending");
+    }
 
     #[test]
     fn the_waiting_line_shows_honest_elapsed_and_expiry_time() {

--- a/bins/topos/src/app.rs
+++ b/bins/topos/src/app.rs
@@ -448,10 +448,35 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
             // and the resumed invocation keeps THIS invocation's flags, so a `--yes` carries through
             // the wait into the apply.
             let policy = WaitPolicy::resolve(json, wait, &clock);
-            let result =
-                block_on_pending(&clock, &policy, first, follow_pending_disclosure, || {
-                    ops::follow(&ctx, &connectors, Vec::new(), mk_opts())
-                });
+            // The zero-typing loopback: only for an interactive wait, only when a local browser
+            // is plausible (never over SSH / headless / `TOPOS_NO_BROWSER`), and only when a
+            // pending WAL exists to derive the flow's challenge from. Everything else keeps the
+            // typed-code fallback untouched.
+            let loopback_plan = if policy.block && !json {
+                let interactive = {
+                    use std::io::IsTerminal;
+                    std::io::stderr().is_terminal()
+                };
+                ops::loopback::choose_browser(&ops::loopback::BrowserEnv::detect(interactive))
+                    .and_then(|opener| {
+                        let wal = crate::enroll::read_wal(&fs, &ctx.layout).ok().flatten()?;
+                        Some(LoopbackPlan {
+                            opener,
+                            runner: &fs,
+                            challenge: ops::device_challenge(&wal.device_code),
+                        })
+                    })
+            } else {
+                None
+            };
+            let result = block_on_pending(
+                &clock,
+                &policy,
+                first,
+                follow_pending_disclosure,
+                loopback_plan,
+                || ops::follow(&ctx, &connectors, Vec::new(), mk_opts()),
+            );
             // The breadth arming sweep rides the enrollment receipt: the promote armed the active
             // adapter (`currency`); every OTHER detected agent's trigger is armed here at the
             // composition root, and the per-agent outcomes ride the same payload honestly.
@@ -510,6 +535,7 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
         }
         Command::Invite {
             email,
+            skill,
             channel,
             yes,
         } => {
@@ -517,7 +543,15 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
                 governance: &connect_governance,
                 directory: &connect_directory,
             };
-            let result = ops::invite(&ctx, &connectors, email, channel, workspace.as_deref(), yes);
+            let result = ops::invite(
+                &ctx,
+                &connectors,
+                email,
+                skill,
+                channel,
+                workspace.as_deref(),
+                yes,
+            );
             finish_invite(json, cmd_name, result, &diag)
         }
         Command::List {
@@ -988,15 +1022,21 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
                     // until the browser approval settles; a headless `--json` run without `--wait`
                     // returns the pending state and never hangs.
                     let policy = WaitPolicy::resolve(json, wait, &clock);
-                    let result =
-                        block_on_pending(&clock, &policy, first, login_pending_disclosure, || {
+                    let result = block_on_pending(
+                        &clock,
+                        &policy,
+                        first,
+                        login_pending_disclosure,
+                        None,
+                        || {
                             ops::login(
                                 &ctx,
                                 &connectors,
                                 server_url.as_deref(),
                                 workspace.as_deref(),
                             )
-                        });
+                        },
+                    );
                     finish_login(json, cmd_name, result, &diag)
                 }
                 AuthCmd::Logout { yes } => {
@@ -2145,11 +2185,11 @@ fn finish_logout(
 const DEVICE_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// A pending device-authorization's human-facing disclosure — the clickable URL (the
-/// `verification_uri_complete`, which embeds the code) plus the short cross-check code and the
+/// `verification_uri`, which embeds the code) plus the short cross-check code and the
 /// server's minimum poll interval. Extracted from either verb's pending outcome so
 /// [`block_on_pending`] can print it once, generically.
 struct PendingDisclosure {
-    verification_uri_complete: String,
+    verification_uri: String,
     user_code: String,
     /// The server's minimum poll interval, when disclosed (else the fallback cadence).
     interval_secs: Option<u64>,
@@ -2171,7 +2211,7 @@ impl PendingDisclosure {
 fn follow_pending_disclosure(out: &ops::FollowOutcome) -> Option<PendingDisclosure> {
     match out {
         ops::FollowOutcome::Data { data, .. } => data.pending.as_ref().map(|p| PendingDisclosure {
-            verification_uri_complete: p.verification_uri_complete.clone(),
+            verification_uri: p.verification_uri.clone(),
             user_code: p.user_code.clone(),
             interval_secs: p.interval_secs,
             expires_at_millis: p.expires_at.as_deref().and_then(parse_rfc3339_utc_millis),
@@ -2184,7 +2224,7 @@ fn follow_pending_disclosure(out: &ops::FollowOutcome) -> Option<PendingDisclosu
 fn login_pending_disclosure(out: &ops::AuthLoginOutcome) -> Option<PendingDisclosure> {
     match out {
         ops::AuthLoginOutcome::Pending(p) => Some(PendingDisclosure {
-            verification_uri_complete: p.verification_uri_complete.clone(),
+            verification_uri: p.verification_uri.clone(),
             user_code: p.user_code.clone(),
             interval_secs: Some(p.interval_secs),
             expires_at_millis: p.expires_at.as_deref().and_then(parse_rfc3339_utc_millis),
@@ -2275,17 +2315,32 @@ impl WaitPolicy {
     }
 }
 
+/// The zero-typing browser plan a follow enrollment's wait may carry: which opener to spawn, the
+/// runner that spawns it, and the flow's device-code CHALLENGE (hex sha256 — identifies the flow
+/// on the approval page's URL without revealing anything; the code itself never rides a URL).
+struct LoopbackPlan<'a> {
+    opener: &'static str,
+    runner: &'a dyn topos_harness::CommandRunner,
+    challenge: String,
+}
+
 /// Block on a pending device-authorization until it settles, an optional deadline passes, or the device
 /// code's own expiry ends it with a terminal error — so a person never re-invokes the command by hand. The
 /// disclosure prints to STDERR once (stdout stays the clean final render). `pending_of` extracts the
 /// disclosure (None ⇒ not pending ⇒ return as-is); `repoll` re-invokes the op, which RESUMES via its
 /// on-disk WAL. A `policy.block == false` (headless `--json` without `--wait`) returns the first result
 /// untouched — a headless agent must not hang.
+///
+/// With a `loopback` plan, the wait ALSO binds an ephemeral 127.0.0.1 listener and auto-opens the
+/// approval page carrying the state-bound return coordinates — the browser's redirect wakes the
+/// next poll immediately (zero typing); the poll stays the source of truth, so a failed open or a
+/// lost redirect degrades to the typed-code wait already printed above it.
 fn block_on_pending<T>(
     clock: &dyn Clock,
     policy: &WaitPolicy,
     first: Result<T, ClientError>,
     pending_of: impl Fn(&T) -> Option<PendingDisclosure>,
+    loopback: Option<LoopbackPlan<'_>>,
     mut repoll: impl FnMut() -> Result<T, ClientError>,
 ) -> Result<T, ClientError> {
     if !policy.block {
@@ -2299,17 +2354,38 @@ fn block_on_pending<T>(
         return first;
     };
 
-    // The waiting disclosure on STDERR (stdout stays the clean final envelope/TTY): the clickable URL
-    // plus the short code the human cross-checks against the approval page, and the one line that
-    // makes the wait unscary — interrupting loses nothing.
+    // The waiting disclosure on STDERR (stdout stays the clean final envelope/TTY): the URL and
+    // the short code on separate lines (the code never rides a URL), and the one line that makes
+    // the wait unscary — interrupting loses nothing.
     eprintln!(
-        "Open this URL to approve:\n  {}\n  code: {} (confirm it matches the page)",
-        disc.verification_uri_complete, disc.user_code,
+        "Open: {}\nCode: {} (the page shows the same code — confirm it matches)",
+        disc.verification_uri, disc.user_code,
     );
     eprintln!(
         "Ctrl-C is safe — the same command resumes this enrollment; `--wait <seconds>` caps the \
          wait."
     );
+    // The loopback arm: bind, auto-open, and let the redirect wake the poll. Every fault here is
+    // silent — the typed-code lines above already carry the whole ceremony.
+    let mut listener = loopback.and_then(|plan| {
+        let state = uuid::Uuid::new_v4().simple().to_string();
+        let bound = ops::loopback::LoopbackListener::bind(state.clone()).ok()?;
+        let url = ops::loopback::approval_url(
+            &disc.verification_uri,
+            &plan.challenge,
+            bound.port(),
+            &state,
+        );
+        let opened = plan
+            .runner
+            .run(plan.opener, &[url.as_str()])
+            .map(|out| out.success)
+            .unwrap_or(false);
+        if opened {
+            eprintln!("Opening your browser to approve — or use the URL and code above.");
+        }
+        opened.then_some(bound)
+    });
     let interval = disc.poll_interval();
     // The live waiting line: honest time (elapsed + the code's expiry countdown), rewritten in
     // place once a second when stderr is a TTY; a single plain line otherwise (no escape codes in
@@ -2352,17 +2428,29 @@ fn block_on_pending<T>(
             let nap_end = clock
                 .now_unix_millis()
                 .saturating_add(u64::try_from(nap.as_millis()).unwrap_or(u64::MAX));
+            // With a listener armed, tick in short slices so the browser's redirect wakes the
+            // poll near-instantly; a lone terminal keeps the calm one-second cadence.
+            let slice = if listener.is_some() {
+                Duration::from_millis(250)
+            } else {
+                Duration::from_secs(1)
+            };
             loop {
                 let now = clock.now_unix_millis();
                 if now >= nap_end {
                     break;
                 }
+                if let Some(bound) = &listener
+                    && bound.try_receive().is_some()
+                {
+                    // The redirect landed (single-use — stop listening) → poll NOW.
+                    listener = None;
+                    break;
+                }
                 use std::io::Write;
                 eprint!("\r{}  ", waiting_line(now, started, disc.expires_at_millis));
                 let _ = std::io::stderr().flush();
-                std::thread::sleep(
-                    Duration::from_millis(nap_end.saturating_sub(now)).min(Duration::from_secs(1)),
-                );
+                std::thread::sleep(Duration::from_millis(nap_end.saturating_sub(now)).min(slice));
             }
         } else {
             std::thread::sleep(nap);

--- a/bins/topos/src/cli.rs
+++ b/bins/topos/src/cli.rs
@@ -93,6 +93,8 @@ pub(crate) enum Command {
         manual: bool,
         /// Block until the browser approval settles, finishing enrollment in ONE command. Bare `--wait`
         /// waits until the code expires; `--wait <seconds>` caps the wait. Put `--wait` AFTER any positional.
+        /// A TTY blocks by default; a PIPED run without `--wait` prints the approval URL and returns
+        /// immediately — re-invoke `follow` to poll, or pass `--wait` to block.
         #[arg(long, value_name = "SECONDS", num_args = 0..=1)]
         wait: Option<Option<u64>>,
     },
@@ -408,7 +410,8 @@ pub(crate) enum AuthCmd {
         #[arg(value_name = "SERVER_URL")]
         server_url: Option<String>,
         /// Block until the browser approval settles in ONE command. Bare `--wait` waits until the
-        /// code expires; `--wait <seconds>` caps the wait.
+        /// code expires; `--wait <seconds>` caps the wait. A TTY blocks by default; a PIPED run
+        /// without `--wait` prints the approval URL and returns — re-invoke to poll.
         #[arg(long, value_name = "SECONDS", num_args = 0..=1)]
         wait: Option<Option<u64>>,
     },

--- a/bins/topos/src/cli.rs
+++ b/bins/topos/src/cli.rs
@@ -340,15 +340,20 @@ pub(crate) enum Command {
         #[arg(long)]
         yes: bool,
     },
-    /// Seat emails as invited members of the workspace (a roster write). Every CLI invitee starts as a
-    /// member; joining is `follow <address>` plus proof of the invited email. Requires prior enrollment.
-    /// A bare `invite` (no emails) reads the workspace address + policy (lands later).
+    /// Invite emails into the workspace. Each address gets a mailed single-use invite link (accept in
+    /// the browser, hand the mail's paste-block to an agent, or `topos follow <invite-url>`); every
+    /// CLI invitee starts as a member. Requires prior enrollment. A bare `invite` (no emails) reads
+    /// the workspace address + policy.
     Invite {
-        /// The emails to invite (folded to canonical form; seeded onto the roster as `invited`).
+        /// The emails to invite (folded to canonical form; each becomes a pending 7-day claim).
         email: Vec<String>,
-        /// Pre-place each invitee into this channel (repeatable).
+        /// Lead the invitation with this SKILL — accepting follows it for the invitee (at most one
+        /// of --skill/--channel).
+        #[arg(long, value_name = "NAME", conflicts_with = "channel")]
+        skill: Option<String>,
+        /// Lead the invitation with this CHANNEL — accepting joins the invitee to it.
         #[arg(long, value_name = "NAME")]
-        channel: Vec<String>,
+        channel: Option<String>,
         /// Apply without the describe step. Parses today; the two-phase describe lands later.
         #[arg(long)]
         yes: bool,

--- a/bins/topos/src/enroll.rs
+++ b/bins/topos/src/enroll.rs
@@ -340,7 +340,8 @@ pub(crate) struct PendingEnrollment {
     /// The short user code (the cross-check shown on the approval page).
     pub user_code: String,
     /// The SERVER-built approval URL with the code embedded — re-emitted verbatim while pending.
-    pub verification_uri_complete: String,
+    #[serde(alias = "verification_uri_complete")]
+    pub verification_uri: String,
     /// The minimum poll interval, in seconds.
     pub interval_secs: u64,
     /// The flow expiry as epoch-millis — the recovery sweep abandons a WAL past this.
@@ -358,7 +359,7 @@ impl std::fmt::Debug for PendingEnrollment {
             .field("intent", &self.intent)
             .field("device_code", &"<redacted>")
             .field("user_code", &self.user_code)
-            .field("verification_uri_complete", &self.verification_uri_complete)
+            .field("verification_uri", &self.verification_uri)
             .field("interval_secs", &self.interval_secs)
             .field("expires_at_millis", &self.expires_at_millis)
             .finish()
@@ -911,7 +912,7 @@ mod tests {
             },
             device_code: "dc_secret".to_owned(),
             user_code: "AAAA-BBBB".to_owned(),
-            verification_uri_complete: "https://topos.sh/verify?code=AAAA-BBBB".to_owned(),
+            verification_uri: "https://topos.sh/verify".to_owned(),
             interval_secs: 5,
             expires_at_millis,
         }

--- a/bins/topos/src/ops/auth.rs
+++ b/bins/topos/src/ops/auth.rs
@@ -69,7 +69,7 @@ pub(crate) struct AuthLoginData {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct AuthLoginPending {
     pub server: String,
-    pub verification_uri_complete: String,
+    pub verification_uri: String,
     pub user_code: String,
     /// The minimum poll interval, in seconds.
     pub interval_secs: u64,
@@ -138,8 +138,11 @@ pub(crate) fn login(
     let base_url = resolve_api_base(&origin, &card.api_base_url)?;
     guard_one_plane(ctx, &base_url)?;
 
-    let start =
-        (connectors.enroll)(&base_url).device_auth_start(&membership.name, &machine_name())?;
+    let start = (connectors.enroll)(&base_url).device_auth_start(
+        &membership.name,
+        &machine_name(),
+        None,
+    )?;
     let now = i64::try_from(ctx.clock.now_unix_millis()).unwrap_or(i64::MAX);
     let expires_at = now.saturating_add(
         i64::try_from(start.expires_in_secs.saturating_mul(1000)).unwrap_or(i64::MAX),
@@ -151,14 +154,14 @@ pub(crate) fn login(
         intent: enroll::EnrollIntentDoc::Login,
         device_code: start.device_code,
         user_code: start.user_code.clone(),
-        verification_uri_complete: start.verification_uri_complete.clone(),
+        verification_uri: start.verification_uri.clone(),
         interval_secs: start.interval_secs,
         expires_at_millis: expires_at,
     };
     enroll::write_wal(ctx.fs, &ctx.layout, &wal)?;
     Ok(AuthLoginOutcome::Pending(AuthLoginPending {
         server: base_url,
-        verification_uri_complete: start.verification_uri_complete,
+        verification_uri: start.verification_uri,
         user_code: start.user_code,
         interval_secs: start.interval_secs,
         expires_at: Some(super::follow::fmt_rfc3339_millis(expires_at)),
@@ -176,7 +179,7 @@ fn resume_login(
     match enroll_src.device_auth_poll(&wal.device_code)? {
         DeviceAuthPoll::Pending => Ok(AuthLoginOutcome::Pending(AuthLoginPending {
             server: wal.base_url.clone(),
-            verification_uri_complete: wal.verification_uri_complete.clone(),
+            verification_uri: wal.verification_uri.clone(),
             user_code: wal.user_code.clone(),
             interval_secs: wal.interval_secs,
             expires_at: Some(super::follow::fmt_rfc3339_millis(wal.expires_at_millis)),

--- a/bins/topos/src/ops/follow.rs
+++ b/bins/topos/src/ops/follow.rs
@@ -4,7 +4,7 @@
 //! - **`follow <workspace-address>`** (call 1) — card-fetch the address, re-root onto the declared API
 //!   base, guard one-plane-per-install, start a device authorization
 //!   (`POST /v1/device/authorize {requested_name, workspace}`), write a `0600` WAL, and return the
-//!   pending disclosure ("open `verification_uri_complete`, enter the code").
+//!   pending disclosure ("open `verification_uri`, enter the code").
 //! - **re-invoking `follow`** (call 2) — with a pending enrollment WAL on disk, re-invoking `follow`
 //!   (with any target, or none) RESUMES it — "re-invoking IS the resume": poll `/v1/device/token`
 //!   once; on a granted poll the answer carries the device's ONE bearer credential (the promoted
@@ -390,7 +390,21 @@ pub(crate) fn follow(
         && opts.skills.is_empty()
         && let [single] = targets.as_slice()
     {
-        // 2) A retired `/i/` invite link. Checked BEFORE `@` so a link carrying userinfo
+        // 2a) A TOKENED invitation URL (`<origin>[/<ws>]/invite/<token>` — what the invitation
+        // mail's terminal line pastes). Checked before `@` for the same reason as the retired
+        // `/i/` links below. An enrolled install accepts directly over the device lane; an
+        // unenrolled one starts the device flow CARRYING the token.
+        if single.contains("/invite/") {
+            let Some((origin, workspace_slug, link)) = parse_invite_url(single) else {
+                return Err(ClientError::InvalidArgument(
+                    "that looks like an invitation link, but not one this tool can read — paste \
+                     the invite URL from the mail verbatim"
+                        .into(),
+                ));
+            };
+            return follow_invite_url(ctx, connectors, &origin, &workspace_slug, link, &opts);
+        }
+        // 2b) A retired `/i/` invite link. Checked BEFORE `@` so a link carrying userinfo
         // (`https://u@host/i/tok`) or a query param (`?x=a@b`) is never misread as `<skill>@<hash>`.
         if single.contains("/i/") {
             return Err(ClientError::Enrollment(
@@ -539,13 +553,21 @@ fn resume(
         }
         // Granted: the poll carries the device's ONE credential + the AUTHORITATIVE workspace (the
         // requested name was only ever a request; unknown/not-yours died at the uniform denial).
-        // Persist, then CONTINUE into the recorded follow intent in this same invocation.
+        // Persist, then CONTINUE into the recorded follow intent in this same invocation. An
+        // invitation grant's HINT wins over the recorded target — an invite enrollment records
+        // only the workspace (the hint is server truth the approval resolved), so the subscribe
+        // describes the invited-to thing first.
         DeviceAuthPoll::Granted(grant) => {
             persist_enrollment(ctx, &wal.base_url, &grant)?;
-            let target = recorded_target.unwrap_or(enroll::FollowTargetDoc {
-                kind: enroll::FollowKindDoc::Workspace,
-                name: wal.workspace_name.clone(),
-            });
+            let target = grant
+                .hint
+                .as_ref()
+                .map(hint_target)
+                .or(recorded_target)
+                .unwrap_or(enroll::FollowTargetDoc {
+                    kind: enroll::FollowKindDoc::Workspace,
+                    name: wal.workspace_name.clone(),
+                });
             // The original invocation's `--manual` rode the WAL; honor it on a resume that omits the
             // flag (a fresh flag still wins — the resumed invocation's consent is the current one).
             let mut opts = opts.clone();
@@ -612,6 +634,26 @@ pub(super) fn persist_enrollment(
 // persists → the two-phase subscribe (describe / `--yes` apply).
 // =================================================================================================
 
+/// The invitation link a `follow <invite-url>` enrollment carries: the mailed single-use token
+/// plus the page URL itself (the browser destination that weaves account → accept → approval).
+/// Hand-written `Debug` — the token is a secret (worth one invitation) and never logs.
+#[derive(Clone)]
+pub(super) struct InviteLink {
+    /// **SECRET** — the invitation token (the URL's last path segment).
+    pub token: String,
+    /// The full invitation page URL, as pasted (scheme included; no query).
+    pub url: String,
+}
+
+impl std::fmt::Debug for InviteLink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InviteLink")
+            .field("token", &"<redacted>")
+            .field("url", &"<invite url redacted>")
+            .finish()
+    }
+}
+
 /// The enroll intent an unresolved single target may fold in: the workspace ADDRESS name, the
 /// follow intent to continue into, and the explicit host when the target was a full URL.
 struct EnrollIntent {
@@ -621,6 +663,60 @@ struct EnrollIntent {
     /// True when the target was a BARE word (no slash, no scheme) — the shape the unenrolled
     /// consent guard gates before any device flow starts.
     bareword: bool,
+    /// The invitation link, when the target was an invite URL — rides the device-authorize start
+    /// (the flow row records it) and swaps the browser destination to the invitation page.
+    invite: Option<InviteLink>,
+}
+
+/// Parse an invitation URL — `<origin>/invite/<token>` (single tenancy) or
+/// `<origin>/<ws>/invite/<token>` (multi) — into its origin, workspace slug (`""` for the
+/// origin-rooted form), and token. A schemeless dotted host reads as `https://` (the same
+/// disambiguation the address grammar applies). `None` = not an invite URL shape.
+pub(super) fn parse_invite_url(raw: &str) -> Option<(String, String, InviteLink)> {
+    let (origin, path) = split_origin(raw)?;
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let (workspace, token) = match segments.as_slice() {
+        ["invite", token] => (String::new(), (*token).to_owned()),
+        [ws, "invite", token] if resolve::is_workspace_name(ws) => {
+            ((*ws).to_owned(), (*token).to_owned())
+        }
+        _ => return None,
+    };
+    if token.is_empty() || token.contains(['?', '#']) {
+        return None;
+    }
+    let url = if workspace.is_empty() {
+        format!("{origin}/invite/{token}")
+    } else {
+        format!("{origin}/{workspace}/invite/{token}")
+    };
+    Some((origin, workspace, InviteLink { token, url }))
+}
+
+/// Split a pasted URL into `(origin, path)`: an explicit `http(s)://` scheme, or a schemeless
+/// DOTTED first segment read as `https://` (the dot disambiguates a host from a slug). Any query
+/// or fragment is dropped before the path splits.
+fn split_origin(raw: &str) -> Option<(String, String)> {
+    let raw = raw.split(['?', '#']).next().unwrap_or(raw);
+    let (scheme, rest) = if let Some(rest) = raw.strip_prefix("https://") {
+        ("https", rest)
+    } else if let Some(rest) = raw.strip_prefix("http://") {
+        ("http", rest)
+    } else {
+        let first = raw.split('/').next().unwrap_or("");
+        if !first.contains('.') {
+            return None;
+        }
+        ("https", raw)
+    };
+    let (host, path) = match rest.split_once('/') {
+        Some((h, p)) => (h, p.to_owned()),
+        None => (rest, String::new()),
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some((format!("{scheme}://{host}"), path))
 }
 
 /// Whether an UNRESOLVED parsed target is shaped like a workspace address this install could enroll
@@ -663,6 +759,7 @@ fn enroll_intent(parsed: &ParsedTarget) -> Option<EnrollIntent> {
                 workspace_name: workspace.clone(),
                 target,
                 bareword: false,
+                invite: None,
             })
         }
         ParsedTarget::Bare(name) if resolve::is_workspace_name(name) => Some(EnrollIntent {
@@ -673,6 +770,7 @@ fn enroll_intent(parsed: &ParsedTarget) -> Option<EnrollIntent> {
                 name: name.clone(),
             },
             bareword: true,
+            invite: None,
         }),
         _ => None,
     }
@@ -708,11 +806,28 @@ fn begin_address(
     let base_url = resolve_api_base(&origin, &card.api_base_url)?;
     guard_one_plane(ctx, &base_url)?;
 
-    let start = (connectors.enroll)(&base_url)
-        .device_auth_start(&intent.workspace_name, &machine_name())?;
+    let start = (connectors.enroll)(&base_url).device_auth_start(
+        &intent.workspace_name,
+        &machine_name(),
+        intent.invite.as_ref().map(|i| i.token.as_str()),
+    )?;
     let expires_at = now_millis(ctx).saturating_add(
         i64::try_from(start.expires_in_secs.saturating_mul(1000)).unwrap_or(i64::MAX),
     );
+    // The browser destination. A PLAIN enrollment prints the server's bare approval page (the
+    // human types the code there — it never rides a URL). An INVITATION enrollment points at the
+    // invitation page instead — account/sign-in → accept → approval as ONE visit — carrying the
+    // flow's device-code HASH as the `device` challenge, so the approval card resolves with zero
+    // typing after the accept (the hash identifies the flow; a preimage is infeasible, and the
+    // code itself still never enters a URL).
+    let verification_uri = match &intent.invite {
+        Some(link) => format!(
+            "{}?device={}",
+            link.url,
+            device_challenge(&start.device_code)
+        ),
+        None => start.verification_uri,
+    };
     let wal = enroll::PendingEnrollment {
         schema_version: PERSISTED_SCHEMA_VERSION,
         base_url,
@@ -727,7 +842,7 @@ fn begin_address(
         },
         device_code: start.device_code,
         user_code: start.user_code,
-        verification_uri_complete: start.verification_uri_complete,
+        verification_uri,
         interval_secs: start.interval_secs,
         expires_at_millis: expires_at,
     };
@@ -735,9 +850,100 @@ fn begin_address(
     Ok(FollowOutcome::plain(pending_followdata(&wal)))
 }
 
+/// The loopback/weave CHALLENGE: hex of the device code's SHA-256 — the same value the server
+/// keys the flow row by, so it identifies the pending request in a URL without carrying any
+/// secret (the code stays off every URL; the device code itself never leaves the WAL).
+pub(crate) fn device_challenge(device_code: &str) -> String {
+    to_hex(&topos_core::digest::sha256(device_code.as_bytes()))
+}
+
+/// The follow target an invitation's first-destination hint names (`channel` → a channel join;
+/// anything else — the catalog's `kind` tag — a direct skill follow).
+fn hint_target(hint: &crate::plane::GrantHint) -> enroll::FollowTargetDoc {
+    enroll::FollowTargetDoc {
+        kind: if hint.kind == "channel" {
+            enroll::FollowKindDoc::Channel
+        } else {
+            enroll::FollowKindDoc::Skill
+        },
+        name: hint.name.clone(),
+    }
+}
+
+/// `follow <invite-url>` — the terminal-first invited person. ENROLLED at the same plane: accept
+/// directly over the device lane (the credential authenticates; no browser) and continue into the
+/// hinted target's describe. Enrolled ELSEWHERE: the wrong-server refusal. UNENROLLED: the
+/// ordinary device flow CARRYING the token — the browser weave (invitation page → /verify) does
+/// account + accept + approval in one visit, and the granted poll's hint steers the subscribe.
+fn follow_invite_url(
+    ctx: &Ctx<'_>,
+    connectors: &FollowConnectors<'_>,
+    origin: &str,
+    workspace_slug: &str,
+    link: InviteLink,
+    opts: &FollowOpts,
+) -> Result<FollowOutcome, ClientError> {
+    if enroll::read_instance(ctx.fs, &ctx.layout)?.is_some() {
+        // The card is fetched at the BARE origin — the invite URL (a capability) never rides a
+        // card probe, and the card is constant on every path anyway.
+        let card = (connectors.enroll)(origin).fetch_card(origin)?;
+        let base_url = resolve_api_base(origin, &card.api_base_url)?;
+        guard_one_plane(ctx, &base_url)?;
+        // Already enrolled here: the device lane accepts directly — the credential already acts
+        // as its person, and the fresh seat extends its reach the moment the accept commits.
+        let directory = (connectors.directory)(&base_url);
+        let accepted = directory.accept_invitation(&link.token)?;
+        let mut user = enroll::read_user(ctx.fs, &ctx.layout)?.unwrap_or_default();
+        user.schema_version = PERSISTED_SCHEMA_VERSION;
+        enroll::upsert_membership(
+            &mut user,
+            enroll::Membership {
+                workspace_id: accepted.workspace.workspace_id.clone(),
+                name: accepted.workspace.name.clone(),
+                display_name: accepted.workspace.display_name.clone(),
+                enrolled_at: now_millis(ctx),
+            },
+        );
+        enroll::write_user(ctx.fs, &ctx.layout, &user)?;
+        let target = match &accepted.hint {
+            Some(hint) => hint_target(hint),
+            None => enroll::FollowTargetDoc {
+                kind: enroll::FollowKindDoc::Workspace,
+                name: accepted.workspace.name.clone(),
+            },
+        };
+        return continue_into_target(
+            ctx,
+            connectors,
+            &base_url,
+            &accepted.workspace.workspace_id,
+            &target,
+            opts,
+        );
+    }
+
+    // Unenrolled: the device flow carries the token; the intent's recorded target is the
+    // workspace (the granted poll's hint refines it at resume).
+    begin_address(
+        ctx,
+        connectors,
+        EnrollIntent {
+            host: Some(origin.to_owned()),
+            workspace_name: workspace_slug.to_owned(),
+            target: enroll::FollowTargetDoc {
+                kind: enroll::FollowKindDoc::Workspace,
+                name: workspace_slug.to_owned(),
+            },
+            bareword: false,
+            invite: Some(link),
+        },
+        opts,
+    )
+}
+
 /// The pending `FollowData` an enrollment surfaces (there is no workspace ID yet — the requested
 /// ADDRESS name rides the disclosure slot; the id arrives with the grant). The human opens
-/// `verification_uri_complete` and cross-checks the code; the agent re-invokes `follow` to poll.
+/// `verification_uri` and cross-checks the code; the agent re-invokes `follow` to poll.
 /// An ORIGIN enrollment has no requested name — the plane base stands in for the disclosure, so the
 /// slot never reads as an empty string.
 fn pending_followdata(wal: &enroll::PendingEnrollment) -> FollowData {
@@ -753,7 +959,7 @@ fn pending_followdata(wal: &enroll::PendingEnrollment) -> FollowData {
         workspace_display_name: None,
         plane_base_url: Some(wal.base_url.clone()),
         pending: Some(EnrollmentPending {
-            verification_uri_complete: wal.verification_uri_complete.clone(),
+            verification_uri: wal.verification_uri.clone(),
             user_code: wal.user_code.clone(),
             expires_at: Some(fmt_rfc3339_millis(wal.expires_at_millis)),
             interval_secs: Some(wal.interval_secs),
@@ -2037,7 +2243,9 @@ fn now_millis(ctx: &Ctx<'_>) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{machine_name, resolve_api_base, validate_base_url};
+    use super::{
+        device_challenge, machine_name, parse_invite_url, resolve_api_base, validate_base_url,
+    };
 
     /// The device name shown on the approval page derives from the HOST (no key material exists to
     /// fingerprint) and always carries the recognizable `topos CLI` prefix.
@@ -2110,5 +2318,50 @@ mod tests {
         ] {
             assert!(validate_base_url(bad).is_err(), "must refuse {bad:?}");
         }
+    }
+
+    #[test]
+    fn invite_urls_parse_in_both_tenancy_shapes() {
+        // Origin-rooted (single tenancy): empty workspace slug.
+        let (origin, ws, link) = parse_invite_url("https://topos.sh/invite/tok_abc").unwrap();
+        assert_eq!(origin, "https://topos.sh");
+        assert_eq!(ws, "");
+        assert_eq!(link.token, "tok_abc");
+        assert_eq!(link.url, "https://topos.sh/invite/tok_abc");
+        // Workspace-nested (multi tenancy).
+        let (origin, ws, link) =
+            parse_invite_url("https://topos.example/acme/invite/tok_xyz").unwrap();
+        assert_eq!(origin, "https://topos.example");
+        assert_eq!(ws, "acme");
+        assert_eq!(link.url, "https://topos.example/acme/invite/tok_xyz");
+        // A schemeless DOTTED host reads as https (the mail's terminal line survives a lossy paste).
+        let (origin, _, link) = parse_invite_url("topos.sh/invite/tok_a").unwrap();
+        assert_eq!(origin, "https://topos.sh");
+        assert_eq!(link.token, "tok_a");
+        // A trailing query/fragment is dropped, never folded into the token.
+        let (_, _, link) = parse_invite_url("https://topos.sh/invite/tok_b?utm=x#frag").unwrap();
+        assert_eq!(link.token, "tok_b");
+    }
+
+    #[test]
+    fn non_invite_shapes_do_not_parse_as_invite_urls() {
+        for bad in [
+            "https://topos.sh/invite",             // no token
+            "https://topos.sh/a/b/invite/tok",     // too deep
+            "https://topos.sh/UPPER/invite/tok",   // not a workspace slug
+            "https://topos.sh/acme/skills/deploy", // a resource address
+            "bare-word",                           // no host
+        ] {
+            assert!(parse_invite_url(bad).is_none(), "must not parse {bad:?}");
+        }
+    }
+
+    #[test]
+    fn the_device_challenge_is_the_hex_sha256_of_the_device_code() {
+        let challenge = device_challenge("dc_secret");
+        assert_eq!(challenge.len(), 64);
+        assert!(challenge.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(challenge, device_challenge("dc_secret"), "deterministic");
+        assert_ne!(challenge, device_challenge("dc_other"));
     }
 }

--- a/bins/topos/src/ops/invite.rs
+++ b/bins/topos/src/ops/invite.rs
@@ -1,10 +1,14 @@
-//! `invite [EMAIL]... [--channel <N>]...` — seat emails as invited members of the workspace.
+//! `invite [EMAIL]... [--skill <N> | --channel <N>]` — invite emails into the workspace.
 //!
-//! An invitation is a ROSTER WRITE: `POST /v1/workspaces/{ws}/invitations` under the workspace Bearer
-//! credential seats each email as an `invited` member (recording who invited whom) and optionally
-//! pre-places each invitee into channels. There is no invite link and no role — every CLI invitee starts
-//! as a member (roles are raised later, on the web); joining is `follow <address>` plus proof of the
-//! invited email. Member-level unless the workspace's invite policy restricts inviting to owners.
+//! An invitation is an INVITATION-ROW write: `POST /v1/workspaces/{ws}/invitations` under the
+//! workspace Bearer credential seats each email as a pending 7-day claim, and the SERVER mails each
+//! address its single-use invite link (the token never appears in this exchange — the mailbox is
+//! its one channel; the receipt carries the workspace address only). At most ONE optional
+//! first-destination hint — `--skill <name>` or `--channel <name>` — rides the invitation: the
+//! accept subscribes it (the seat first, then the follow/membership, one transaction server-side),
+//! and the invitee's post-enrollment describe targets it. No role field — every CLI invitee starts
+//! as a member (roles are raised later, on the web). Member-level unless the workspace's invite
+//! policy restricts inviting to owners.
 //!
 //! Requires prior enrollment: the plane (`base_url`) and the workspace (`workspace_id`) come from the
 //! sidecar `follow` wrote; the acting device rides the transport's ONE **Bearer credential** (the
@@ -61,10 +65,16 @@ pub(crate) fn invite(
     ctx: &Ctx<'_>,
     connectors: &InviteConnectors<'_>,
     emails: Vec<String>,
-    channels: Vec<String>,
+    skill: Option<String>,
+    channel: Option<String>,
     workspace: Option<&str>,
     yes: bool,
 ) -> Result<InviteOutcome, ClientError> {
+    if skill.is_some() && channel.is_some() {
+        return Err(ClientError::InvalidArgument(
+            "an invitation carries at most one first destination — `--skill` OR `--channel`".into(),
+        ));
+    }
     // Require enrollment: the pinned plane's base URL comes from what `follow` wrote.
     let instance = enroll::read_instance(ctx.fs, &ctx.layout)?.ok_or(ClientError::NotEnrolled)?;
     // Pick the workspace (the invitation's scope) from the enrolled `user.json` memberships:
@@ -106,7 +116,11 @@ pub(crate) fn invite(
         let me = (connectors.directory)(&instance.base_url).me(&workspace_id)?;
         let mut yes_argv = vec!["topos".to_owned(), "invite".to_owned()];
         yes_argv.extend(emails.iter().cloned());
-        for c in &channels {
+        if let Some(s) = &skill {
+            yes_argv.push("--skill".to_owned());
+            yes_argv.push(s.clone());
+        }
+        if let Some(c) = &channel {
             yes_argv.push("--channel".to_owned());
             yes_argv.push(c.clone());
         }
@@ -116,7 +130,8 @@ pub(crate) fn invite(
                 address: me.address,
                 invite_policy: me.invite_policy,
                 seat: emails,
-                channels,
+                skill,
+                channel,
             },
             yes_argv,
         });
@@ -124,9 +139,14 @@ pub(crate) fn invite(
 
     // ---- APPLY (`--yes`) ----
     // POST the invitation under the workspace Bearer credential (the transport looks it up by
-    // `workspace_id`; the plane resolves the credential's registry row → principal → the invite-policy
-    // gate). The workspace id rides the URL path; the body carries only the emails + channel pre-placements.
-    let body = InvitationRequest { emails, channels };
+    // `workspace_id`; the plane resolves the credential's registry row → principal → the
+    // invite-policy gate). The workspace id rides the URL path; the body carries the emails + the
+    // optional hint.
+    let body = InvitationRequest {
+        emails,
+        skill,
+        channel,
+    };
     let transport = (connectors.governance)(&instance.base_url);
     Ok(InviteOutcome::Applied(
         transport.invite(&workspace_id, body)?,

--- a/bins/topos/src/ops/loopback.rs
+++ b/bins/topos/src/ops/loopback.rs
@@ -1,0 +1,295 @@
+//! The LOOPBACK approval listener — zero-typing browser enrollment.
+//!
+//! When a local browser is available, the enrollment wait binds an ephemeral `127.0.0.1`
+//! listener, auto-opens the approval page (carrying the flow's device-code CHALLENGE — the hex
+//! of its SHA-256, the same value the server keys the flow row by, so the page resolves the
+//! request with zero typing; the short code itself never rides a URL), and receives the outcome
+//! as ONE state-bound single-use localhost redirect. The redirect carries NOTHING sensitive —
+//! `state` (minted per ceremony, matched exactly, spent on first receipt) and the outcome word —
+//! and the CLI's ordinary `device/token` POLL stays the source of truth: a lost or spoofed
+//! redirect changes nothing but the wake-up latency. The typed-code flow stays the SSH/headless
+//! fallback, chosen automatically ([`choose_browser`]).
+//!
+//! `std::net::TcpListener` only — no server crate enters the client graph.
+
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, TcpListener, TcpStream};
+use std::time::Duration;
+
+/// What the localhost redirect reported. Advisory: the poll re-verifies either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LoopbackOutcome {
+    Approved,
+    Denied,
+}
+
+/// The ephemeral single-ceremony listener: `127.0.0.1:0`, non-blocking, one matching redirect.
+pub(crate) struct LoopbackListener {
+    listener: TcpListener,
+    port: u16,
+    state: String,
+}
+
+impl LoopbackListener {
+    /// Bind on an ephemeral loopback port. `state` is the ceremony's one-time binding token
+    /// (minted by the caller; matched exactly by [`Self::try_receive`]).
+    pub(crate) fn bind(state: String) -> std::io::Result<Self> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+        listener.set_nonblocking(true)?;
+        let port = listener.local_addr()?.port();
+        Ok(Self {
+            listener,
+            port,
+            state,
+        })
+    }
+
+    pub(crate) fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Drain any waiting connections without blocking; answer each; return the outcome of the
+    /// FIRST request whose `state` matches (spending it — the caller stops listening). Anything
+    /// else (a stray probe, a wrong state, a favicon fetch) gets a plain 404 and keeps nothing.
+    pub(crate) fn try_receive(&self) -> Option<LoopbackOutcome> {
+        loop {
+            match self.listener.accept() {
+                Ok((stream, _)) => {
+                    if let Some(outcome) = answer_connection(stream, &self.state) {
+                        return Some(outcome);
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => return None,
+                Err(_) => return None,
+            }
+        }
+    }
+}
+
+/// Read one HTTP request off the accepted connection, answer it, and return the outcome when it
+/// is the ceremony's own redirect. Faults are swallowed — the poll is the truth, never this.
+fn answer_connection(mut stream: TcpStream, state: &str) -> Option<LoopbackOutcome> {
+    let _ = stream.set_nonblocking(false);
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let mut buf = [0u8; 2048];
+    let n = stream.read(&mut buf).ok()?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("");
+    match parse_callback(path, state) {
+        Some(outcome) => {
+            let body = match outcome {
+                LoopbackOutcome::Approved => {
+                    "You're set — this device is approved. Return to your terminal."
+                }
+                LoopbackOutcome::Denied => "Request denied — nothing was connected.",
+            };
+            let _ = stream.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: text/html; charset=utf-8\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            );
+            Some(outcome)
+        }
+        None => {
+            let _ = stream.write_all(
+                b"HTTP/1.1 404 Not Found\r\nconnection: close\r\ncontent-length: 0\r\n\r\n",
+            );
+            None
+        }
+    }
+}
+
+/// Parse a redirect path (`/cb?state=…&outcome=approved|denied`) against the ceremony's state.
+/// Pure — unit-tested. A missing/mismatched state or an unknown outcome is `None` (404'd, kept
+/// listening): the state binds the redirect to the CLI process that started the flow.
+pub(crate) fn parse_callback(path: &str, expected_state: &str) -> Option<LoopbackOutcome> {
+    let query = path.strip_prefix("/cb?")?;
+    let mut state = None;
+    let mut outcome = None;
+    for pair in query.split('&') {
+        match pair.split_once('=') {
+            Some(("state", v)) => state = Some(v),
+            Some(("outcome", v)) => outcome = Some(v),
+            _ => {}
+        }
+    }
+    if state != Some(expected_state) || expected_state.is_empty() {
+        return None;
+    }
+    match outcome {
+        Some("approved") => Some(LoopbackOutcome::Approved),
+        Some("denied") => Some(LoopbackOutcome::Denied),
+        _ => None,
+    }
+}
+
+/// The full auto-open URL: the pending disclosure's approval page + the flow challenge (when the
+/// page doesn't already carry one — an invitation enrollment's does) + this listener's return
+/// coordinates. Everything appended is non-secret.
+pub(crate) fn approval_url(base: &str, challenge: &str, port: u16, state: &str) -> String {
+    let mut url = base.to_owned();
+    let mut sep = if url.contains('?') { '&' } else { '?' };
+    if !url.contains("device=") {
+        url.push(sep);
+        url.push_str("device=");
+        url.push_str(challenge);
+        sep = '&';
+    }
+    url.push(sep);
+    url.push_str(&format!("port={port}&state={state}"));
+    url
+}
+
+/// The environment facts the browser-open decision reads — a snapshot, so the decision itself
+/// is a pure function ([`choose_browser`]) the tests table-drive.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BrowserEnv {
+    /// A human is watching (TTY stderr, not `--json`).
+    pub interactive: bool,
+    /// An SSH session (`SSH_CONNECTION`/`SSH_TTY`) — the browser would open on the wrong machine.
+    pub ssh: bool,
+    /// `TOPOS_NO_BROWSER` set — the explicit opt-out.
+    pub suppressed: bool,
+    /// macOS (`open` always exists).
+    pub macos: bool,
+    /// A graphical session on other unixes (`DISPLAY`/`WAYLAND_DISPLAY`).
+    pub display: bool,
+}
+
+impl BrowserEnv {
+    /// Snapshot the real process environment (`interactive` is the caller's fact).
+    pub(crate) fn detect(interactive: bool) -> Self {
+        let set = |k: &str| std::env::var_os(k).is_some_and(|v| !v.is_empty());
+        Self {
+            interactive,
+            ssh: set("SSH_CONNECTION") || set("SSH_TTY"),
+            suppressed: set("TOPOS_NO_BROWSER"),
+            macos: cfg!(target_os = "macos"),
+            display: set("DISPLAY") || set("WAYLAND_DISPLAY"),
+        }
+    }
+}
+
+/// Choose the browser opener, or `None` for the typed-code fallback. Pure and table-tested:
+/// headless / `--json` / SSH / opted-out never open anything; macOS uses `open`; a graphical
+/// unix session uses `xdg-open`; anything else falls back.
+pub(crate) fn choose_browser(env: &BrowserEnv) -> Option<&'static str> {
+    if !env.interactive || env.ssh || env.suppressed {
+        return None;
+    }
+    if env.macos {
+        return Some("open");
+    }
+    if env.display {
+        return Some("xdg-open");
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(
+        interactive: bool,
+        ssh: bool,
+        suppressed: bool,
+        macos: bool,
+        display: bool,
+    ) -> BrowserEnv {
+        BrowserEnv {
+            interactive,
+            ssh,
+            suppressed,
+            macos,
+            display,
+        }
+    }
+
+    #[test]
+    fn browser_selection_is_a_pure_table() {
+        // Interactive macOS opens; SSH / suppressed / headless never do.
+        assert_eq!(
+            choose_browser(&env(true, false, false, true, false)),
+            Some("open")
+        );
+        assert_eq!(
+            choose_browser(&env(true, false, false, false, true)),
+            Some("xdg-open")
+        );
+        assert_eq!(choose_browser(&env(true, false, false, false, false)), None);
+        assert_eq!(choose_browser(&env(false, false, false, true, true)), None);
+        assert_eq!(choose_browser(&env(true, true, false, true, true)), None);
+        assert_eq!(choose_browser(&env(true, false, true, true, true)), None);
+    }
+
+    #[test]
+    fn callback_parsing_binds_to_the_exact_state() {
+        let s = "st-0123456789";
+        assert_eq!(
+            parse_callback("/cb?state=st-0123456789&outcome=approved", s),
+            Some(LoopbackOutcome::Approved)
+        );
+        assert_eq!(
+            parse_callback("/cb?outcome=denied&state=st-0123456789", s),
+            Some(LoopbackOutcome::Denied)
+        );
+        // Wrong / missing state, wrong path, unknown outcome: all refused.
+        assert_eq!(parse_callback("/cb?state=other&outcome=approved", s), None);
+        assert_eq!(parse_callback("/cb?outcome=approved", s), None);
+        assert_eq!(parse_callback("/favicon.ico", s), None);
+        assert_eq!(
+            parse_callback("/cb?state=st-0123456789&outcome=maybe", s),
+            None
+        );
+        // An empty expected state can never match (fail-closed).
+        assert_eq!(parse_callback("/cb?state=&outcome=approved", ""), None);
+    }
+
+    #[test]
+    fn approval_url_appends_challenge_once_and_the_return_coordinates() {
+        // A plain /verify page gains the challenge + coordinates.
+        assert_eq!(
+            approval_url("https://x/verify", "ab12", 4321, "st"),
+            "https://x/verify?device=ab12&port=4321&state=st"
+        );
+        // An invitation page already carrying its challenge gains only the coordinates.
+        assert_eq!(
+            approval_url("https://x/invite/tok?device=ab12", "ab12", 4321, "st"),
+            "https://x/invite/tok?device=ab12&port=4321&state=st"
+        );
+    }
+
+    #[test]
+    fn listener_receives_exactly_the_state_bound_redirect() {
+        let listener = LoopbackListener::bind("st-abcdef".to_owned()).expect("bind loopback");
+        let port = listener.port();
+        assert_eq!(listener.try_receive(), None, "nothing arrived yet");
+
+        // A wrong-state probe answers 404 and spends nothing. The single test thread writes
+        // FIRST, lets try_receive accept+answer, then reads the buffered response.
+        let mut probe = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        probe
+            .write_all(b"GET /cb?state=wrong&outcome=approved HTTP/1.1\r\nhost: x\r\n\r\n")
+            .expect("write");
+        assert_eq!(listener.try_receive(), None);
+        let mut answer = String::new();
+        let _ = probe.read_to_string(&mut answer);
+        assert!(answer.starts_with("HTTP/1.1 404"), "{answer}");
+
+        // The ceremony's own redirect lands.
+        let mut real = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        real.write_all(b"GET /cb?state=st-abcdef&outcome=approved HTTP/1.1\r\nhost: x\r\n\r\n")
+            .expect("write");
+        assert_eq!(listener.try_receive(), Some(LoopbackOutcome::Approved));
+        let mut answer = String::new();
+        let _ = real.read_to_string(&mut answer);
+        assert!(answer.starts_with("HTTP/1.1 200"), "{answer}");
+    }
+}

--- a/bins/topos/src/ops/loopback.rs
+++ b/bins/topos/src/ops/loopback.rs
@@ -152,6 +152,12 @@ pub(crate) fn approval_url(base: &str, challenge: &str, port: u16, state: &str) 
 pub(crate) struct BrowserEnv {
     /// A human is watching (TTY stderr, not `--json`).
     pub interactive: bool,
+    /// STDOUT is a terminal — the wait may block indefinitely (a piped run without an explicit
+    /// `--wait` exits after one poll, so a loopback ceremony there would be orphaned).
+    pub stdout_tty: bool,
+    /// `--wait` was given in any form — the caller explicitly opted into a blocking wait, so the
+    /// process stays alive to receive the redirect even when piped.
+    pub explicit_wait: bool,
     /// An SSH session (`SSH_CONNECTION`/`SSH_TTY`) — the browser would open on the wrong machine.
     pub ssh: bool,
     /// `TOPOS_NO_BROWSER` set — the explicit opt-out.
@@ -163,11 +169,14 @@ pub(crate) struct BrowserEnv {
 }
 
 impl BrowserEnv {
-    /// Snapshot the real process environment (`interactive` is the caller's fact).
-    pub(crate) fn detect(interactive: bool) -> Self {
+    /// Snapshot the real process environment (`interactive` / `stdout_tty` / `explicit_wait` are
+    /// the caller's facts).
+    pub(crate) fn detect(interactive: bool, stdout_tty: bool, explicit_wait: bool) -> Self {
         let set = |k: &str| std::env::var_os(k).is_some_and(|v| !v.is_empty());
         Self {
             interactive,
+            stdout_tty,
+            explicit_wait,
             ssh: set("SSH_CONNECTION") || set("SSH_TTY"),
             suppressed: set("TOPOS_NO_BROWSER"),
             macos: cfg!(target_os = "macos"),
@@ -177,10 +186,15 @@ impl BrowserEnv {
 }
 
 /// Choose the browser opener, or `None` for the typed-code fallback. Pure and table-tested:
-/// headless / `--json` / SSH / opted-out never open anything; macOS uses `open`; a graphical
-/// unix session uses `xdg-open`; anything else falls back.
+/// headless / `--json` / SSH / opted-out never open anything, and a PIPED run without an explicit
+/// `--wait` never does either — the loopback ceremony needs the process to outlive the human's
+/// click, and the piped default exits after one poll. macOS uses `open`; a graphical unix session
+/// uses `xdg-open`; anything else falls back.
 pub(crate) fn choose_browser(env: &BrowserEnv) -> Option<&'static str> {
     if !env.interactive || env.ssh || env.suppressed {
+        return None;
+    }
+    if !env.stdout_tty && !env.explicit_wait {
         return None;
     }
     if env.macos {
@@ -198,6 +212,8 @@ mod tests {
 
     fn env(
         interactive: bool,
+        stdout_tty: bool,
+        explicit_wait: bool,
         ssh: bool,
         suppressed: bool,
         macos: bool,
@@ -205,6 +221,8 @@ mod tests {
     ) -> BrowserEnv {
         BrowserEnv {
             interactive,
+            stdout_tty,
+            explicit_wait,
             ssh,
             suppressed,
             macos,
@@ -214,19 +232,58 @@ mod tests {
 
     #[test]
     fn browser_selection_is_a_pure_table() {
-        // Interactive macOS opens; SSH / suppressed / headless never do.
+        // A full TTY on macOS / a graphical unix opens; SSH / suppressed / headless never do.
         assert_eq!(
-            choose_browser(&env(true, false, false, true, false)),
+            choose_browser(&env(true, true, false, false, false, true, false)),
             Some("open")
         );
         assert_eq!(
-            choose_browser(&env(true, false, false, false, true)),
+            choose_browser(&env(true, true, false, false, false, false, true)),
             Some("xdg-open")
         );
-        assert_eq!(choose_browser(&env(true, false, false, false, false)), None);
-        assert_eq!(choose_browser(&env(false, false, false, true, true)), None);
-        assert_eq!(choose_browser(&env(true, true, false, true, true)), None);
-        assert_eq!(choose_browser(&env(true, false, true, true, true)), None);
+        assert_eq!(
+            choose_browser(&env(true, true, false, false, false, false, false)),
+            None
+        );
+        assert_eq!(
+            choose_browser(&env(false, true, false, false, false, true, true)),
+            None
+        );
+        assert_eq!(
+            choose_browser(&env(true, true, false, true, false, true, true)),
+            None
+        );
+        assert_eq!(
+            choose_browser(&env(true, true, false, false, true, true, true)),
+            None
+        );
+    }
+
+    #[test]
+    fn a_piped_run_opens_no_browser_unless_wait_was_explicit() {
+        // Piped stdout, no --wait: the wait exits after one poll, so a loopback ceremony would be
+        // orphaned — never open. An explicit --wait keeps the process alive → the loopback may run.
+        assert_eq!(
+            choose_browser(&env(true, false, false, false, false, true, true)),
+            None
+        );
+        assert_eq!(
+            choose_browser(&env(true, false, true, false, false, true, false)),
+            Some("open")
+        );
+        assert_eq!(
+            choose_browser(&env(true, false, true, false, false, false, true)),
+            Some("xdg-open")
+        );
+        // --wait does not override the harder refusals (SSH / opt-out / non-interactive).
+        assert_eq!(
+            choose_browser(&env(true, false, true, true, false, true, true)),
+            None
+        );
+        assert_eq!(
+            choose_browser(&env(false, false, true, false, false, true, true)),
+            None
+        );
     }
 
     #[test]

--- a/bins/topos/src/ops/mod.rs
+++ b/bins/topos/src/ops/mod.rs
@@ -28,6 +28,7 @@ mod follow;
 mod invite;
 mod list;
 mod log;
+pub(crate) mod loopback;
 mod merge_resolve;
 mod protect;
 mod publish;
@@ -69,7 +70,7 @@ pub(crate) use channel::{ChannelConnectors, ChannelOutcome, channel};
 pub(crate) use diff::{DiffBudget, diff};
 pub(crate) use follow::{
     BarewordDecision, FollowApplied, FollowConnectors, FollowDescribe, FollowOpts, FollowOutcome,
-    Reattach, follow,
+    Reattach, device_challenge, follow,
 };
 // Test-only re-export: the waiting-line parser round-trips against the disclosures' emitter.
 #[cfg(test)]

--- a/bins/topos/src/ops/status.rs
+++ b/bins/topos/src/ops/status.rs
@@ -174,7 +174,7 @@ mod tests {
                 },
                 device_code: "dc_expired".to_owned(),
                 user_code: "XXXX-YYYY".to_owned(),
-                verification_uri_complete: "https://topos.sh/verify?code=XXXX-YYYY".to_owned(),
+                verification_uri: "https://topos.sh/verify".to_owned(),
                 interval_secs: 5,
                 // Long expired — recovery would reap this WAL on any ordinary command.
                 expires_at_millis: 1_000,

--- a/bins/topos/src/plane.rs
+++ b/bins/topos/src/plane.rs
@@ -277,6 +277,23 @@ pub(crate) trait DirectorySource {
     /// fault; [`ClientError::WireInvalid`] on a malformed body.
     fn me(&self, workspace_id: &str) -> Result<WireMe, ClientError>;
 
+    /// `POST /v1/invitations/accept` — the ALREADY-ENROLLED device consuming an invite URL: the
+    /// credential authenticates the person (no seat exists yet, so this is the one PERSON-scoped
+    /// call on this transport — no workspace id anywhere). The OK answer carries the joined
+    /// workspace + the optional first-destination hint; the invitation's own fences may refuse
+    /// typed (wrong account / unverified mailbox), and a dead token is the uniform 404. Defaulted
+    /// so read-only fakes need no arm.
+    ///
+    /// # Errors
+    /// [`ClientError::TargetNotFound`] on a dead token; [`ClientError::PlaneTerminal`] on a fence
+    /// refusal; [`ClientError::Plane`]/[`ClientError::WireInvalid`] on transport/parse faults.
+    fn accept_invitation(&self, token: &str) -> Result<InviteAccepted, ClientError> {
+        let _ = token;
+        Err(ClientError::Plane(
+            "this transport serves no invitation accept".into(),
+        ))
+    }
+
     /// `GET /v1/workspaces/{ws}/channels` — the channel index with the caller's membership marked.
     ///
     /// # Errors
@@ -426,10 +443,10 @@ pub(crate) struct DeviceAuthStart {
     /// **SECRET** — the device code the client polls with (promoted server-side to the device's ONE
     /// bearer credential on approval). Redacted in `Debug`, never logged / in a URL.
     pub device_code: String,
-    /// The short human-facing code the approval page displays (a cross-check, never typed as a secret).
+    /// The short human-facing code the approval page asks for and displays back (the glance-check).
     pub user_code: String,
-    /// The approval URL with the user code already embedded — used VERBATIM.
-    pub verification_uri_complete: String,
+    /// The BARE approval URL — printed beside the code on its own line; the code never rides a URL.
+    pub verification_uri: String,
     /// The flow lifetime, in seconds.
     pub expires_in_secs: u64,
     /// The minimum poll interval, in seconds.
@@ -441,7 +458,7 @@ impl std::fmt::Debug for DeviceAuthStart {
         f.debug_struct("DeviceAuthStart")
             .field("device_code", &"<redacted>")
             .field("user_code", &self.user_code)
-            .field("verification_uri_complete", &self.verification_uri_complete)
+            .field("verification_uri", &self.verification_uri)
             .field("expires_in_secs", &self.expires_in_secs)
             .field("interval_secs", &self.interval_secs)
             .finish()
@@ -459,6 +476,23 @@ pub(crate) struct EnrolledWorkspace {
     pub display_name: String,
 }
 
+/// The first-destination hint an accepted invitation named — the post-enrollment subscribe's
+/// target (`kind` is the catalog's tag — `skill` today — or the literal `channel`).
+#[derive(Debug, Clone)]
+pub(crate) struct GrantHint {
+    pub kind: String,
+    pub name: String,
+}
+
+/// The direct-accept answer (`POST /v1/invitations/accept`): the joined workspace + the optional
+/// first-destination hint. The already-held device credential now reaches the workspace — no new
+/// secret arrives.
+#[derive(Debug, Clone)]
+pub(crate) struct InviteAccepted {
+    pub workspace: EnrolledWorkspace,
+    pub hint: Option<GrantHint>,
+}
+
 /// A GRANTED device-authorization poll: the device's ONE bearer credential (the promoted device code),
 /// the registered device's id, and the joined workspace. Hand-written `Debug` redacts the credential.
 #[derive(Clone)]
@@ -469,6 +503,9 @@ pub(crate) struct EnrolledGrant {
     pub device_id: String,
     /// The joined workspace.
     pub workspace: EnrolledWorkspace,
+    /// The invitation's first-destination hint — present when the flow carried an invite token
+    /// whose (now accepted) invitation named one.
+    pub hint: Option<GrantHint>,
 }
 
 impl std::fmt::Debug for EnrolledGrant {
@@ -477,6 +514,7 @@ impl std::fmt::Debug for EnrolledGrant {
             .field("credential", &"<redacted>")
             .field("device_id", &self.device_id)
             .field("workspace", &self.workspace)
+            .field("hint", &self.hint)
             .finish()
     }
 }
@@ -514,7 +552,9 @@ pub(crate) trait EnrollSource {
     /// `POST /v1/device/authorize` — begin a device-authorization toward the workspace named by its
     /// ADDRESS slug (whether the name exists is never disclosed here — an unknown name runs the same
     /// flow to the same uniform denial). `requested_name` is the human-readable device name shown on
-    /// the approval page (a confused-deputy aid, not authority).
+    /// the approval page (a confused-deputy aid, not authority). `invite_token` is the invitation
+    /// link's token when this enrollment came from `follow <invite-url>` — recorded on the flow so
+    /// the approval weaves the accept in; never validated at this unauthenticated start.
     ///
     /// # Errors
     /// [`ClientError::Plane`] on a transport fault / non-OK status; [`ClientError::WireInvalid`] on a
@@ -523,6 +563,7 @@ pub(crate) trait EnrollSource {
         &self,
         workspace: &str,
         requested_name: &str,
+        invite_token: Option<&str>,
     ) -> Result<DeviceAuthStart, ClientError>;
 
     /// `POST /v1/device/token` — one poll of the flow. The poll STATE (pending / denied / expired /

--- a/bins/topos/src/plane_http.rs
+++ b/bins/topos/src/plane_http.rs
@@ -35,8 +35,8 @@ use crate::error::ClientError;
 use crate::plane::{
     CatalogSource, ContributeSource, DeviceAuthPoll, DeviceAuthStart, DirectorySource,
     EnrollSource, EnrolledGrant, EnrolledWorkspace, FetchedFile, FetchedVersion, FollowContext,
-    FollowSource, GovernanceSource, KnownCurrent, PlaneError, PlaneSource, PointerFetch,
-    WriteReceipt,
+    FollowSource, GovernanceSource, InviteAccepted, KnownCurrent, PlaneError, PlaneSource,
+    PointerFetch, WriteReceipt,
 };
 
 /// Fail fast establishing a connection (a dead plane must not hang the session-start sweep).
@@ -660,10 +660,12 @@ impl EnrollSource for UreqDeviceClient {
         &self,
         workspace: &str,
         requested_name: &str,
+        invite_token: Option<&str>,
     ) -> Result<DeviceAuthStart, ClientError> {
         let body = serde_json::to_value(DeviceAuthStartRequest {
             requested_name: requested_name.to_owned(),
             workspace: workspace.to_owned(),
+            invite_token: invite_token.map(str::to_owned),
         })
         .map_err(|e| ClientError::Corrupt(format!("authorize body: {e}")))?;
         let url = format!("{}/v1/device/authorize", self.base_url);
@@ -679,7 +681,7 @@ impl EnrollSource for UreqDeviceClient {
         Ok(DeviceAuthStart {
             device_code: resp.device_code,
             user_code: resp.user_code,
-            verification_uri_complete: resp.verification_uri_complete,
+            verification_uri: resp.verification_uri,
             expires_in_secs: resp.expires_in_secs,
             interval_secs: resp.interval_secs,
         })
@@ -735,6 +737,10 @@ fn map_poll_response(status: u16, bytes: &[u8]) -> Result<DeviceAuthPoll, Client
                     name: workspace.name,
                     display_name: workspace.display_name,
                 },
+                hint: resp.hint.map(|h| crate::plane::GrantHint {
+                    kind: h.kind,
+                    name: h.name,
+                }),
             })
         }
     })
@@ -828,6 +834,44 @@ fn map_invite_envelope(status: u16, bytes: &[u8]) -> Result<InvitationData, Clie
     }
     serde_json::from_value(env.data)
         .map_err(|e| ClientError::WireInvalid(format!("invitation data is malformed: {e}")))
+}
+
+/// Map the invite-accept **200 envelope** to the typed [`InviteAccepted`]: `ok` carries the joined
+/// workspace + hint; `!ok` is the typed refusal (wrong account / unverified — carried verbatim so
+/// the verb explains without echoing any address). **Pure** (bytes in), unit-testable.
+fn map_invite_accept_envelope(bytes: &[u8]) -> Result<InviteAccepted, ClientError> {
+    let env: JsonEnvelope = serde_json::from_slice(bytes).map_err(|e| {
+        ClientError::WireInvalid(format!("invite accept envelope is malformed: {e}"))
+    })?;
+    if !env.ok {
+        return Err(match env.error {
+            Some(e) => ClientError::PlaneTerminal {
+                outcome: e.outcome,
+                code: e.code,
+                retryable: e.retryable,
+            },
+            None => ClientError::PlaneTerminal {
+                outcome: TerminalOutcome::Denied,
+                code: "DENIED".to_owned(),
+                retryable: false,
+            },
+        });
+    }
+    let data: topos_types::requests::InviteAcceptData = serde_json::from_value(env.data)
+        .map_err(|e| ClientError::WireInvalid(format!("invite accept data is malformed: {e}")))?;
+    crate::id::validate_workspace_id(&data.workspace.workspace_id)
+        .map_err(crate::id::wire_flavor)?;
+    Ok(InviteAccepted {
+        workspace: EnrolledWorkspace {
+            workspace_id: data.workspace.workspace_id,
+            name: data.workspace.name,
+            display_name: data.workspace.display_name,
+        },
+        hint: data.hint.map(|h| crate::plane::GrantHint {
+            kind: h.kind,
+            name: h.name,
+        }),
+    })
 }
 
 // =================================================================================================
@@ -1080,6 +1124,37 @@ impl DirectorySource for UreqDeviceClient {
             "membership describe",
             workspace_id,
         )
+    }
+
+    fn accept_invitation(&self, token: &str) -> Result<InviteAccepted, ClientError> {
+        // Person-scoped: the ONE device credential authenticates; there is no workspace id (the
+        // caller has no seat in the invitation's workspace yet — that is the point).
+        let credential = self.credential_for("")?;
+        let url = format!("{}/v1/invitations/accept", self.base_url);
+        let body = serde_json::json!({ "token": token });
+        let payload = serde_json::to_vec(&body)
+            .map_err(|_| ClientError::Corrupt("invite accept: could not serialize".to_owned()))?;
+        let resp = self
+            .agent
+            .post(&url)
+            .header("authorization", &format!("Bearer {credential}"))
+            .header("content-type", "application/json")
+            .send(payload.as_slice())
+            .map_err(|e| ClientError::Plane(format!("invite accept: {e}")))?;
+        let status = resp.status().as_u16();
+        match classify(status) {
+            HttpClass::Ok => {
+                let bytes = read_body(resp).map_err(plane_err)?;
+                map_invite_accept_envelope(&bytes)
+            }
+            // The uniform non-answer: a dead token and an unknown route read the same.
+            HttpClass::NotFound => Err(ClientError::TargetNotFound {
+                target: "invitation".to_owned(),
+            }),
+            HttpClass::NotModified | HttpClass::Other => {
+                Err(ClientError::Plane(format!("invite accept: HTTP {status}")))
+            }
+        }
     }
 
     fn channels_index(&self, workspace_id: &str) -> Result<WireChannelIndex, ClientError> {

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -965,15 +965,16 @@ pub(crate) fn follow_tty(data: &FollowData, resumed: &[String]) -> String {
         if let Some(plane) = &data.plane_base_url {
             s.push_str(&format!("\nserver: {plane}"));
         }
-        // The code rides inside the URL (`verification_uri_complete`) — the human clicks it and
-        // cross-checks the SAME code on the approval page before approving. This render surfaces
-        // only when the invocation ENDED still pending (a headless run, or a `--wait` cap that
-        // passed): the interactive path auto-polls to completion and never shows it, so the
-        // re-invoke line here is honest resume guidance, never a required post-approval step.
+        // The URL and the code print on SEPARATE lines — the code never rides a URL. The human
+        // opens the page (an invitation enrollment's page weaves account → accept → approval)
+        // and checks the code shown there against this one. This render surfaces only when the
+        // invocation ENDED still pending (a headless run, or a `--wait` cap that passed): the
+        // interactive path auto-polls to completion and never shows it, so the re-invoke line
+        // here is honest resume guidance, never a required post-approval step.
         s.push_str(&format!(
-            "\nOpen this URL to approve:\n  {}\n  \
-             code: {} (confirm it matches the page before approving)",
-            pending.verification_uri_complete, pending.user_code,
+            "\nOpen: {}\nCode: {} (the page shows the same code — confirm it matches before \
+             approving)",
+            pending.verification_uri, pending.user_code,
         ));
         if let Some(exp) = &pending.expires_at {
             s.push_str(&format!("\nThe code is valid until {exp}."));
@@ -1298,9 +1299,9 @@ pub(crate) fn unfollow_applied_tty(a: &crate::ops::UnfollowApplied) -> String {
 /// so the re-invoke line is resume guidance, never a required post-approval step.
 pub(crate) fn login_pending_tty(p: &crate::ops::AuthLoginPending) -> String {
     let mut s = format!(
-        "Signing in to {}\nOpen this URL to approve:\n  {}\n  \
-         code: {} (confirm it matches the page before approving)",
-        p.server, p.verification_uri_complete, p.user_code,
+        "Signing in to {}\nOpen: {}\nCode: {} (the page shows the same code — confirm it \
+         matches before approving)",
+        p.server, p.verification_uri, p.user_code,
     );
     if let Some(exp) = &p.expires_at {
         s.push_str(&format!("\nThe code is valid until {exp}."));
@@ -1799,25 +1800,29 @@ pub(crate) fn invite_read_tty(data: &topos_types::results::InviteReadData) -> St
     )
 }
 
-/// The `invite <email>...` DESCRIBE's TTY — who gets seated, the pre-placements, the mail-or-paste note.
+/// The `invite <email>...` DESCRIBE's TTY — who gets invited, the hint, the mailed-link note.
 pub(crate) fn invite_describe_tty(
     data: &topos_types::results::InviteDescribeData,
     yes_argv: &[String],
 ) -> String {
-    let mut s = format!("Would seat as invited members of {}:", data.address);
+    let mut s = format!("Would invite into {}:", data.address);
     for e in &data.seat {
         s.push_str(&format!("\n  {e}"));
     }
-    if !data.channels.is_empty() {
+    if let Some(skill) = &data.skill {
         s.push_str(&format!(
-            "\nPre-placed into channels: #{}",
-            data.channels.join(", #")
+            "\nLeads with the {skill} skill — accepting follows it for them."
         ));
     }
-    s.push_str(&format!(
-        "\nThey join at {} — the server mails them if it can, otherwise paste the address to them.",
-        data.address
-    ));
+    if let Some(channel) = &data.channel {
+        s.push_str(&format!(
+            "\nLeads with #{channel} — accepting joins them to it."
+        ));
+    }
+    s.push_str(
+        "\nEach address gets a mailed single-use invite link (browser, agent paste-block, or \
+         `topos follow <invite-url>`).",
+    );
     s.push_str(&format!(
         "\nNothing has changed yet — apply with:\n  {}",
         argv_line(yes_argv)
@@ -2962,7 +2967,7 @@ mod tests {
             workspace_display_name: Some("Acme Inc".to_owned()),
             plane_base_url: Some("https://api.topos.sh".to_owned()),
             pending: Some(EnrollmentPending {
-                verification_uri_complete: "https://topos.sh/verify?code=WXYZ-1234".to_owned(),
+                verification_uri: "https://topos.sh/verify".to_owned(),
                 user_code: "WXYZ-1234".to_owned(),
                 expires_at: None,
                 interval_secs: Some(5),
@@ -2971,13 +2976,11 @@ mod tests {
             triggers: Vec::new(),
         };
         let text = follow_tty(&data, &[]);
-        // The clickable URL is surfaced, plus the SHORT code to cross-check against the approval page.
-        assert!(
-            text.contains("https://topos.sh/verify?code=WXYZ-1234"),
-            "{text}"
-        );
-        assert!(text.contains("code: WXYZ-1234"), "{text}");
-        assert!(text.contains("confirm it matches the page"), "{text}");
+        // The bare URL and the SHORT code surface on SEPARATE lines — the code never rides a URL.
+        assert!(text.contains("Open: https://topos.sh/verify"), "{text}");
+        assert!(text.contains("Code: WXYZ-1234"), "{text}");
+        assert!(!text.contains("verify?code="), "{text}");
+        assert!(text.contains("confirm it matches"), "{text}");
     }
 
     #[test]

--- a/bins/topos/src/test_support.rs
+++ b/bins/topos/src/test_support.rs
@@ -1633,7 +1633,8 @@ impl FollowHarness {
         ids
     }
 
-    /// Drive `invite <emails>... [--channel <c>]... --yes` and return the FULL applied invitation:
+    /// Drive `invite <emails>... [--channel <c>] --yes` (the first channel, if any, rides as the
+    /// single first-destination hint) and return the FULL applied invitation:
     /// `(address, invited, mailed)` — `mailed` is the server's honest can-deliver flag (false on a
     /// plane with no SMTP relay; the inviter pastes the address by hand).
     ///
@@ -1660,7 +1661,8 @@ impl FollowHarness {
                 ctx,
                 &connectors,
                 emails.iter().map(|e| (*e).to_owned()).collect(),
-                channels.iter().map(|c| (*c).to_owned()).collect(),
+                None,
+                channels.first().map(|c| (*c).to_owned()),
                 None,
                 true,
             )? {
@@ -2139,7 +2141,8 @@ impl FollowHarness {
                 &ctx,
                 &connectors,
                 vec![email.to_owned()],
-                Vec::new(),
+                None,
+                None,
                 workspace,
                 true,
             )

--- a/bins/topos/src/tests/auth.rs
+++ b/bins/topos/src/tests/auth.rs
@@ -170,6 +170,7 @@ impl FakeEnroll {
     }
     fn granted() -> DeviceAuthPoll {
         DeviceAuthPoll::Granted(EnrolledGrant {
+            hint: None,
             credential: "devc_new".into(),
             device_id: "dev_new".into(),
             workspace: EnrolledWorkspace {
@@ -196,6 +197,7 @@ impl EnrollSource for FakeEnroll {
         &self,
         workspace: &str,
         _requested_name: &str,
+        _invite_token: Option<&str>,
     ) -> Result<DeviceAuthStart, ClientError> {
         self.log
             .lock()
@@ -204,7 +206,7 @@ impl EnrollSource for FakeEnroll {
         Ok(DeviceAuthStart {
             device_code: "dc_login".into(),
             user_code: "LOGN-1234".into(),
-            verification_uri_complete: format!("{API}/verify?code=LOGN-1234"),
+            verification_uri: format!("{API}/verify"),
             expires_in_secs: 900,
             interval_secs: 7,
         })
@@ -464,7 +466,7 @@ fn a_follow_owned_wal_refuses_toward_follow() {
             },
             device_code: "dc_follow".to_owned(),
             user_code: "CODE".to_owned(),
-            verification_uri_complete: format!("{API}/verify?code=CODE"),
+            verification_uri: format!("{API}/verify"),
             interval_secs: 5,
             expires_at_millis: i64::MAX,
         },

--- a/bins/topos/src/tests/follow.rs
+++ b/bins/topos/src/tests/follow.rs
@@ -160,6 +160,7 @@ impl FakeEnroll {
     }
     fn granted() -> DeviceAuthPoll {
         DeviceAuthPoll::Granted(EnrolledGrant {
+            hint: None,
             credential: "devc_secret".into(),
             device_id: "dev_1".into(),
             workspace: EnrolledWorkspace {
@@ -186,15 +187,18 @@ impl EnrollSource for FakeEnroll {
         &self,
         workspace: &str,
         requested_name: &str,
+        invite_token: Option<&str>,
     ) -> Result<DeviceAuthStart, ClientError> {
-        self.log
-            .lock()
-            .unwrap()
-            .push(format!("authorize {workspace} as {requested_name}"));
+        self.log.lock().unwrap().push(match invite_token {
+            // The log records the token VERBATIM so the suite can assert exactly what rode the
+            // wire (a fake — nothing is secret here).
+            Some(token) => format!("authorize {workspace} as {requested_name} + invite {token}"),
+            None => format!("authorize {workspace} as {requested_name}"),
+        });
         Ok(DeviceAuthStart {
             device_code: "dc_secret".into(),
             user_code: "WXYZ-1234".into(),
-            verification_uri_complete: format!("{}/verify?code=WXYZ-1234", self.api_base),
+            verification_uri: format!("{}/verify", self.api_base),
             expires_in_secs: 900,
             interval_secs: 5,
         })
@@ -388,10 +392,8 @@ fn begin_writes_the_single_phase_wal_and_discloses_the_pending_url() {
     };
     assert!(!data.enrolled);
     let pending = data.pending.expect("a pending device flow");
-    assert_eq!(
-        pending.verification_uri_complete,
-        format!("{API}/verify?code=WXYZ-1234")
-    );
+    // The BARE approval page — the code rides its own field, never a URL.
+    assert_eq!(pending.verification_uri, format!("{API}/verify"));
     assert_eq!(pending.user_code, "WXYZ-1234");
     assert_eq!(pending.interval_secs, Some(5));
     assert_eq!(data.plane_base_url.as_deref(), Some(API), "re-rooted");
@@ -475,8 +477,8 @@ fn resume_pending_re_emits_the_persisted_url_without_restarting() {
     };
     let pending = data.pending.expect("still pending");
     assert_eq!(
-        pending.verification_uri_complete,
-        format!("{API}/verify?code=WXYZ-1234"),
+        pending.verification_uri,
+        format!("{API}/verify"),
         "the SERVER-built URL is re-emitted verbatim from the WAL"
     );
     let l = log.lock().unwrap();
@@ -568,6 +570,7 @@ fn a_second_workspace_grant_replaces_the_credential_and_adds_a_membership() {
     let second = FakeEnroll {
         polls: Arc::new(Mutex::new(
             vec![DeviceAuthPoll::Granted(EnrolledGrant {
+                hint: None,
                 credential: "devc_two".into(),
                 device_id: "dev_2".into(),
                 workspace: EnrolledWorkspace {
@@ -609,7 +612,7 @@ fn a_login_owned_wal_refuses_toward_auth_login() {
             intent: enroll::EnrollIntentDoc::Login,
             device_code: "dc_login".to_owned(),
             user_code: "CODE".to_owned(),
-            verification_uri_complete: format!("{API}/verify?code=CODE"),
+            verification_uri: format!("{API}/verify"),
             interval_secs: 5,
             expires_at_millis: i64::MAX,
         },
@@ -642,7 +645,7 @@ fn the_recovery_sweep_reaps_an_expired_wal_so_follow_starts_fresh() {
             },
             device_code: "dc_dead".to_owned(),
             user_code: "DEAD".to_owned(),
-            verification_uri_complete: format!("{API}/verify?code=DEAD"),
+            verification_uri: format!("{API}/verify"),
             interval_secs: 5,
             expires_at_millis: 1_000,
         },
@@ -831,5 +834,326 @@ fn an_enrolled_install_keeps_its_prior_bareword_behavior() {
     assert!(
         l.iter().any(|e| e.starts_with("authorize ghost")),
         "the flow ran against the pinned plane: {l:?}"
+    );
+}
+
+// =================================================================================================
+// The tokened invitation URL — `follow <invite-url>`: an unenrolled install starts the device flow
+// CARRYING the token (the browser destination becomes the invitation page + the flow challenge);
+// a granted flow's HINT steers the post-enrollment subscribe; an enrolled install accepts directly
+// over the device lane with no browser at all.
+// =================================================================================================
+
+/// A directory whose catalog carries the hinted skill and whose `accept_invitation` is armed —
+/// the invite-URL suites' universe (the classic [`FakeDirectory`] serves the plain flows).
+#[derive(Clone)]
+struct InviteDirectory {
+    log: CallLog,
+    hint: Option<crate::plane::GrantHint>,
+}
+impl DirectorySource for InviteDirectory {
+    fn me(&self, ws: &str) -> Result<WireMe, ClientError> {
+        FakeDirectory.me(ws)
+    }
+    fn accept_invitation(&self, token: &str) -> Result<crate::plane::InviteAccepted, ClientError> {
+        self.log.lock().unwrap().push(format!("accept {token}"));
+        Ok(crate::plane::InviteAccepted {
+            workspace: EnrolledWorkspace {
+                workspace_id: WS.into(),
+                name: "acme".into(),
+                display_name: "Acme Inc".into(),
+            },
+            hint: self.hint.clone(),
+        })
+    }
+    fn channels_index(&self, ws: &str) -> Result<WireChannelIndex, ClientError> {
+        FakeDirectory.channels_index(ws)
+    }
+    fn skills_index(&self, _ws: &str) -> Result<WireSkillIndex, ClientError> {
+        Ok(WireSkillIndex {
+            skills: vec![topos_types::requests::WireSkillIndexEntry {
+                skill_id: "s_deploy".into(),
+                name: "deploy".into(),
+                kind: "skill".into(),
+                display_name: None,
+                status: "active".into(),
+                version_id: "a".repeat(64),
+                bundle_digest: "b".repeat(64),
+                generation: 1,
+                updated_at: 0,
+                open_proposals: 0,
+            }],
+        })
+    }
+    fn proposals_index(&self, _ws: &str) -> Result<WireProposalIndex, ClientError> {
+        unreachable!()
+    }
+    fn skill_log(&self, _ws: &str, _s: &str) -> Result<WireSkillLog, ClientError> {
+        unreachable!()
+    }
+    fn reach(&self, _ws: &str, _s: &str) -> Result<WireReach, ClientError> {
+        unreachable!()
+    }
+    fn follow_skill(&self, _ws: &str, _s: &str) -> Result<(), ClientError> {
+        self.log.lock().unwrap().push("follow_skill".into());
+        Ok(())
+    }
+    fn unfollow_skill(&self, _ws: &str, _s: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn channel_join(&self, _ws: &str, _c: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn channel_leave(&self, _ws: &str, _c: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn channel_place(&self, _ws: &str, _c: &str, _s: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn channel_unplace(&self, _ws: &str, _c: &str, _s: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn exclude_device(&self, _ws: &str, _s: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn protect_skill(&self, _ws: &str, _s: &str, _l: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn protect_channel(&self, _ws: &str, _c: &str, _l: &str) -> Result<(), ClientError> {
+        unreachable!()
+    }
+    fn ack_notices(&self, _ws: &str, _ids: &[String]) -> Result<(), ClientError> {
+        unreachable!()
+    }
+}
+
+fn run_follow_invite(
+    rig: &Rig,
+    enroll_fake: &FakeEnroll,
+    directory: &InviteDirectory,
+    targets: Vec<String>,
+    opts: ops::FollowOpts,
+) -> Result<ops::FollowOutcome, ClientError> {
+    crate::identity::load_or_create_device_id(&rig.fs, &rig.layout()).unwrap();
+    sidecar::recover(&rig.fs, &rig.layout(), FIXED_MILLIS as i64).unwrap();
+    let inert_p = InertPlane;
+    let inert_f = InertFollow;
+    let ctx = rig.ctx(&inert_p, &inert_f);
+    let enroll_connect = |_b: &str| -> Box<dyn EnrollSource> { Box::new(enroll_fake.clone()) };
+    let dir_connect = |_b: &str| -> Box<dyn DirectorySource> { Box::new(directory.clone()) };
+    let del_connect = |_b: &str| -> Box<dyn ReconcileTransport> { Box::new(EmptyTransport) };
+    let connectors = ops::FollowConnectors {
+        enroll: &enroll_connect,
+        directory: &dir_connect,
+        delivery: &del_connect,
+        web_origin: "https://topos.sh".to_owned(),
+        confirm_bareword: &|_, _| panic!("an invite URL never prompts the bareword guard"),
+    };
+    ops::follow(&ctx, &connectors, targets, opts)
+}
+
+#[test]
+fn an_invite_url_starts_the_flow_carrying_the_token_and_weaves_the_browser_destination() {
+    let rig = Rig::new("inv-url-begin");
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeEnroll::new(log.clone(), vec![DeviceAuthPoll::Pending]);
+    let directory = InviteDirectory {
+        log: log.clone(),
+        hint: None,
+    };
+    let out = run_follow_invite(
+        &rig,
+        &enroll_fake,
+        &directory,
+        vec!["https://topos.sh/invite/tok_abc123".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Data { data, .. } = out else {
+        panic!("an unenrolled invite URL answers the pending wire payload");
+    };
+    let pending = data.pending.expect("a pending device flow");
+    // The browser destination is the INVITATION page (the one-visit weave), carrying the flow's
+    // device-code CHALLENGE — never the code, never the server's bare /verify.
+    let challenge = ops::device_challenge("dc_secret");
+    assert_eq!(
+        pending.verification_uri,
+        format!("https://topos.sh/invite/tok_abc123?device={challenge}")
+    );
+    {
+        let l = log.lock().unwrap();
+        // The card probe hits the BARE origin — the token never rides a card fetch.
+        assert!(l.iter().any(|e| e == "card https://topos.sh"), "{l:?}");
+        // The token rode the authorize start (the flow row records it server-side); the
+        // origin-rooted form names no workspace slug.
+        assert!(
+            l.iter()
+                .any(|e| e.starts_with("authorize  as topos CLI")
+                    && e.ends_with("+ invite tok_abc123")),
+            "{l:?}"
+        );
+    }
+    // The WAL records the weave destination; the multi-shape slug variant parses too.
+    let wal = enroll::read_wal(&rig.fs, &rig.layout()).unwrap().unwrap();
+    assert_eq!(wal.workspace_name, "");
+    assert!(wal.verification_uri.contains("/invite/tok_abc123?device="));
+}
+
+#[test]
+fn a_multi_tenant_invite_url_names_its_workspace_slug() {
+    let rig = Rig::new("inv-url-multi");
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeEnroll::new(log.clone(), vec![DeviceAuthPoll::Pending]);
+    let directory = InviteDirectory {
+        log: log.clone(),
+        hint: None,
+    };
+    run_follow_invite(
+        &rig,
+        &enroll_fake,
+        &directory,
+        vec!["https://topos.sh/acme/invite/tok_xyz".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let l = log.lock().unwrap();
+    assert!(
+        l.iter().any(
+            |e| e.starts_with("authorize acme as topos CLI") && e.ends_with("+ invite tok_xyz")
+        ),
+        "{l:?}"
+    );
+}
+
+#[test]
+fn a_granted_invite_flow_continues_into_the_hinted_skill() {
+    let rig = Rig::new("inv-url-hint");
+    let log: CallLog = Arc::default();
+    let granted_with_hint = DeviceAuthPoll::Granted(EnrolledGrant {
+        hint: Some(crate::plane::GrantHint {
+            kind: "skill".into(),
+            name: "deploy".into(),
+        }),
+        credential: "devc_secret".into(),
+        device_id: "dev_1".into(),
+        workspace: EnrolledWorkspace {
+            workspace_id: WS.into(),
+            name: "acme".into(),
+            display_name: "Acme Inc".into(),
+        },
+    });
+    let enroll_fake = FakeEnroll::new(log.clone(), vec![granted_with_hint]);
+    let directory = InviteDirectory {
+        log: log.clone(),
+        hint: None,
+    };
+    // Call 1: begin (pending WAL). The fake's scripted poll then grants on the resume.
+    let pending_fake = FakeEnroll::new(log.clone(), vec![DeviceAuthPoll::Pending]);
+    run_follow_invite(
+        &rig,
+        &pending_fake,
+        &directory,
+        vec!["https://topos.sh/invite/tok_hint".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    // Call 2: the resume persists the grant and continues INTO THE HINT — the describe targets
+    // the invited-to skill, not the whole workspace.
+    let out = run_follow_invite(&rig, &enroll_fake, &directory, Vec::new(), opts(false)).unwrap();
+    let ops::FollowOutcome::Described { describe, .. } = out else {
+        panic!("a granted resume continues into the two-phase describe, got {out:?}");
+    };
+    assert_eq!(describe.targets.len(), 1);
+    assert_eq!(describe.targets[0].kind, "skill");
+    assert_eq!(describe.targets[0].name, "deploy");
+    assert!(describe.enrolled_now);
+}
+
+#[test]
+fn an_enrolled_install_accepts_directly_and_continues_into_the_hint() {
+    let rig = Rig::new("inv-url-direct2");
+    let log: CallLog = Arc::default();
+    let directory = InviteDirectory {
+        log: log.clone(),
+        hint: Some(crate::plane::GrantHint {
+            kind: "skill".into(),
+            name: "deploy".into(),
+        }),
+    };
+    // Seed the enrolled state directly (instance + credentials + membership), as a granted
+    // flow's persist would have.
+    crate::identity::load_or_create_device_id(&rig.fs, &rig.layout()).unwrap();
+    enroll::write_instance(
+        &rig.fs,
+        &rig.layout(),
+        &enroll::Instance {
+            schema_version: topos_types::PERSISTED_SCHEMA_VERSION,
+            base_url: API.to_owned(),
+        },
+    )
+    .unwrap();
+    enroll::write_credentials(&rig.fs, &rig.layout(), "devc_secret", "dev_1").unwrap();
+
+    let enroll_fake = FakeEnroll::new(log.clone(), vec![DeviceAuthPoll::Pending]);
+    let out = run_follow_invite(
+        &rig,
+        &enroll_fake,
+        &directory,
+        vec!["https://topos.sh/invite/tok_direct".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    // No device flow started — the accept rode the device lane, and the describe targets the hint.
+    let ops::FollowOutcome::Described { describe, .. } = out else {
+        panic!("the direct accept continues into the two-phase describe, got {out:?}");
+    };
+    assert_eq!(describe.targets[0].name, "deploy");
+    {
+        let l = log.lock().unwrap();
+        assert!(l.iter().any(|e| e == "accept tok_direct"), "{l:?}");
+        assert!(
+            !l.iter().any(|e| e.starts_with("authorize")),
+            "no device flow starts on an enrolled install: {l:?}"
+        );
+    }
+    // The membership persisted (the credential now reaches the joined workspace).
+    let user = enroll::read_user(&rig.fs, &rig.layout()).unwrap().unwrap();
+    assert!(user.workspaces.iter().any(|m| m.workspace_id == WS));
+    // No WAL exists — nothing to resume.
+    assert!(enroll::read_wal(&rig.fs, &rig.layout()).unwrap().is_none());
+}
+
+#[test]
+fn an_invite_url_for_a_different_plane_refuses_toward_the_second_install_hatch() {
+    let rig = Rig::new("inv-url-wrong");
+    let log: CallLog = Arc::default();
+    let directory = InviteDirectory {
+        log: log.clone(),
+        hint: None,
+    };
+    crate::identity::load_or_create_device_id(&rig.fs, &rig.layout()).unwrap();
+    enroll::write_instance(
+        &rig.fs,
+        &rig.layout(),
+        &enroll::Instance {
+            schema_version: topos_types::PERSISTED_SCHEMA_VERSION,
+            base_url: "https://api.other.test".to_owned(),
+        },
+    )
+    .unwrap();
+    let enroll_fake = FakeEnroll::new(log.clone(), vec![DeviceAuthPoll::Pending]);
+    let err = run_follow_invite(
+        &rig,
+        &enroll_fake,
+        &directory,
+        vec!["https://topos.sh/invite/tok_wrong".to_owned()],
+        opts(false),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("TOPOS_HOME"), "{msg}");
+    assert!(
+        !log.lock().unwrap().iter().any(|e| e.starts_with("accept")),
+        "nothing was accepted across planes"
     );
 }

--- a/bins/topos/src/tests/subscribe.rs
+++ b/bins/topos/src/tests/subscribe.rs
@@ -462,6 +462,7 @@ impl EnrollSource for FakeAddressEnroll {
         &self,
         workspace: &str,
         _requested_name: &str,
+        _invite_token: Option<&str>,
     ) -> Result<DeviceAuthStart, ClientError> {
         self.log
             .lock()
@@ -470,7 +471,7 @@ impl EnrollSource for FakeAddressEnroll {
         Ok(DeviceAuthStart {
             device_code: "dc_secret".into(),
             user_code: "CODE".into(),
-            verification_uri_complete: format!("{}/verify?code=CODE", self.api_base),
+            verification_uri: format!("{}/verify", self.api_base),
             expires_in_secs: 900,
             interval_secs: 5,
         })
@@ -478,6 +479,7 @@ impl EnrollSource for FakeAddressEnroll {
     fn device_auth_poll(&self, _dc: &str) -> Result<DeviceAuthPoll, ClientError> {
         self.log.lock().unwrap().push("poll".to_owned());
         Ok(DeviceAuthPoll::Granted(EnrolledGrant {
+            hint: None,
             credential: "devc_secret".into(),
             device_id: "dev_1".into(),
             workspace: EnrolledWorkspace {

--- a/bins/topos/src/tests/verbs_b.rs
+++ b/bins/topos/src/tests/verbs_b.rs
@@ -766,7 +766,7 @@ fn invite_bare_reads_address_and_policy_and_changes_nothing() {
     let inert_p = InertPlane;
     let inert_f = InertFollow;
     let ctx = rig.ctx(&inert_p, &inert_f);
-    let out = ops::invite(&ctx, &connectors, Vec::new(), Vec::new(), None, false).unwrap();
+    let out = ops::invite(&ctx, &connectors, Vec::new(), None, None, None, false).unwrap();
     match out {
         ops::InviteOutcome::Read(data) => {
             assert_eq!(data.address, "https://topos.sh/acme");
@@ -804,27 +804,40 @@ fn invite_with_emails_describes_then_applies_and_folds() {
         &ctx,
         &connectors,
         emails.clone(),
-        vec!["eng".into()],
+        None,
+        Some("eng".into()),
         None,
         false,
     )
     .unwrap();
     match out {
-        ops::InviteOutcome::Described { describe, .. } => {
+        ops::InviteOutcome::Described { describe, yes_argv } => {
             assert_eq!(describe.seat, vec!["bob@acme.com".to_owned()]);
-            assert_eq!(describe.channels, vec!["eng".to_owned()]);
+            assert_eq!(describe.channel.as_deref(), Some("eng"));
+            assert!(describe.skill.is_none());
+            // The apply argv re-spells the hint.
+            assert!(yes_argv.iter().any(|a| a == "--channel"));
         }
         _ => panic!("emails without --yes describe"),
     }
     assert!(captured.lock().unwrap().is_none());
 
     // Apply (--yes): the folded wire body reaches the transport.
-    let out = ops::invite(&ctx, &connectors, emails, vec!["eng".into()], None, true).unwrap();
+    let out = ops::invite(
+        &ctx,
+        &connectors,
+        emails,
+        None,
+        Some("eng".into()),
+        None,
+        true,
+    )
+    .unwrap();
     assert!(matches!(out, ops::InviteOutcome::Applied(_)));
     let (ws, body) = captured.lock().unwrap().clone().unwrap();
     assert_eq!(ws, WS);
     assert_eq!(body.emails, vec!["bob@acme.com".to_owned()]);
-    assert_eq!(body.channels, vec!["eng".to_owned()]);
+    assert_eq!(body.channel.as_deref(), Some("eng"));
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/bins/topos/tests/piped_follow.rs
+++ b/bins/topos/tests/piped_follow.rs
@@ -1,0 +1,237 @@
+//! The PIPED enrollment default, proven over the real binary: an agent harness surfaces a
+//! command's output only when it exits, so a piped `topos follow <address>` (no `--json`, no
+//! `--wait`) must NEVER sit in the human blocking wait — it prints the approval instructions,
+//! performs its invocation's one poll, and exits 0 with the WAL pending for the next re-invoke.
+//! `--wait <seconds>` stays the explicit piped opt-in, capped at its deadline.
+//!
+//! The fixture is a real loopback HTTP server (std `TcpListener`, one thread) answering the
+//! constant protocol card, the device-authorize start, and an always-`pending` token poll — the
+//! exact wire the binary dials; the binary itself runs as a child with PIPED stdio (the point of
+//! the test), fenced by a watchdog far under the ~15-minute code TTL the old default waited out.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_topos")
+}
+
+/// A unique, self-created scratch home for one enrollment (`TOPOS_HOME`).
+fn scratch(tag: &str) -> PathBuf {
+    use std::sync::atomic::AtomicU32;
+    static N: AtomicU32 = AtomicU32::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("topos-piped-{tag}-{}-{n}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// The loopback enrollment fixture: serves the constant protocol card at any path, the
+/// device-authorize start, and an always-`pending` token poll. Returns the base URL, a live poll
+/// counter, and a stop flag the test sets on teardown.
+struct Fixture {
+    base: String,
+    polls: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+}
+
+fn spawn_fixture() -> Fixture {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture server");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking listener");
+    let port = listener.local_addr().expect("local addr").port();
+    let base = format!("http://127.0.0.1:{port}");
+    let polls = Arc::new(AtomicUsize::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let (base_for_card, polls_thread, stop_thread) =
+        (base.clone(), Arc::clone(&polls), Arc::clone(&stop));
+    std::thread::spawn(move || {
+        while !stop_thread.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    handle(stream, &base_for_card, &polls_thread);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
+        }
+    });
+    Fixture { base, polls, stop }
+}
+
+/// Answer one enrollment request. Every response carries `Connection: close`, so ureq opens a
+/// fresh connection per request and each accept sees exactly one.
+fn handle(mut stream: TcpStream, base: &str, polls: &AtomicUsize) {
+    // A stream accepted from a non-blocking listener inherits the flag on macOS — force it
+    // blocking so the read waits for the request bytes instead of racing to an empty read.
+    let _ = stream.set_nonblocking(false);
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+    let mut buf = [0u8; 4096];
+    let n = stream.read(&mut buf).unwrap_or(0);
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let line = request.lines().next().unwrap_or("");
+    let body = if line.contains("/v1/device/authorize") {
+        // The device-authorize start: a short poll interval keeps a --wait run brisk.
+        format!(
+            r#"{{"device_code":"dc_secret","user_code":"WXYZ-3N3X","verification_uri":"{base}/verify","expires_in_secs":900,"interval_secs":1}}"#
+        )
+    } else if line.contains("/v1/device/token") {
+        polls.fetch_add(1, Ordering::Relaxed);
+        r#"{"status":"pending"}"#.to_owned()
+    } else {
+        // Any other path is the constant protocol card (the bare-origin card fetch); the base it
+        // re-roots onto is this same server.
+        format!(r#"{{"schema_version":1,"card":"topos-protocol-card","api_base_url":"{base}"}}"#)
+    };
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(resp.as_bytes());
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Run `topos <args>` as a CHILD with PIPED stdio (the point: stdout is not a TTY), under a
+/// watchdog far below the code's ~15-minute TTL. Returns the captured output, or panics if the
+/// child overran the watchdog (the old blocking default would have).
+fn run_piped(home: &Path, base: &str, args: &[&str], watchdog: Duration) -> Output {
+    let mut child = Command::new(bin())
+        .env("TOPOS_HOME", home)
+        .env("CLAUDE_CONFIG_DIR", home.join(".claude-isolated"))
+        .env("TOPOS_PLANE_URL", base)
+        .env("TOPOS_NO_BROWSER", "1")
+        .env_remove("SSH_CONNECTION")
+        .env_remove("SSH_TTY")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn topos");
+    let started = Instant::now();
+    loop {
+        if let Some(_status) = child.try_wait().expect("poll child") {
+            return child.wait_with_output().expect("collect output");
+        }
+        if started.elapsed() > watchdog {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "`topos {}` did not exit within {watchdog:?} — the piped default is blocking",
+                args.join(" ")
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn a_piped_follow_prints_the_instructions_and_exits_without_the_blocking_wait() {
+    let fx = spawn_fixture();
+    let home = scratch("begin");
+
+    // Call 1 — begin: card → authorize → WAL. Piped, no --wait → returns promptly (well under the
+    // 30s watchdog; the old default would have blocked the full ~15-minute code TTL).
+    let out = run_piped(
+        &home,
+        &fx.base,
+        &["follow", &fx.base],
+        Duration::from_secs(30),
+    );
+    assert!(
+        out.status.success(),
+        "begin exits 0: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // The approval instructions print — the two-line shape (URL, then the code). A piped,
+    // non-`--json` run returns the pending state without entering the blocking wait, so the
+    // instructions ride the ordinary TTY render on STDOUT (the blocking wait's stderr disclosure
+    // only fires when it actually blocks).
+    let printed = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        printed.contains("Open:"),
+        "the approval URL prints: {printed}"
+    );
+    assert!(printed.contains("Code:"), "the code prints: {printed}");
+    assert!(
+        printed.contains("WXYZ-3N3X"),
+        "the fixture's code is shown: {printed}"
+    );
+    // The pending WAL is persisted for the re-invoke.
+    assert!(
+        home.join("identity/enrollment.json").exists(),
+        "the enrollment WAL is on disk"
+    );
+    // Begin performs the authorize, not a token poll — the poll is the resume's job.
+    assert_eq!(fx.polls.load(Ordering::Relaxed), 0, "begin does not poll");
+
+    // Re-invoke — resume: a SINGLE poll, still pending, exits promptly again (never a blocking loop).
+    let out = run_piped(&home, &fx.base, &["follow"], Duration::from_secs(30));
+    assert!(
+        out.status.success(),
+        "resume exits 0: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        fx.polls.load(Ordering::Relaxed),
+        1,
+        "the resume polls exactly once"
+    );
+    assert!(
+        home.join("identity/enrollment.json").exists(),
+        "still pending — the WAL survives"
+    );
+}
+
+#[test]
+fn an_explicit_wait_cap_blocks_piped_then_returns_at_the_deadline() {
+    let fx = spawn_fixture();
+    let home = scratch("wait");
+
+    // `--wait 1` is the explicit piped opt-in: it blocks and re-polls, but the 1-second cap ends it
+    // far under the watchdog (never the ~15-minute code TTL). The always-pending fixture means it
+    // polls at least once past the deadline before returning.
+    let started = Instant::now();
+    let out = run_piped(
+        &home,
+        &fx.base,
+        &["follow", &fx.base, "--wait", "1"],
+        Duration::from_secs(30),
+    );
+    let elapsed = started.elapsed();
+    assert!(
+        out.status.success(),
+        "the capped wait exits 0: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // It actually blocked (past the 1s cap) rather than returning instantly like the no-wait
+    // default, and it did poll while blocking.
+    assert!(
+        elapsed >= Duration::from_millis(900),
+        "the --wait cap blocked for its ~1s: {elapsed:?}"
+    );
+    assert!(
+        fx.polls.load(Ordering::Relaxed) >= 1,
+        "the blocking wait re-polled at least once"
+    );
+    // Still pending — the WAL survives for the next re-invoke.
+    assert!(home.join("identity/enrollment.json").exists());
+}

--- a/contracts/fixtures/json/follow.pending.json
+++ b/contracts/fixtures/json/follow.pending.json
@@ -8,7 +8,7 @@
       "expires_at": "2026-06-25T00:15:00Z",
       "interval_secs": 5,
       "user_code": "WXYZ-1234",
-      "verification_uri_complete": "https://topos.sh/verify?code=WXYZ-1234"
+      "verification_uri": "https://topos.sh/verify"
     },
     "plane_base_url": "https://topos.sh/api",
     "workspace_id": "acme"

--- a/contracts/openapi/openapi.json
+++ b/contracts/openapi/openapi.json
@@ -27,7 +27,7 @@
         },
         "responses": {
           "200": {
-            "description": "The device-authorization grant: the secret device_code to poll with (promoted to the device's ONE bearer credential on approval), the human-facing user_code, and the approval URLs.",
+            "description": "The device-authorization grant: the secret device_code to poll with (promoted to the device's ONE bearer credential on approval), the human-facing user_code, and the BARE approval URL (the code never rides a URL; the approval page's lookup is a POST). An invite_token in the body is recorded on the flow unvalidated — never a token oracle.",
             "content": {
               "application/json": {
                 "schema": {
@@ -87,7 +87,7 @@
         },
         "responses": {
           "200": {
-            "description": "The poll status; `granted` carries the ONE bearer credential (the promoted device code), the device id, and the joined workspace.",
+            "description": "The poll status; `granted` carries the ONE bearer credential (the promoted device code), the device id, the joined workspace, and — when the flow carried an invitation naming one — the first-destination hint.",
             "content": {
               "application/json": {
                 "schema": {
@@ -118,6 +118,87 @@
           },
           "500": {
             "description": "Internal fault.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/invitations/accept": {
+      "post": {
+        "tags": [
+          "enrollment"
+        ],
+        "operationId": "invite_accept",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "`Bearer <device credential>` — PERSON-scoped: the caller has no seat in the invitation's workspace yet.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteAcceptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK carries the InviteAcceptData (the joined workspace + the optional first-destination hint); the ceremony fences answer 200 DENIED INVITE_OTHER_ACCOUNT / EMAIL_UNVERIFIED (no address is ever echoed).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Missing/blank credential, a revoked device, or a dead token — invalid, expired, revoked, or already consumed (indistinguishable).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited (Retry-After header).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Integrity / internal store fault.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1385,7 +1466,7 @@
         },
         "responses": {
           "200": {
-            "description": "The invitation receipt — OK carries the InvitationData (address + invited + the honest mailed flag); a policy refusal is a 200 DENIED OWNER_ROLE_REQUIRED, an unknown channel a 200 DENIED UNKNOWN_CHANNEL.",
+            "description": "The invitation receipt — OK carries the InvitationData (address + invited + the honest mailed flag; the tokened invite link travels ONLY in the mail); a policy refusal is a 200 DENIED OWNER_ROLE_REQUIRED, an unresolvable hint a 200 DENIED UNKNOWN_SKILL / UNKNOWN_CHANNEL, an unarmed mail transport a 200 DENIED MAIL_NOT_CONFIGURED.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2493,6 +2574,24 @@
           }
         }
       },
+      "DeviceAuthHint": {
+        "type": "object",
+        "description": "The first-destination HINT an accepted invitation named — decorated onto a `granted` poll (and\nthe direct-accept answer) so the enrolled client's post-accept subscribe can target it. `kind`\nis the bundle catalog's own tag (`skill` today) or the literal `channel` — displayed and routed\non, never trusted as authority.",
+        "required": [
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "What the hinted thing is: the catalog's `kind` tag, or `channel`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The hinted bundle's or channel's name in the joined workspace."
+          }
+        }
+      },
       "DeviceAuthPollRequest": {
         "type": "object",
         "description": "`POST /v1/device/token` body — poll a device-authorization flow for its outcome.",
@@ -2526,6 +2625,17 @@
               "null"
             ],
             "description": "The registered device's id — present ONLY when `status` is `granted`."
+          },
+          "hint": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DeviceAuthHint",
+                "description": "The invitation's first-destination hint — present only on a `granted` poll whose flow\ncarried an invite token naming one."
+              }
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/DeviceAuthPollStatus",
@@ -2562,6 +2672,13 @@
           "workspace"
         ],
         "properties": {
+          "invite_token": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The invitation-link token a `follow <invite-url>` enrollment carries. Recorded on the flow\n(as its hash) UNVALIDATED — this unauthenticated start is never a token oracle; the approval\nceremony resolves it and weaves the invitation accept into its own fence."
+          },
           "requested_name": {
             "type": "string",
             "description": "A human-readable device name shown on the approval page (a confused-deputy guard, not\nauthority) and kept as the device's display name once approved."
@@ -2579,7 +2696,6 @@
           "device_code",
           "user_code",
           "verification_uri",
-          "verification_uri_complete",
           "expires_in_secs",
           "interval_secs"
         ],
@@ -2606,11 +2722,7 @@
           },
           "verification_uri": {
             "type": "string",
-            "description": "The approval URL a signed-in human visits."
-          },
-          "verification_uri_complete": {
-            "type": "string",
-            "description": "The approval URL with the user code already embedded — the one link to open; a client uses\nit VERBATIM when present."
+            "description": "The approval URL a signed-in human visits. The code NEVER rides a URL: the client prints\nthis bare address and the short code on separate lines, and the page's lookup is a POST."
           }
         }
       },
@@ -2662,7 +2774,7 @@
       },
       "InvitationData": {
         "type": "object",
-        "description": "`POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the workspace\nADDRESS (the whole invitation besides the roster rows themselves).",
+        "description": "`POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the\nworkspace ADDRESS. Deliberately NOT the tokened link: the link travels only in the invitation\nmail, so the inviter's receipt can never stand in for the invitee's mailbox.",
         "required": [
           "address",
           "invited",
@@ -2688,17 +2800,17 @@
       },
       "InvitationRequest": {
         "type": "object",
-        "description": "`POST /v1/workspaces/{ws}/invitations` body — invitation as a ROSTER WRITE: seat each email as an\ninvited member (recording who invited whom) and optionally pre-place the person into channels.\nThere is no invite link and no role field — every CLI invitee starts as a member (roles are raised\nlater, on the web), and joining is `follow <address>` plus proof of the invited email. Member-level\nunless the workspace's invite policy restricts inviting to owners.",
+        "description": "`POST /v1/workspaces/{ws}/invitations` body — invitation as an INVITATION-ROW write: each email\nbecomes a pending 7-day claim redeemable through the single-use link the server MAILS (the token\nnever appears in this exchange — the mailbox is its one channel). At most ONE optional\nfirst-destination hint (a skill or a channel of this workspace) rides the invitation and is\ndelivered by the accept. No role field — every CLI invitee starts as a member (roles are raised\nlater, on the web). Member-level unless the workspace's invite policy restricts inviting to\nowners.",
         "required": [
           "emails"
         ],
         "properties": {
-          "channels": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Channel names to pre-place each invitee into (re-inviting restores placements; the structural\n`everyone` needs no placement and is accepted as a no-op)."
+          "channel": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The first-destination CHANNEL hint (a channel name in this workspace). At most one of\n`skill`/`channel` may be set."
           },
           "emails": {
             "type": "array",
@@ -2706,6 +2818,50 @@
               "type": "string"
             },
             "description": "The emails to seat as invited members (folded to the canonical lowercase form server-side)."
+          },
+          "skill": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The first-destination SKILL hint (a bundle name in this workspace). At most one of\n`skill`/`channel` may be set."
+          }
+        }
+      },
+      "InviteAcceptData": {
+        "type": "object",
+        "description": "`POST /v1/invitations/accept` success `data` — the joined workspace + the optional\nfirst-destination hint the client's post-accept subscribe targets. Nothing lands on any device\nfrom this accept: bytes still move only through the device-side two-phase describe/consent.",
+        "required": [
+          "workspace"
+        ],
+        "properties": {
+          "hint": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DeviceAuthHint",
+                "description": "The invitation's first-destination hint, when it named one."
+              }
+            ]
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/DeviceAuthWorkspace",
+            "description": "The workspace the accept seated the person in."
+          }
+        }
+      },
+      "InviteAcceptRequest": {
+        "type": "object",
+        "description": "`POST /v1/invitations/accept` body — the ALREADY-ENROLLED device consuming an invite URL: the\nbearer credential authenticates the person (seat-LESS by construction — the caller has no seat\nin the invitation's workspace yet), and the token names the invitation. The same ceremony\nfences as the browser accept apply; an invalid/expired/consumed token answers the uniform 404.",
+        "required": [
+          "token"
+        ],
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "The invitation-link token (the mailed single-use secret)."
           }
         }
       },

--- a/contracts/schemas/device-auth-poll-response.schema.json
+++ b/contracts/schemas/device-auth-poll-response.schema.json
@@ -18,6 +18,17 @@
         "null"
       ]
     },
+    "hint": {
+      "description": "The invitation's first-destination hint — present only on a `granted` poll whose flow\ncarried an invite token naming one.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DeviceAuthHint"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "status": {
       "description": "The poll status.",
       "$ref": "#/$defs/DeviceAuthPollStatus"
@@ -38,6 +49,24 @@
     "status"
   ],
   "$defs": {
+    "DeviceAuthHint": {
+      "description": "The first-destination HINT an accepted invitation named — decorated onto a `granted` poll (and\nthe direct-accept answer) so the enrolled client's post-accept subscribe can target it. `kind`\nis the bundle catalog's own tag (`skill` today) or the literal `channel` — displayed and routed\non, never trusted as authority.",
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "What the hinted thing is: the catalog's `kind` tag, or `channel`.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The hinted bundle's or channel's name in the joined workspace.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ]
+    },
     "DeviceAuthPollStatus": {
       "description": "A device-authorization poll status (snake_case). `granted` carries the credential + the joined\nworkspace; every other status carries only itself.",
       "oneOf": [

--- a/contracts/schemas/device-auth-start-request.schema.json
+++ b/contracts/schemas/device-auth-start-request.schema.json
@@ -4,6 +4,13 @@
   "description": "`POST /v1/device/authorize` body — begin a device-authorization flow toward a workspace named by\nits address slug. Whether the name exists is never disclosed on this route: an unknown name runs\nthe same flow to the same uniform denial.",
   "type": "object",
   "properties": {
+    "invite_token": {
+      "description": "The invitation-link token a `follow <invite-url>` enrollment carries. Recorded on the flow\n(as its hash) UNVALIDATED — this unauthenticated start is never a token oracle; the approval\nceremony resolves it and weaves the invitation accept into its own fence.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "requested_name": {
       "description": "A human-readable device name shown on the approval page (a confused-deputy guard, not\nauthority) and kept as the device's display name once approved.",
       "type": "string"

--- a/contracts/schemas/device-auth-start-response.schema.json
+++ b/contracts/schemas/device-auth-start-response.schema.json
@@ -25,11 +25,7 @@
       "type": "string"
     },
     "verification_uri": {
-      "description": "The approval URL a signed-in human visits.",
-      "type": "string"
-    },
-    "verification_uri_complete": {
-      "description": "The approval URL with the user code already embedded — the one link to open; a client uses\nit VERBATIM when present.",
+      "description": "The approval URL a signed-in human visits. The code NEVER rides a URL: the client prints\nthis bare address and the short code on separate lines, and the page's lookup is a POST.",
       "type": "string"
     }
   },
@@ -37,7 +33,6 @@
     "device_code",
     "user_code",
     "verification_uri",
-    "verification_uri_complete",
     "expires_in_secs",
     "interval_secs"
   ]

--- a/contracts/schemas/follow-data.schema.json
+++ b/contracts/schemas/follow-data.schema.json
@@ -126,7 +126,7 @@
       ]
     },
     "EnrollmentPending": {
-      "description": "A pending device-authorization a `follow` surfaced — the human visits `verification_uri_complete` (which\nembeds the `user_code`), then the client re-polls. **INFERRED.**",
+      "description": "A pending device-authorization a `follow` surfaced — the human opens `verification_uri` and\nenters `user_code` there (or the invitation page the URI names weaves them through); the client\nre-polls. The code never rides a URL. **INFERRED.**",
       "type": "object",
       "properties": {
         "expires_at": {
@@ -146,16 +146,16 @@
           "minimum": 0
         },
         "user_code": {
-          "description": "The short human-facing code embedded in `verification_uri_complete` (a cross-check against the\napproval page — the human clicks the URL; the code is never typed as a secret).",
+          "description": "The short human-facing code the approval page asks for and displays back (the glance-check\nagainst this terminal — never typed as a secret, never part of a URL).",
           "type": "string"
         },
-        "verification_uri_complete": {
-          "description": "The verification URL with the `user_code` embedded — the human opens it to approve the session.",
+        "verification_uri": {
+          "description": "The page the human opens to approve the session — the bare approval address (or, for an\ninvitation enrollment, the invitation page that weaves accept + approval). Never embeds the\ncode.",
           "type": "string"
         }
       },
       "required": [
-        "verification_uri_complete",
+        "verification_uri",
         "user_code"
       ]
     },

--- a/contracts/schemas/invitation-data.schema.json
+++ b/contracts/schemas/invitation-data.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "InvitationData",
-  "description": "`POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the workspace\nADDRESS (the whole invitation besides the roster rows themselves).",
+  "description": "`POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the\nworkspace ADDRESS. Deliberately NOT the tokened link: the link travels only in the invitation\nmail, so the inviter's receipt can never stand in for the invitee's mailbox.",
   "type": "object",
   "properties": {
     "address": {

--- a/contracts/schemas/invite-accept-data.schema.json
+++ b/contracts/schemas/invite-accept-data.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "InviteAcceptData",
+  "description": "`POST /v1/invitations/accept` success `data` — the joined workspace + the optional\nfirst-destination hint the client's post-accept subscribe targets. Nothing lands on any device\nfrom this accept: bytes still move only through the device-side two-phase describe/consent.",
+  "type": "object",
+  "properties": {
+    "hint": {
+      "description": "The invitation's first-destination hint, when it named one.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DeviceAuthHint"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "workspace": {
+      "description": "The workspace the accept seated the person in.",
+      "$ref": "#/$defs/DeviceAuthWorkspace"
+    }
+  },
+  "required": [
+    "workspace"
+  ],
+  "$defs": {
+    "DeviceAuthHint": {
+      "description": "The first-destination HINT an accepted invitation named — decorated onto a `granted` poll (and\nthe direct-accept answer) so the enrolled client's post-accept subscribe can target it. `kind`\nis the bundle catalog's own tag (`skill` today) or the literal `channel` — displayed and routed\non, never trusted as authority.",
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "What the hinted thing is: the catalog's `kind` tag, or `channel`.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The hinted bundle's or channel's name in the joined workspace.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ]
+    },
+    "DeviceAuthWorkspace": {
+      "description": "The workspace context a `granted` poll carries — everything the CLI needs to record what it\nenrolled into (the id it scopes requests by, the address slug it joined at, and a display name).",
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "description": "The workspace's display name.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The workspace's ADDRESS slug (what the human typed at `follow`).",
+          "type": "string"
+        },
+        "workspace_id": {
+          "description": "The workspace id (the `{ws}` path segment of every subsequent request).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id",
+        "name",
+        "display_name"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/invite-accept-request.schema.json
+++ b/contracts/schemas/invite-accept-request.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "InviteAcceptRequest",
+  "description": "`POST /v1/invitations/accept` body — the ALREADY-ENROLLED device consuming an invite URL: the\nbearer credential authenticates the person (seat-LESS by construction — the caller has no seat\nin the invitation's workspace yet), and the token names the invitation. The same ceremony\nfences as the browser accept apply; an invalid/expired/consumed token answers the uniform 404.",
+  "type": "object",
+  "properties": {
+    "token": {
+      "description": "The invitation-link token (the mailed single-use secret).",
+      "type": "string"
+    }
+  },
+  "required": [
+    "token"
+  ]
+}

--- a/contracts/schemas/invite-describe-data.schema.json
+++ b/contracts/schemas/invite-describe-data.schema.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "InviteDescribeData",
-  "description": "`invite <email>...` (bare, no `--yes`) — the describe: who gets seated, the channel pre-placements,\nand the mail-or-paste note. **INFERRED.**",
+  "description": "`invite <email>...` (bare, no `--yes`) — the describe: who gets invited, the optional\nfirst-destination hint, and the mailed-link note. **INFERRED.**",
   "type": "object",
   "properties": {
     "address": {
       "type": "string"
     },
-    "channels": {
-      "description": "The channels each invitee would be pre-placed into.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+    "channel": {
+      "description": "The first-destination CHANNEL hint the invitation would carry.",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "invite_policy": {
       "type": "string"
@@ -23,6 +23,13 @@
       "items": {
         "type": "string"
       }
+    },
+    "skill": {
+      "description": "The first-destination SKILL hint the invitation would carry (at most one of skill/channel).",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [

--- a/crates/topos-types/src/requests.rs
+++ b/crates/topos-types/src/requests.rs
@@ -548,6 +548,11 @@ pub struct DeviceAuthStartRequest {
     /// EMPTY string names "the workspace the origin itself addresses" (single-tenant installs, where
     /// the origin IS its one workspace); a non-empty value is the address slug as today.
     pub workspace: String,
+    /// The invitation-link token a `follow <invite-url>` enrollment carries. Recorded on the flow
+    /// (as its hash) UNVALIDATED — this unauthenticated start is never a token oracle; the approval
+    /// ceremony resolves it and weaves the invitation accept into its own fence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invite_token: Option<String>,
 }
 
 /// `POST /v1/device/authorize` response — the device-authorization grant (RFC-8628-shaped names).
@@ -563,11 +568,9 @@ pub struct DeviceAuthStartResponse {
     /// The short human-facing code the approval page displays (a cross-check, never typed as a
     /// secret).
     pub user_code: String,
-    /// The approval URL a signed-in human visits.
+    /// The approval URL a signed-in human visits. The code NEVER rides a URL: the client prints
+    /// this bare address and the short code on separate lines, and the page's lookup is a POST.
     pub verification_uri: String,
-    /// The approval URL with the user code already embedded — the one link to open; a client uses
-    /// it VERBATIM when present.
-    pub verification_uri_complete: String,
     /// The flow lifetime, in seconds.
     pub expires_in_secs: u64,
     /// The minimum poll interval, in seconds.
@@ -602,6 +605,22 @@ pub enum DeviceAuthPollStatus {
     Expired,
     /// Approved — `credential`, `device_id`, and `workspace` are present.
     Granted,
+}
+
+/// The first-destination HINT an accepted invitation named — decorated onto a `granted` poll (and
+/// the direct-accept answer) so the enrolled client's post-accept subscribe can target it. `kind`
+/// is the bundle catalog's own tag (`skill` today) or the literal `channel` — displayed and routed
+/// on, never trusted as authority.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "contract-derives",
+    derive(schemars::JsonSchema, utoipa::ToSchema)
+)]
+pub struct DeviceAuthHint {
+    /// What the hinted thing is: the catalog's `kind` tag, or `channel`.
+    pub kind: String,
+    /// The hinted bundle's or channel's name in the joined workspace.
+    pub name: String,
 }
 
 /// The workspace context a `granted` poll carries — everything the CLI needs to record what it
@@ -641,6 +660,10 @@ pub struct DeviceAuthPollResponse {
     /// The joined workspace — present ONLY when `status` is `granted`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace: Option<DeviceAuthWorkspace>,
+    /// The invitation's first-destination hint — present only on a `granted` poll whose flow
+    /// carried an invite token naming one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hint: Option<DeviceAuthHint>,
 }
 
 // =================================================================================================
@@ -649,11 +672,13 @@ pub struct DeviceAuthPollResponse {
 // role matrix — never a body field); the op is derived from the route + body. `op_id` is a UUIDv4.
 // =================================================================================================
 
-/// `POST /v1/workspaces/{ws}/invitations` body — invitation as a ROSTER WRITE: seat each email as an
-/// invited member (recording who invited whom) and optionally pre-place the person into channels.
-/// There is no invite link and no role field — every CLI invitee starts as a member (roles are raised
-/// later, on the web), and joining is `follow <address>` plus proof of the invited email. Member-level
-/// unless the workspace's invite policy restricts inviting to owners.
+/// `POST /v1/workspaces/{ws}/invitations` body — invitation as an INVITATION-ROW write: each email
+/// becomes a pending 7-day claim redeemable through the single-use link the server MAILS (the token
+/// never appears in this exchange — the mailbox is its one channel). At most ONE optional
+/// first-destination hint (a skill or a channel of this workspace) rides the invitation and is
+/// delivered by the accept. No role field — every CLI invitee starts as a member (roles are raised
+/// later, on the web). Member-level unless the workspace's invite policy restricts inviting to
+/// owners.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "contract-derives",
@@ -662,14 +687,19 @@ pub struct DeviceAuthPollResponse {
 pub struct InvitationRequest {
     /// The emails to seat as invited members (folded to the canonical lowercase form server-side).
     pub emails: Vec<String>,
-    /// Channel names to pre-place each invitee into (re-inviting restores placements; the structural
-    /// `everyone` needs no placement and is accepted as a no-op).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub channels: Vec<String>,
+    /// The first-destination SKILL hint (a bundle name in this workspace). At most one of
+    /// `skill`/`channel` may be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill: Option<String>,
+    /// The first-destination CHANNEL hint (a channel name in this workspace). At most one of
+    /// `skill`/`channel` may be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
 }
 
-/// `POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the workspace
-/// ADDRESS (the whole invitation besides the roster rows themselves).
+/// `POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the
+/// workspace ADDRESS. Deliberately NOT the tokened link: the link travels only in the invitation
+/// mail, so the inviter's receipt can never stand in for the invitee's mailbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "contract-derives",
@@ -682,6 +712,36 @@ pub struct InvitationData {
     pub invited: Vec<String>,
     /// Whether invitation mail was sent server-side (`true` only when the server can send mail).
     pub mailed: bool,
+}
+
+/// `POST /v1/invitations/accept` body — the ALREADY-ENROLLED device consuming an invite URL: the
+/// bearer credential authenticates the person (seat-LESS by construction — the caller has no seat
+/// in the invitation's workspace yet), and the token names the invitation. The same ceremony
+/// fences as the browser accept apply; an invalid/expired/consumed token answers the uniform 404.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "contract-derives",
+    derive(schemars::JsonSchema, utoipa::ToSchema)
+)]
+pub struct InviteAcceptRequest {
+    /// The invitation-link token (the mailed single-use secret).
+    pub token: String,
+}
+
+/// `POST /v1/invitations/accept` success `data` — the joined workspace + the optional
+/// first-destination hint the client's post-accept subscribe targets. Nothing lands on any device
+/// from this accept: bytes still move only through the device-side two-phase describe/consent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "contract-derives",
+    derive(schemars::JsonSchema, utoipa::ToSchema)
+)]
+pub struct InviteAcceptData {
+    /// The workspace the accept seated the person in.
+    pub workspace: DeviceAuthWorkspace,
+    /// The invitation's first-destination hint, when it named one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hint: Option<DeviceAuthHint>,
 }
 
 /// `DELETE /v1/workspaces/{ws}/devices` body — revoke a registered device key (owner, or the device's own
@@ -1088,6 +1148,7 @@ mod tests {
             credential: None,
             device_id: None,
             workspace: None,
+            hint: None,
         };
         let v = serde_json::to_value(&pending).unwrap();
         assert_eq!(v["status"], "pending");
@@ -1103,6 +1164,10 @@ mod tests {
                 name: "acme".to_owned(),
                 display_name: "Acme".to_owned(),
             }),
+            hint: Some(DeviceAuthHint {
+                kind: "skill".to_owned(),
+                name: "deploy".to_owned(),
+            }),
         };
         let v = serde_json::to_value(&granted).unwrap();
         assert_eq!(v["status"], "granted");
@@ -1113,8 +1178,7 @@ mod tests {
         let start = DeviceAuthStartResponse {
             device_code: "dc_secret".to_owned(),
             user_code: "AAAA-BBBB".to_owned(),
-            verification_uri: "https://topos.example/devices".to_owned(),
-            verification_uri_complete: "https://topos.example/verify?code=AAAA-BBBB".to_owned(),
+            verification_uri: "https://topos.example/verify".to_owned(),
             expires_in_secs: 900,
             interval_secs: 5,
         };
@@ -1252,22 +1316,28 @@ mod tests {
 
     #[test]
     fn invitation_bodies_round_trip() {
-        // The invitation is a roster write: emails + optional channel pre-placements, no role
-        // field (every CLI invitee starts as a member) and no link (the address is the answer).
+        // The invitation body: emails + at most one first-destination hint, no role field (every
+        // CLI invitee starts as a member) and no token anywhere (the link travels only in mail).
         let req = InvitationRequest {
             emails: vec!["alice@acme.com".to_owned()],
-            channels: vec!["ops".to_owned()],
+            skill: None,
+            channel: Some("ops".to_owned()),
         };
         let v = serde_json::to_value(&req).unwrap();
         assert_eq!(v["emails"][0], "alice@acme.com");
-        assert_eq!(v["channels"][0], "ops");
+        assert_eq!(v["channel"], "ops");
+        assert!(v.get("skill").is_none(), "an unset hint omits");
         // The acting device rides the Authorization header — never a body field.
         assert!(v.get("device_key_id").is_none() && v.get("credential").is_none());
         assert!(v.get("role").is_none(), "invitations mint members only");
-        // Channels omit when empty (skip_serializing_if) and default on the way in.
+        assert!(
+            v.get("token").is_none(),
+            "no token ever rides this exchange"
+        );
+        // The hints omit when unset (skip_serializing_if) and default on the way in.
         let bare: InvitationRequest =
             serde_json::from_value(serde_json::json!({ "emails": ["bob@acme.com"] })).unwrap();
-        assert!(bare.channels.is_empty());
+        assert!(bare.skill.is_none() && bare.channel.is_none());
         let data = InvitationData {
             address: "https://topos.example/acme".to_owned(),
             invited: vec!["alice@acme.com".to_owned()],

--- a/crates/topos-types/src/results.rs
+++ b/crates/topos-types/src/results.rs
@@ -578,15 +578,18 @@ pub struct BreadthTriggerReport {
     pub note: Option<String>,
 }
 
-/// A pending device-authorization a `follow` surfaced — the human visits `verification_uri_complete` (which
-/// embeds the `user_code`), then the client re-polls. **INFERRED.**
+/// A pending device-authorization a `follow` surfaced — the human opens `verification_uri` and
+/// enters `user_code` there (or the invitation page the URI names weaves them through); the client
+/// re-polls. The code never rides a URL. **INFERRED.**
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "contract-derives", derive(schemars::JsonSchema))]
 pub struct EnrollmentPending {
-    /// The verification URL with the `user_code` embedded — the human opens it to approve the session.
-    pub verification_uri_complete: String,
-    /// The short human-facing code embedded in `verification_uri_complete` (a cross-check against the
-    /// approval page — the human clicks the URL; the code is never typed as a secret).
+    /// The page the human opens to approve the session — the bare approval address (or, for an
+    /// invitation enrollment, the invitation page that weaves accept + approval). Never embeds the
+    /// code.
+    pub verification_uri: String,
+    /// The short human-facing code the approval page asks for and displays back (the glance-check
+    /// against this terminal — never typed as a secret, never part of a URL).
     pub user_code: String,
     /// The session expiry as an RFC-3339 string, if it expires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -993,8 +996,8 @@ pub struct InviteReadData {
     pub changed: bool,
 }
 
-/// `invite <email>...` (bare, no `--yes`) — the describe: who gets seated, the channel pre-placements,
-/// and the mail-or-paste note. **INFERRED.**
+/// `invite <email>...` (bare, no `--yes`) — the describe: who gets invited, the optional
+/// first-destination hint, and the mailed-link note. **INFERRED.**
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "contract-derives", derive(schemars::JsonSchema))]
 pub struct InviteDescribeData {
@@ -1002,9 +1005,12 @@ pub struct InviteDescribeData {
     pub invite_policy: String,
     /// The emails that would be seated (canonical form).
     pub seat: Vec<String>,
-    /// The channels each invitee would be pre-placed into.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub channels: Vec<String>,
+    /// The first-destination SKILL hint the invitation would carry (at most one of skill/channel).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill: Option<String>,
+    /// The first-destination CHANNEL hint the invitation would carry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
 }
 
 /// `update --reset <skill>` — discard a local draft back to the followed `current` (or an imported

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -254,12 +254,13 @@ Set a skill's (or channel's) protection level. Bare tightens to `reviewed` (skil
 topos invite [OPTIONS] [EMAIL]...
 ```
 
-Seat emails as invited members of the workspace (a roster write). Every CLI invitee starts as a member; joining is `follow <address>` plus proof of the invited email. Requires prior enrollment. A bare `invite` (no emails) reads the workspace address + policy (lands later)
+Invite emails into the workspace. Each address gets a mailed single-use invite link (accept in the browser, hand the mail's paste-block to an agent, or `topos follow <invite-url>`); every CLI invitee starts as a member. Requires prior enrollment. A bare `invite` (no emails) reads the workspace address + policy
 
 | Argument / flag | Value | Default | Description |
 |---|---|---|---|
-| `[EMAIL]...` |  |  | The emails to invite (folded to canonical form; seeded onto the roster as `invited`) |
-| `--channel` | `<NAME>` |  | Pre-place each invitee into this channel (repeatable) |
+| `[EMAIL]...` |  |  | The emails to invite (folded to canonical form; each becomes a pending 7-day claim) |
+| `--skill` | `<NAME>` |  | Lead the invitation with this SKILL — accepting follows it for the invitee (at most one of --skill/--channel) |
+| `--channel` | `<NAME>` |  | Lead the invitation with this CHANNEL — accepting joins the invitee to it |
 | `--yes` |  |  | Apply without the describe step. Parses today; the two-phase describe lands later |
 
 ## Maintenance

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,7 +45,7 @@ Follow a workspace, channel, or skill — enroll if needed, then subscribe two-p
 | `--yes` |  |  | Apply the described subscription (the one-shot consent). Bare = describe only |
 | `--prefix-dirname` |  |  | Install a dirname-colliding skill under `<workspace>.<name>` instead of declining it |
 | `--manual` |  |  | Adopt followed skills in confirm-each mode (a one-tap accept per new version) instead of auto |
-| `--wait` | `<SECONDS>` |  | Block until the browser approval settles, finishing enrollment in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. Put `--wait` AFTER any positional |
+| `--wait` | `<SECONDS>` |  | Block until the browser approval settles, finishing enrollment in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. Put `--wait` AFTER any positional. A TTY blocks by default; a PIPED run without `--wait` prints the approval URL and returns immediately — re-invoke `follow` to poll, or pass `--wait` to block |
 
 
 ### `topos unfollow`
@@ -299,7 +299,7 @@ Re-enroll this machine (the same browser-approval device flow `follow` runs, min
 | Argument / flag | Value | Default | Description |
 |---|---|---|---|
 | `[SERVER_URL]` |  |  | The server URL to sign in to (optional; the enrolled plane, else the hosted default) |
-| `--wait` | `<SECONDS>` |  | Block until the browser approval settles in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait |
+| `--wait` | `<SECONDS>` |  | Block until the browser approval settles in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. A TTY blocks by default; a PIPED run without `--wait` prints the approval URL and returns — re-invoke to poll |
 
 
 #### `topos auth logout`

--- a/skills/topos/SKILL.md
+++ b/skills/topos/SKILL.md
@@ -111,9 +111,9 @@ the only browser moments are theirs:
    browser), or self-host per `INSTALL.md`. The address — `topos.sh/<name>` — is the
    workspace's one handle: enrollment, invites, and every publish receipt all speak it.
 2. Enroll THIS machine: `topos follow <address>`. Show your human the printed approval URL —
-   they open it in a browser and approve; never approve in their place. Re-invoking `follow`
-   polls once; `--wait <seconds>` blocks with a cap. Then run the printed
-   `topos follow <address> --yes` — that lands what the workspace offers.
+   they open it in a browser and approve; never approve in their place. Piped runs print the
+   approval URL and return; re-invoke `follow` to poll, `--wait <seconds>` to block with a cap.
+   Then run the printed `topos follow <address> --yes` — that lands what the workspace offers.
 3. Seat teammates: `topos invite <email>` per person (bare describes, `--yes` sends).
 4. Hand each teammate the join line for their own agent — an invite seats them, but only this
    line brings their machine in:

--- a/skills/topos/reference.md
+++ b/skills/topos/reference.md
@@ -254,12 +254,13 @@ Set a skill's (or channel's) protection level. Bare tightens to `reviewed` (skil
 topos invite [OPTIONS] [EMAIL]...
 ```
 
-Seat emails as invited members of the workspace (a roster write). Every CLI invitee starts as a member; joining is `follow <address>` plus proof of the invited email. Requires prior enrollment. A bare `invite` (no emails) reads the workspace address + policy (lands later)
+Invite emails into the workspace. Each address gets a mailed single-use invite link (accept in the browser, hand the mail's paste-block to an agent, or `topos follow <invite-url>`); every CLI invitee starts as a member. Requires prior enrollment. A bare `invite` (no emails) reads the workspace address + policy
 
 | Argument / flag | Value | Default | Description |
 |---|---|---|---|
-| `[EMAIL]...` |  |  | The emails to invite (folded to canonical form; seeded onto the roster as `invited`) |
-| `--channel` | `<NAME>` |  | Pre-place each invitee into this channel (repeatable) |
+| `[EMAIL]...` |  |  | The emails to invite (folded to canonical form; each becomes a pending 7-day claim) |
+| `--skill` | `<NAME>` |  | Lead the invitation with this SKILL — accepting follows it for the invitee (at most one of --skill/--channel) |
+| `--channel` | `<NAME>` |  | Lead the invitation with this CHANNEL — accepting joins the invitee to it |
 | `--yes` |  |  | Apply without the describe step. Parses today; the two-phase describe lands later |
 
 ## Maintenance

--- a/skills/topos/reference.md
+++ b/skills/topos/reference.md
@@ -45,7 +45,7 @@ Follow a workspace, channel, or skill — enroll if needed, then subscribe two-p
 | `--yes` |  |  | Apply the described subscription (the one-shot consent). Bare = describe only |
 | `--prefix-dirname` |  |  | Install a dirname-colliding skill under `<workspace>.<name>` instead of declining it |
 | `--manual` |  |  | Adopt followed skills in confirm-each mode (a one-tap accept per new version) instead of auto |
-| `--wait` | `<SECONDS>` |  | Block until the browser approval settles, finishing enrollment in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. Put `--wait` AFTER any positional |
+| `--wait` | `<SECONDS>` |  | Block until the browser approval settles, finishing enrollment in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. Put `--wait` AFTER any positional. A TTY blocks by default; a PIPED run without `--wait` prints the approval URL and returns immediately — re-invoke `follow` to poll, or pass `--wait` to block |
 
 
 ### `topos unfollow`
@@ -299,7 +299,7 @@ Re-enroll this machine (the same browser-approval device flow `follow` runs, min
 | Argument / flag | Value | Default | Description |
 |---|---|---|---|
 | `[SERVER_URL]` |  |  | The server URL to sign in to (optional; the enrolled plane, else the hosted default) |
-| `--wait` | `<SECONDS>` |  | Block until the browser approval settles in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait |
+| `--wait` | `<SECONDS>` |  | Block until the browser approval settles in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. A TTY blocks by default; a PIPED run without `--wait` prints the approval URL and returns — re-invoke to poll |
 
 
 #### `topos auth logout`

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -9,9 +9,12 @@ resource addresses/protocol card, and the `/api/v1` device lane over its own `we
 of an in-process vault (`topos_plane::router` — pure byte custody, the bearer-gated `/internal/v1`
 lane, no public face). Identity is ONE `user.id`: the harness claims the boot-minted workspace,
 signs people in with cookie sessions, and approves every device flow at the real `/verify` ceremony
-(a plain signed-in accept — no step-up) — the same HTTP a browser would send. SMTP stays UNSET in every suite:
-the whole enrolled loop must work with zero mail delivery. Per-crate unit + generative tests live in
-their crates; this directory is for what only a cross-crate composed run can prove.
+(a plain signed-in accept — no step-up) — the same HTTP a browser would send. SMTP stays UNSET in the
+default suites (the whole enrolled loop must work with zero mail delivery); the invitation-redemption
+suite alone runs `start_stack_mailed` — dummy relay coordinates that `APP_ENV=test` never dials, but
+which flip the mail-rung gates on (inviting, the passwordless account mint), with every mail recorded
+to `web/.invite-emails.jsonl` / the dev outbox instead of sent. Per-crate unit + generative tests live
+in their crates; this directory is for what only a cross-crate composed run can prove.
 
 ## Layout (what actually exists)
 
@@ -104,6 +107,16 @@ their crates; this directory is for what only a cross-crate composed run can pro
   row inserted directly, a credential seated in workspace A gets the uniform wire 404 on EVERY
   workspace-B route (reads and row-op writes), byte-identical to a workspace that never existed
   and to a wrong path — no oracle in any direction; the A lane is untouched.
+- **`tests/invite_redemption_e2e.rs`** — the terminal-first invited person, mail-armed: a lane
+  invite with a first-destination SKILL hint mails the tokened link; `topos follow <invite-url>`
+  starts the device flow CARRYING the token (the browser destination is the invitation page + the
+  flow challenge — the code never rides a URL); ONE browser visit (driven raw) mints the account
+  passwordlessly (born verified — the token's delivery is the proof), consumes the invitation,
+  seats the person, writes the hint follow, and continues into `/verify` where the challenge
+  resolves the card and the now-seated invitee approves; the granted resume DESCRIBES the hinted
+  skill (no local follow row, no bytes) and only the `--yes` apply lands the genesis byte-exact.
+  Plus the already-enrolled arm: a member's device consuming an invite URL accepts DIRECTLY over
+  the device lane (no browser, no new device row) and continues into the hint's describe.
 - **`tests/claim_e2e.rs`** — the first-boot claim door: the printed link (the
   `TOPOS_SETUP_LINK_FILE` mirror) claims once — first account, first owner seat, signed in — and
   the consumed code is then the SAME uniform miss as a wrong code (GET and POST, byte-for-byte;

--- a/tests/tests/common/mod.rs
+++ b/tests/tests/common/mod.rs
@@ -217,6 +217,7 @@ fn spawn_app(
     plane_base: &str,
     app_port: u16,
     link_file: &std::path::Path,
+    mail_armed: bool,
 ) -> AppServer {
     let web_dir = repo_root().join("web");
     let build = web_dir.join("build").join("server").join("index.js");
@@ -234,8 +235,8 @@ fn spawn_app(
         .join("@react-router")
         .join("serve")
         .join("bin.cjs");
-    let child = std::process::Command::new("node")
-        .arg(&serve_bin)
+    let mut cmd = std::process::Command::new("node");
+    cmd.arg(&serve_bin)
         .arg("./build/server/index.js")
         .current_dir(&web_dir)
         .env("PORT", app_port.to_string())
@@ -252,8 +253,20 @@ fn spawn_app(
         .env("TOPOS_WEB_RATELIMIT", "off")
         .env("TOPOS_WORKSPACE_NAME", WS_NAME)
         .env("TOPOS_SETUP_CODE", SETUP_CODE)
-        .env("TOPOS_SETUP_LINK_FILE", link_file)
-        // SMTP stays UNSET throughout: the whole enrolled loop must work with zero mail delivery.
+        .env("TOPOS_SETUP_LINK_FILE", link_file);
+    if mail_armed {
+        // Dummy relay coordinates: `APP_ENV=test` records every mail to the dev outbox files in
+        // the web dir and never dials a socket — but an ARMED transport flips the mail-rung
+        // gates on (inviting requires it, and the invitation page's account mint goes
+        // passwordless through the magic-link rung the composition arms alongside it). The
+        // default suites stay SMTP-UNSET: the whole enrolled loop must work with zero delivery.
+        cmd.env("TOPOS_MAIL_SMTP_HOST", "127.0.0.1")
+            .env("TOPOS_MAIL_SMTP_PORT", "2525")
+            .env("TOPOS_MAIL_SMTP_USER", "e2e")
+            .env("TOPOS_MAIL_SMTP_PASS", "e2e")
+            .env("TOPOS_MAIL_SMTP_FROM", "Topos <no-reply@e2e.test>");
+    }
+    let child = cmd
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::inherit())
         .spawn()
@@ -306,10 +319,12 @@ pub(crate) struct Session {
     cookies: Mutex<BTreeMap<String, String>>,
 }
 
-/// A response the session hands back: the status + the body text (empty when unreadable).
+/// A response the session hands back: the status + the body text (empty when unreadable) + the
+/// redirect target when the answer was one (redirects are OFF — a 302 is an asserted outcome).
 pub(crate) struct HttpAnswer {
     pub(crate) status: u16,
     pub(crate) body: String,
+    pub(crate) location: Option<String>,
 }
 
 fn blocking_agent() -> ureq::Agent {
@@ -374,13 +389,22 @@ impl Session {
     fn read(&self, mut resp: ureq::http::Response<ureq::Body>) -> HttpAnswer {
         self.absorb_cookies(&resp);
         let status = resp.status().as_u16();
+        let location = resp
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
         let mut body = String::new();
         let _ = resp
             .body_mut()
             .as_reader()
             .take(4 * 1024 * 1024)
             .read_to_string(&mut body);
-        HttpAnswer { status, body }
+        HttpAnswer {
+            status,
+            body,
+            location,
+        }
     }
 
     /// GET a path (an in-app path like `/login`, or `?`-suffixed) with the browser `Accept`.
@@ -479,6 +503,17 @@ pub(crate) struct Stack {
 /// of it, and poke ONE document request so first-boot setup mints the workspace (with the preset
 /// claim code). The workspace is returned UNCLAIMED — `claim_owner` is the first ceremony.
 pub(crate) fn start_stack(tag: &str) -> Stack {
+    start_stack_with(tag, false)
+}
+
+/// [`start_stack`] with the app's mail transport ARMED (dummy coordinates; `APP_ENV=test` records
+/// to the web dir's dev outbox files instead of dialing) — for the invitation-redemption suite,
+/// whose invite ceremony and passwordless account mint both ride the mail rung.
+pub(crate) fn start_stack_mailed(tag: &str) -> Stack {
+    start_stack_with(tag, true)
+}
+
+fn start_stack_with(tag: &str, mail_armed: bool) -> Stack {
     let dir = Scratch::new("topos-e2e", tag);
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -506,7 +541,13 @@ pub(crate) fn start_stack(tag: &str) -> Stack {
 
     let app_port = free_port();
     let setup_link_file = dir.0.join("setup-link.txt");
-    let app = spawn_app(&web_url, &plane_base, app_port, &setup_link_file);
+    let app = spawn_app(
+        &web_url,
+        &plane_base,
+        app_port,
+        &setup_link_file,
+        mail_armed,
+    );
     let origin = app.origin.clone();
     let api_base = format!("{origin}/api");
 
@@ -726,7 +767,11 @@ impl Stack {
             .as_reader()
             .take(4 * 1024 * 1024)
             .read_to_string(&mut text);
-        HttpAnswer { status, body: text }
+        HttpAnswer {
+            status,
+            body: text,
+            location: None,
+        }
     }
 
     /// GET a device-lane path (e.g. `/v1/workspaces/{ws}/delivery`) under `credential`.

--- a/tests/tests/follow_e2e.rs
+++ b/tests/tests/follow_e2e.rs
@@ -119,9 +119,9 @@ fn e2e_real_follow_enrolls_describes_and_lands_the_first_skill() {
     assert!(!pending.enrolled, "call 1 only begins enrollment");
     let handle = pending.pending.expect("the pending verification handle");
     assert!(
-        handle.verification_uri_complete.starts_with(&stack.origin),
+        handle.verification_uri.starts_with(&stack.origin),
         "the approval URL rides this origin: {}",
-        handle.verification_uri_complete
+        handle.verification_uri
     );
     assert!(
         client.wal_exists(),
@@ -241,9 +241,9 @@ fn e2e_follow_by_bare_origin_enrolls_describes_and_delivers() {
     assert!(!pending.enrolled, "call 1 only begins enrollment");
     let handle = pending.pending.expect("the pending verification handle");
     assert!(
-        handle.verification_uri_complete.starts_with(&stack.origin),
+        handle.verification_uri.starts_with(&stack.origin),
         "the approval URL rides this origin: {}",
-        handle.verification_uri_complete
+        handle.verification_uri
     );
     assert!(client.wal_exists(), "the pending WAL is written");
 

--- a/tests/tests/invite_redemption_e2e.rs
+++ b/tests/tests/invite_redemption_e2e.rs
@@ -1,0 +1,333 @@
+//! The INVITATION-REDEMPTION loop over the composed stack — the terminal-first invited person:
+//!
+//!   invite (device lane, with a first-destination skill hint) → the mailed tokened link →
+//!   `topos follow <invite-url>` (the device flow CARRYING the token) → the ONE-visit browser
+//!   weave (account minted passwordlessly on the invitation page → the invitation accepted →
+//!   the device approved at /verify, resolved by the flow challenge with zero typing) → the
+//!   enrolled resume describing the HINTED skill → and the bytes landing ONLY after the
+//!   device-side `--yes` consent.
+//!
+//! Plus the already-enrolled arm: a member's device consuming an invite URL accepts directly
+//! over the device lane — no browser, no new device — and continues into the hint's describe.
+//!
+//! The app runs MAIL-ARMED here (dummy relay coordinates; `APP_ENV=test` records every mail to
+//! `web/.invite-emails.jsonl` instead of dialing) because inviting requires the mail rung and
+//! the invitation page's account mint rides the magic-link rung the composition arms with it.
+
+mod common;
+
+use topos::test_support::FollowHarness;
+
+const OWNER_EMAIL: &str = "owner@acme.test";
+const SKILL: &str = "s-deploy";
+
+/// The genesis bundle the author publishes (SKILL.md + an executable script).
+fn genesis_files() -> Vec<(&'static str, bool, &'static [u8])> {
+    vec![
+        (
+            "SKILL.md",
+            false,
+            b"# deploy runbook\nrun it right\n" as &[u8],
+        ),
+        ("run.sh", true, b"#!/bin/sh\necho ok\n"),
+    ]
+}
+
+/// The mail-armed stack with a claimed owner, an enrolled author device (owned by the owner),
+/// and the genesis skill published — the arrangement both tests start from.
+fn stack_with_genesis(tag: &str) -> (common::Stack, common::Session, FollowHarness) {
+    let stack = common::start_stack_mailed(tag);
+    let owner = stack.claim_owner(OWNER_EMAIL);
+    let author = FollowHarness::new(&format!("{tag}-author"));
+    stack.enroll_begin_and_approve(&author, &owner);
+    let applied = author.resume_apply().expect("the author's resume applies");
+    assert!(applied.enrolled_now, "the author's device enrolled");
+    author.adopt(SKILL, &genesis_files());
+    let digest = author.draft_digest(SKILL);
+    author
+        .publish_message("", &format!("{SKILL}@{digest}"), "genesis: deploy runbook")
+        .expect("the genesis publish lands");
+    (stack, owner, author)
+}
+
+/// The recorded invitation mail for `to` — the dev-outbox stand-in for the recipient's mailbox
+/// (`web/.invite-emails.jsonl`, shared across suites; the LAST line for the address wins).
+fn recorded_invite_url(to: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .join("web")
+        .join(".invite-emails.jsonl");
+    let text = std::fs::read_to_string(&path).expect("the recorded invite mail file exists");
+    let line = text
+        .lines()
+        .rev()
+        .find(|l| l.contains(&format!("\"to\":\"{to}\"")))
+        .expect("an invite mail was recorded for the address");
+    let v: serde_json::Value = serde_json::from_str(line).expect("a JSON mail line");
+    v["inviteUrl"]
+        .as_str()
+        .expect("the mail carries the tokened invite URL")
+        .to_owned()
+}
+
+/// Mint one invitation over the device lane, with an optional skill hint; return the mailed URL.
+fn invite_via_lane(
+    stack: &common::Stack,
+    credential: &str,
+    email: &str,
+    skill_hint: Option<&str>,
+) -> String {
+    let mut body = serde_json::json!({ "emails": [email] });
+    if let Some(skill) = skill_hint {
+        body["skill"] = serde_json::Value::String(skill.to_owned());
+    }
+    let resp = stack.device_post_json(
+        Some(credential),
+        &format!("/v1/workspaces/{}/invitations", stack.workspace_id),
+        &body,
+    );
+    assert_eq!(resp.status, 200, "the invite lands: {}", resp.body);
+    let env: serde_json::Value = serde_json::from_str(&resp.body).expect("invite envelope");
+    assert_eq!(env["ok"], true, "the invite envelope is OK: {}", resp.body);
+    assert_eq!(env["data"]["mailed"], true, "the server mailed the link");
+    recorded_invite_url(email)
+}
+
+// ── the keystone: terminal-first invited person, one browser visit, consent-gated install ─────────
+
+#[test]
+fn e2e_the_terminal_first_invited_person_weaves_one_visit_and_installs_after_consent() {
+    let invitee_email = "terminal-invitee@acme.test";
+    let (stack, owner, _author) = stack_with_genesis("invredeem");
+
+    // The inviter's probe device (the CLI-shaped lane call), hinting the genesis skill.
+    let inviter = stack.mint_device(&owner, "inviter probe");
+    let invite_url = invite_via_lane(&stack, &inviter.credential, invitee_email, Some(SKILL));
+    assert!(
+        invite_url.starts_with(&stack.origin) && invite_url.contains("/invite/"),
+        "the mailed link is this origin's tokened invitation URL: {invite_url}"
+    );
+
+    // `topos follow <invite-url>` — the device flow starts CARRYING the token; the browser
+    // destination is the INVITATION page with the flow challenge (never the code).
+    let invitee = FollowHarness::new("invredeem-invitee");
+    let pending = invitee.follow(&invite_url).expect("follow call 1 begins");
+    assert!(!pending.enrolled);
+    let pending = pending.pending.expect("the pending verification handle");
+    assert!(
+        pending.verification_uri.starts_with(&invite_url)
+            && pending.verification_uri.contains("?device="),
+        "the browser destination is the invitation page + the flow challenge: {}",
+        pending.verification_uri
+    );
+    assert!(
+        !pending.verification_uri.contains(&pending.user_code),
+        "the code never rides a URL"
+    );
+
+    // The ONE browser visit, driven over raw HTTP. Step 1: the invitation page's account-mint
+    // arm (mail is armed, so it is PASSWORDLESS — the token's delivery is the proof).
+    let weave_path = pending
+        .verification_uri
+        .strip_prefix(&stack.origin)
+        .expect("the weave URL is app-origin")
+        .to_owned();
+    let browser = common::Session::new(&stack.origin);
+    let page = browser.get(&weave_path);
+    assert_eq!(
+        page.status, 200,
+        "the invitation page renders: {}",
+        page.body
+    );
+    assert!(
+        page.body.contains("Accept and create my account"),
+        "the account-mint arm renders (passwordless)"
+    );
+    assert!(
+        !page.body.contains("Choose a password"),
+        "no password field on a mail-rung deployment"
+    );
+    assert!(
+        page.body.contains("First up") && page.body.contains(SKILL),
+        "the summary leads with the hinted skill: {}",
+        page.body
+    );
+    assert!(
+        page.body.contains(invitee_email),
+        "the page names the invited address to the token holder"
+    );
+
+    // Step 2: accept — mints the account (born verified), consumes the invitation, seats the
+    // person, writes the hint follow, and CONTINUES to /verify carrying the challenge.
+    let accepted = browser.post_form(
+        &weave_path,
+        &[("intent", "accept-new"), ("name", "Terminal Invitee")],
+    );
+    assert_eq!(
+        accepted.status, 302,
+        "the accept redirects: {}",
+        accepted.body
+    );
+    let location = accepted.location.clone().expect("a redirect target");
+    assert!(
+        location.starts_with("/verify?device="),
+        "the weave continues into the device approval: {location}"
+    );
+
+    // Step 3: /verify resolves the flow by challenge (zero typing), shows the code for the
+    // glance-check, and the now-seated invitee approves.
+    let verify = browser.get(&location);
+    assert_eq!(
+        verify.status, 200,
+        "the approval card renders: {}",
+        verify.body
+    );
+    assert!(
+        verify.body.contains(&pending.user_code),
+        "the resolved card shows the code for the glance-check"
+    );
+    assert!(
+        verify.body.contains("acts with your seat in"),
+        "the card disclosed the credential's workspace reach"
+    );
+    let approved = browser.post_form(
+        "/verify",
+        &[("intent", "approve"), ("code", &pending.user_code)],
+    );
+    assert_eq!(
+        approved.status, 200,
+        "the approval lands: {}",
+        approved.body
+    );
+    assert!(approved.body.contains("connected"), "{}", approved.body);
+
+    // The row witnesses: the account is born VERIFIED, the seat stands, the invitation is
+    // consumed, and the hint follow rides the accept.
+    assert_eq!(
+        stack.count(&format!(
+            "SELECT count(*) FROM web.\"user\" WHERE email = '{invitee_email}' AND email_verified"
+        )),
+        1,
+        "the token's delivery to the mailbox IS the verification"
+    );
+    assert_eq!(
+        stack.count(&format!(
+            "SELECT count(*) FROM web.seat s JOIN web.\"user\" u ON u.id = s.user_id \
+             WHERE u.email = '{invitee_email}' AND s.role = 'member'"
+        )),
+        1
+    );
+    assert_eq!(
+        stack.count(&format!(
+            "SELECT count(*) FROM web.invitation WHERE email = '{invitee_email}' \
+             AND status = 'accepted'"
+        )),
+        1
+    );
+    assert_eq!(
+        stack.count(&format!(
+            "SELECT count(*) FROM web.bundle_subscription bs \
+             JOIN web.\"user\" u ON u.id = bs.user_id \
+             WHERE u.email = '{invitee_email}' AND bs.state = 'following'"
+        )),
+        1,
+        "the hint subscribed — nothing landed on any device from the web accept"
+    );
+
+    // The resume: the grant carries the HINT, so the describe targets the invited-to skill —
+    // and NOTHING has installed yet (the two-phase consent still gates the bytes).
+    let describe = invitee
+        .resume_describe()
+        .expect("the granted resume describes");
+    assert!(describe.enrolled_now, "the resume persisted the enrollment");
+    assert_eq!(
+        describe.targets,
+        vec![("skill".to_owned(), SKILL.to_owned())],
+        "the subscribe targets the hinted skill, not the whole workspace"
+    );
+    assert_eq!(describe.installs.len(), 1, "{:?}", describe.installs);
+    assert_eq!(describe.installs[0].name, SKILL);
+    assert_eq!(
+        invitee.follows_count(),
+        0,
+        "no local follow row before the consent"
+    );
+
+    // The consent: `--yes` on the described target lands the genesis byte-exact.
+    let applied = invitee
+        .follow_apply(&format!("{}/skills/{SKILL}", common::WS_NAME))
+        .expect("the --yes apply lands the hinted skill");
+    assert_eq!(applied.installed.len(), 1, "{:?}", applied.installed);
+    assert_eq!(applied.installed[0].name, SKILL);
+    let placed = invitee.placement_files(&applied.installed[0].skill_id);
+    let skill_md = placed
+        .iter()
+        .find(|(p, _, _)| p == "SKILL.md")
+        .expect("SKILL.md placed");
+    assert_eq!(
+        skill_md.2,
+        genesis_files()[0].2.to_vec(),
+        "the genesis bytes land byte-exact, only after the consent"
+    );
+}
+
+// ── the already-enrolled arm: the device lane accepts directly, no browser ────────────────────────
+
+#[test]
+fn e2e_an_enrolled_device_consumes_an_invite_url_directly() {
+    let (stack, owner, author) = stack_with_genesis("invdirect");
+
+    // The owner's account must be mailbox-proven for a lane accept (the browser weave proves it
+    // via the token; an enrolled device presents no token-holder ceremony, so the standing fence
+    // applies). The claim ceremony verifies no mailbox — arrange the fact directly.
+    stack
+        .rt
+        .block_on(
+            sqlx::query("UPDATE web.\"user\" SET email_verified = true WHERE email = $1")
+                .bind(OWNER_EMAIL)
+                .execute(&stack.pool),
+        )
+        .expect("mark the owner's mailbox proven");
+
+    // Invite the OWNER's own address with a skill hint (an existing member being pointed at a
+    // first destination — the accept is idempotent on the seat and still delivers the hint).
+    let probe = stack.mint_device(&owner, "inviter probe");
+    let invite_url = invite_via_lane(&stack, &probe.credential, OWNER_EMAIL, Some(SKILL));
+
+    let devices_before = stack.count("SELECT count(*) FROM web.device WHERE revoked_at IS NULL");
+
+    // The ENROLLED author device consumes the URL: the accept rides the device lane (no browser,
+    // no new device flow) and the verb continues into the hint's two-phase describe.
+    let describe = author
+        .follow_describe(&invite_url)
+        .expect("the direct accept continues into the describe");
+    assert_eq!(
+        describe.targets,
+        vec![("skill".to_owned(), SKILL.to_owned())],
+        "the describe targets the hinted skill"
+    );
+
+    // No browser ceremony ran: no new device row, no pending flow — and the invitation consumed.
+    assert_eq!(
+        stack.count("SELECT count(*) FROM web.device WHERE revoked_at IS NULL"),
+        devices_before,
+        "no device flow started"
+    );
+    assert_eq!(
+        stack.count(&format!(
+            "SELECT count(*) FROM web.invitation WHERE email = '{OWNER_EMAIL}' \
+             AND status = 'accepted'"
+        )),
+        1
+    );
+    assert_eq!(
+        stack.count(&format!(
+            "SELECT count(*) FROM web.bundle_subscription bs \
+             JOIN web.\"user\" u ON u.id = bs.user_id WHERE u.email = '{OWNER_EMAIL}' \
+             AND bs.state = 'following'"
+        )),
+        1,
+        "the hint follow landed with the accept"
+    );
+}

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -8,7 +8,8 @@ app is its one caller.
 
 **The device lane terminates here.** Every `/api/v1/…` path is answered in this tier — there is no splat
 forwarder to the vault anymore. The row ops (delivery · the fleet report · me/channels/reach ·
-subscriptions/follows · curation · exclusions · protection · notices ack · invitations) are Drizzle
+subscriptions/follows · curation · exclusions · protection · notices ack · invitations · the
+person-scoped invitation accept) are Drizzle
 queries against this app's OWN `web` schema, behind the device-credential guard (`requireDeviceActor` —
 the presented `Authorization: Bearer` resolved credential → device → person → seat, the hash computed IN
 Postgres, so this tier still holds zero crypto). The **byte/pointer** ops of a publish-family verb
@@ -51,20 +52,58 @@ transaction, FOR UPDATE-fenced or single-statement-atomic, audit row inside):
 - **The claim** (`claim.tsx` → `consumeClaim`): one atomic UPDATE consumes the code and seats the first
   **owner** (email + password). Single-use by construction.
 - **The gh-style device flow** (`verify.tsx` + `api.v1.device-authorize`/`api.v1.device-token`;
-  `startDeviceAuth`/`pollDeviceAuth`/`approveDeviceAuth`): the CLI prints "open `<origin>/verify` and
-  enter AB12-CD34" and polls; the signed-in person approves with a **plain accept** — a live session
-  plus the explicit approve click IS the whole ceremony (no step-up) — minting the device (owned by
-  that person) + its ONE bearer credential (the device code is promoted to the credential — same
-  plaintext, same stored hash). The flow row records the workspace ADDRESS SLUG the authorize call
-  named; multi tenancy shape-checks that slug only (an unauthenticated start is never a
-  workspace-existence oracle — the workspace may be created mid-flow), and approval resolves it under
-  the tenancy grammar and requires the approver's SEAT in the resolved workspace, inside the same
-  FOR-UPDATE fence — a missing workspace or a seatless approver gets the same uniform refusal an
-  expired code does. On a multi-tenant deployment a signed-in approver with zero seats anywhere is
-  first woven through workspace creation (`/verify` redirects to `/new` carrying itself as `next` +
-  the flow's slug as a `name` prefill). The signed-out loader bounce carries the code as `next`, so a
-  password OR a magic-link sign-in both return to finish the approval. Revocation is self-service,
-  immediate, and FINAL (a DB trigger refuses any un-revoke).
+  `startDeviceAuth`/`pollDeviceAuth`/`approveDeviceAuth`): the CLI prints the BARE `<origin>/verify`
+  and the short code on SEPARATE lines (the code never rides a URL — the retired code-embedding
+  `verification_uri_complete` left the wire) and polls; `/verify` is TWO-STATE — a POST code-lookup
+  form, then the resolved card showing the requesting device, the code for the glance-check, and
+  EVERY workspace the credential will reach (the approver's seats + the one being joined) — and the
+  signed-in person approves with a **plain accept** — a live session plus the explicit approve click
+  IS the whole ceremony (no step-up) — minting the device (owned by that person) + its ONE bearer
+  credential (the device code is promoted to the credential — same plaintext, same stored hash). The
+  flow row records the workspace ADDRESS SLUG the authorize call named — and, when the enrollment
+  came from `follow <invite-url>`, the invite token's hash (recorded UNVALIDATED — the start is
+  never a token oracle); the approval weaves accept-the-invitation into its own fence when the
+  approver is the invitation's addressee, and the granted poll decorates the invitation's
+  first-destination `hint`. Multi tenancy shape-checks the slug only (an unauthenticated start is
+  never a workspace-existence oracle — the workspace may be created mid-flow), and approval resolves
+  it under the tenancy grammar and requires the approver's SEAT in the resolved workspace, inside
+  the same FOR-UPDATE fence — a missing workspace or a seatless approver gets the same uniform
+  refusal an expired code does. On a multi-tenant deployment a signed-in approver with zero seats
+  anywhere is first woven through workspace creation (`/verify` redirects to `/new` carrying itself
+  as `next` + the flow's slug as a `name` prefill) — unless the flow carries an invitation, whose
+  accept will seat them right there. The LOOPBACK arrival (the CLI auto-opened the page): the URL
+  carries `device` — hex of the flow's device-code HASH, resolving the card with zero typing — plus
+  `port`/`state` naming the CLI's ephemeral 127.0.0.1 listener; the approve/deny outcome returns as
+  ONE state-bound localhost redirect (nothing sensitive rides it — the CLI's poll stays the source
+  of truth). The signed-out loader bounce carries the page (validated params only) as `next`.
+  Revocation is self-service, immediate, and FINAL (a DB trigger refuses any un-revoke).
+- **The tokened invitation** (`invite-redeem.tsx` at `/invite/<token>` — `/<ws>/invite/<token>` in
+  multi — + the ceremonies in `identity.server.ts`): inviting mints a long single-use token per
+  address (only its SHA-256 stored — the claim-code pattern; 7-day lapse; re-inviting mints a fresh
+  token over the pending row, killing the old link; revoke kills it too), optionally carrying ONE
+  first-destination hint (a bundle or channel of its own workspace, composite-FK-pinned with a
+  per-column SET NULL). The link travels ONLY in the invitation mail (three CTAs, in order: the
+  browser link, the agent paste-block, the terminal `topos follow <invite-url>` line — hint-led);
+  the inviter's receipts carry the workspace address, never the token. The page is GET-safe
+  (viewing never consumes) and branches on the ONE sanctioned email-binding predicate beside
+  `bindInvitedSeats`: signed in as the invited address → one-click accept; no such account → the
+  page MINTS it (email locked to the invited address; PASSWORDLESS through Better Auth's own
+  magic-link door when the mail rung exists — the token's delivery IS the mailbox proof, so the
+  account is born verified with no verification mail; a password field on password-only
+  deployments) inside the invitation registration ceremony; signed in as someone else → the switch
+  page (names the invited address, offers sign-out-and-return, never accepts); an unverified squat
+  on the invited address → one mailbox round-trip first; already a member → redirect into the
+  workspace (nothing consumed). ACCEPT is ONE FOR-UPDATE-fenced transaction beside
+  `bindInvitedSeats`: consume the token, write the seat, apply the hint effects AFTER the seat
+  (`bundle_subscription` 'following' / `channel_member`), audit — the hint SUBSCRIBES; nothing
+  lands on any device from a web accept. DECLINE is recorded (the members page shows it;
+  re-invitable) and deliberately session-less (token possession is the proof). Every dead token —
+  invalid, expired, revoked, used — renders ONE constant page naming neither workspace nor email,
+  behind the public-read belt. An already-enrolled device accepts with no browser at
+  `POST /api/v1/invitations/accept` behind `requireDevicePerson` (credential → device → user,
+  seat-LESS by construction). The skill FACE carries an invite affordance minting a
+  skill-hinted invitation. The legacy sign-up auto-bind (`bindInvitedSeats` on
+  `afterEmailVerification`) stays unchanged beside all of this.
 - **Recovery** (`app/lib/auth/recovery.server.ts` + `scripts/mint-recovery-code.mjs`): reset mail when
   SMTP is armed; a mail-less solo owner runs the one-shot box-side script to print a single-use recovery
   code (machine control is the proof).

--- a/web/app/components/members/pending-invitations.tsx
+++ b/web/app/components/members/pending-invitations.tsx
@@ -3,10 +3,12 @@ import { useFetcher } from "react-router";
 import { StepUpFields } from "@/components/step-up";
 import { buttonClasses, Card, Chip, SectionHeading } from "@/components/ui";
 
-/** One pending invitation as the members page renders it (loader-shaped; lapse pre-computed). */
+/** One open invitation as the members page renders it (loader-shaped; lapse pre-computed). */
 export interface PendingInvitationView {
   id: string;
   email: string;
+  /** 'pending' (a live claim) or 'declined' (the recorded "no thanks" — re-invitable). */
+  status: "pending" | "declined";
   invitedByDisplay: string;
   /** "lapses in 6 days" / "lapsed" — computed in the loader so hydration re-reads no clock. */
   lapse: string;
@@ -21,10 +23,12 @@ interface RevokeInvitationActionData {
 }
 
 /**
- * The claims-in-flight panel: invitations that no user has bound yet. Every member may see the
- * list (who was invited is roster-adjacent fact, not a secret); the REVOKE arm is owner-only
- * and a step-up ceremony. Re-inviting an address is just inviting it again — the pending row
- * upserts and the 7-day clock re-arms, so there is no separate resend control here.
+ * The claims-in-flight panel: invitations that no user has bound yet, plus DECLINED ones — the
+ * recorded "no thanks" the inviter should see (re-inviting the address supersedes it). Every
+ * member may see the list (who was invited is roster-adjacent fact, not a secret); the REVOKE
+ * arm is owner-only, pending-only, and a step-up ceremony. Re-inviting an address is just
+ * inviting it again — the pending row upserts, a fresh link mails, and the 7-day clock re-arms,
+ * so there is no separate resend control here.
  */
 export function PendingInvitations({
   invitations,
@@ -43,8 +47,8 @@ export function PendingInvitations({
           <span id="invitations-heading">Pending invitations</span>
         </SectionHeading>
         <p className="text-dim text-sm">
-          Each becomes a seat the moment its address signs up and verifies the mailbox. Invite an
-          address again to resend and re-arm its clock.
+          Each becomes a seat the moment its address accepts the mailed link (or signs up and
+          verifies the mailbox). Invite an address again to mail a fresh link and re-arm its clock.
         </p>
       </div>
       <Card className="overflow-hidden">
@@ -55,11 +59,16 @@ export function PendingInvitations({
               className="flex min-h-12 flex-wrap items-center gap-x-4 gap-y-2 border-line-soft border-b px-4 py-3 last:border-b-0"
             >
               <span className="text-ink text-sm">{invitation.email}</span>
-              <Chip tone="pending">pending</Chip>
+              {invitation.status === "pending" ? (
+                <Chip tone="pending">pending</Chip>
+              ) : (
+                <Chip tone="unverified">declined</Chip>
+              )}
               <span className="text-faint text-xs">
-                invited by {invitation.invitedByDisplay} · {invitation.lapse}
+                invited by {invitation.invitedByDisplay}
+                {invitation.status === "pending" ? ` · ${invitation.lapse}` : ""}
               </span>
-              {isOwner && (
+              {isOwner && invitation.status === "pending" && (
                 <span className="ml-auto">
                   <RevokeInvitationForm invitationId={invitation.id} email={invitation.email} />
                 </span>

--- a/web/app/components/skill/skill-invite.tsx
+++ b/web/app/components/skill/skill-invite.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from "react";
+import { useFetcher } from "react-router";
+import { buttonClasses, Card } from "@/components/ui";
+
+/** The skill route's typed reply for `intent=invite` (mirrors the action's return union). */
+interface SkillInviteReply {
+  intent: "invite";
+  status: "invited" | "owner_required" | "mail_unarmed" | "error";
+  /** Echoed on a non-success so the field keeps the typed address through the re-render. */
+  submittedEmail?: string;
+  /** The address invited, on success. */
+  invited?: string;
+  /** Whether the notice mail went out (the invitation row stands regardless). */
+  emailSent?: boolean;
+}
+
+/**
+ * "Invite a teammate to this skill" — a quiet, collapsed affordance on the skill face. A member
+ * expands it to a single-email form; submitting mints an invitation whose FIRST destination is
+ * THIS skill, so the mail leads with the skill and the invitee lands looking at it. Inviting is a
+ * member op the workspace's invite-policy gates, and it REQUIRES armed mail (the invitation's
+ * identity proof is a mailbox round-trip) — so when mail is unarmed, or the policy restricts
+ * inviting to owners and the viewer is a plain member, the expanded panel says so honestly
+ * instead of offering a form that can only fail. The action re-checks both regardless of what
+ * this renders, and its refusals surface here too (a policy can change between render and submit).
+ */
+export function SkillInviteAffordance({
+  mailArmed,
+  invitePolicy,
+  isOwner,
+}: {
+  mailArmed: boolean;
+  invitePolicy: "members" | "owners";
+  isOwner: boolean;
+}) {
+  const fetcher = useFetcher<SkillInviteReply>();
+  const [open, setOpen] = useState(false);
+  const pending = fetcher.state !== "idle";
+  const state = fetcher.data;
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // React Router does not reset a fetcher form after submit; clear the field once, on a landed
+  // invite, so a second teammate can be invited without re-typing over the last address. A
+  // non-success keeps the typed address via the echoed submittedEmail below.
+  useEffect(() => {
+    if (fetcher.state === "idle" && state?.status === "invited") {
+      formRef.current?.reset();
+    }
+  }, [fetcher.state, state]);
+
+  if (!open) {
+    return (
+      <div className="space-y-2">
+        <button type="button" onClick={() => setOpen(true)} className={buttonClasses("quiet")}>
+          Invite a teammate
+        </button>
+        {state?.status === "invited" && (
+          <p className="text-dim text-sm" role="status">
+            Invited {state.invited} — the mail leads with this skill.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  const restricted = invitePolicy === "owners" && !isOwner;
+  return (
+    <Card className="space-y-3 px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-display text-[10px] text-faint uppercase tracking-[0.12em]">
+          Invite a teammate
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-faint text-xs hover:text-dim"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {!mailArmed ? (
+        <p className="text-dim text-sm">
+          Configure mail (TOPOS_MAIL_SMTP_*) to invite your team — the invitation&apos;s identity
+          proof is a mailbox round-trip.
+        </p>
+      ) : restricted ? (
+        <p className="text-dim text-sm">
+          Inviting is restricted to owners in this workspace (the invite-policy knob in settings).
+        </p>
+      ) : (
+        <>
+          <fetcher.Form ref={formRef} method="post" className="flex flex-wrap items-end gap-2">
+            <input type="hidden" name="intent" value="invite" />
+            <label className="block flex-1">
+              <span className="mb-1 block font-medium text-dim text-sm">Invite by email</span>
+              <input
+                type="text"
+                name="email"
+                required
+                autoComplete="off"
+                placeholder="teammate@company.com"
+                // The echoed submittedEmail (keyed, so the node remounts) keeps the typed address
+                // through a denial/error re-render.
+                key={state?.submittedEmail ?? "initial"}
+                defaultValue={state?.submittedEmail ?? ""}
+                className="block h-11 w-full min-w-56 rounded-md border border-line px-3 text-ink text-sm placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={pending}
+              className={`${buttonClasses("quiet")} min-h-11`}
+            >
+              {pending ? "Inviting…" : "Invite"}
+            </button>
+          </fetcher.Form>
+          <p className="text-faint text-xs">
+            The invitation leads with this skill — it is the first thing the invitee sees.
+          </p>
+        </>
+      )}
+
+      {state?.status === "invited" && (
+        <p className="text-dim text-sm" role="status">
+          Invited {state.invited} — the mail leads with this skill.{" "}
+          {state.emailSent
+            ? "They were emailed the invite; accepting puts this skill in front of them first."
+            : "The invitation stands, but the mail didn't send — invite the address again to resend."}
+        </p>
+      )}
+      {state?.status === "owner_required" && (
+        <p className="text-red-600 text-sm" role="alert">
+          Only a workspace owner can invite here.
+        </p>
+      )}
+      {state?.status === "mail_unarmed" && (
+        <p className="text-red-600 text-sm" role="alert">
+          Mail isn&apos;t configured on this deployment — set TOPOS_MAIL_SMTP_* to invite.
+        </p>
+      )}
+      {state?.status === "error" && (
+        <p className="text-red-600 text-sm" role="alert">
+          That didn&apos;t go through — check the address and try again.
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/web/app/lib/auth/guards.server.ts
+++ b/web/app/lib/auth/guards.server.ts
@@ -1,7 +1,14 @@
 import { data, redirect } from "react-router";
 import { composition } from "@/composition.server";
 import { bearerToken, uniformNotFound } from "@/lib/api/wire.server";
-import { deviceActor, seatOf, theWorkspace, workspaceByName } from "@/lib/db/identity.server";
+import {
+  deviceActor,
+  devicePerson,
+  type SessionAccount,
+  seatOf,
+  theWorkspace,
+  workspaceByName,
+} from "@/lib/db/identity.server";
 import { personDisplay } from "@/lib/person-display";
 import { getAuth } from "./server";
 
@@ -298,4 +305,23 @@ export async function requireDeviceActor(
     deviceId: row.deviceId,
     role: row.role,
   } as DeviceActor;
+}
+
+/**
+ * The PERSON-scoped device guard: credential → device → user, NO seat requirement — for the
+ * one lane op whose caller by definition has no seat yet (accepting an invitation from an
+ * already-enrolled device). The email facts ride along because the invitation ceremony fences
+ * on them, resolved from the trusted user row — never a client field. Every miss is the same
+ * uniform wire 404 the seated guard answers.
+ */
+export async function requireDevicePerson(request: Request): Promise<SessionAccount> {
+  const credential = bearerToken(request);
+  if (credential === null) {
+    throw uniformNotFound();
+  }
+  const row = await devicePerson(credential);
+  if (row === null) {
+    throw uniformNotFound();
+  }
+  return row;
 }

--- a/web/app/lib/auth/registration.server.ts
+++ b/web/app/lib/auth/registration.server.ts
@@ -22,6 +22,9 @@ import { mailDelivery } from "@/lib/mail/transport.server";
  *       the deployment can actually verify it (unarmed SMTP ⇒ inviting is disabled AND a
  *       leftover invitation admits nothing — the old self-asserted-email impersonation hole
  *       stays closed);
+ *   (b2) the invitation-REDEMPTION ceremony — the invite page resolved a live single-use link
+ *       token and mints the invited address's account inside [`withInvitationCeremony`]: the
+ *       token's delivery to that mailbox is the proof, so no second mail round-trip gates it;
  *   (c) in SINGLE tenancy only, the operator knob `workspace.registration = 'open'` on THE
  *       one workspace this install serves, off by default.
  * Everything else gets ONE constant, non-enumerating refusal — the same answer whether the
@@ -39,11 +42,21 @@ import { mailDelivery } from "@/lib/mail/transport.server";
  * accidentally reopen registration.
  */
 
-const ceremonyContext = new AsyncLocalStorage<{ ceremony: "claim" }>();
+const ceremonyContext = new AsyncLocalStorage<{ ceremony: "claim" | "invitation" }>();
 
 /** The claim ceremony wraps its internal sign-up call so the create hook admits it. */
 export function withRegistrationCeremony<T>(fn: () => Promise<T>): Promise<T> {
   return ceremonyContext.run({ ceremony: "claim" }, fn);
+}
+
+/**
+ * The invitation-redemption ceremony wraps ITS account mint the same way: the invite page has
+ * already resolved a live single-use token before it creates the invited email's account, so
+ * the create hook admits exactly that one sign-up — a ceremony wrapper, never an email check,
+ * and never a policy the hook re-derives (the token's delivery to the mailbox is the proof).
+ */
+export function withInvitationCeremony<T>(fn: () => Promise<T>): Promise<T> {
+  return ceremonyContext.run({ ceremony: "invitation" }, fn);
 }
 
 /** The one refusal string every closed path answers with (non-enumerating by sameness). */
@@ -55,6 +68,8 @@ export function registrationDecision(facts: {
   policy: "gated" | "open";
   tenancy: "single" | "multi";
   inClaimCeremony: boolean;
+  /** True inside the invitation-redemption ceremony: a live invite token already resolved. */
+  inInvitationCeremony: boolean;
   /** The single-tenant workspace's own knob; ALWAYS null in multi (never consulted there). */
   registrationKnob: "invite_only" | "open" | null;
   pendingInvitation: boolean;
@@ -63,7 +78,7 @@ export function registrationDecision(facts: {
   if (facts.policy === "open") {
     return "allow";
   }
-  if (facts.inClaimCeremony) {
+  if (facts.inClaimCeremony || facts.inInvitationCeremony) {
     return "allow";
   }
   // The workspace knob opens sign-up only where the install IS the workspace: a knob scoped
@@ -109,7 +124,8 @@ export async function assertRegistrationAllowed(email: string): Promise<void> {
   if (composition.registration === "open") {
     return;
   }
-  if (ceremonyContext.getStore()?.ceremony === "claim") {
+  const ceremony = ceremonyContext.getStore()?.ceremony;
+  if (ceremony === "claim" || ceremony === "invitation") {
     return;
   }
   const lowered = email.trim().toLowerCase();
@@ -125,6 +141,7 @@ export async function assertRegistrationAllowed(email: string): Promise<void> {
     policy: "gated",
     tenancy,
     inClaimCeremony: false,
+    inInvitationCeremony: false,
     registrationKnob,
     pendingInvitation: await hasPendingInvitation(lowered, invitationScope),
     mailArmed: mailDelivery().canSend,

--- a/web/app/lib/db/identity.server.ts
+++ b/web/app/lib/db/identity.server.ts
@@ -475,74 +475,103 @@ async function seatedFlowWorkspaceTx(
  * step-up gate runs in the ROUTE before this is called — approval mints a credential that
  * acts as you.
  */
+/** The in-transaction abort sentinel: an approval that cannot complete must ROLL BACK any
+ * invitation accept it already made (a bare `return null` from a Drizzle transaction COMMITS —
+ * only a throw rolls back). Thrown inside the fence, caught at the boundary → the uniform null.
+ */
+const APPROVE_ABORT = Symbol("device-approve-abort");
+
 export async function approveDeviceAuth(
   userCode: string,
   approver: { userId: string; display: string },
 ): Promise<{ deviceId: string; requestedName: string } | null> {
-  return await getDb().transaction(async (tx) => {
-    const rows = await tx.execute(
-      sql`SELECT id, requested_name, requested_workspace, device_code_sha256,
-                 invite_token_sha256
-          FROM ${deviceAuthSession}
-          WHERE user_code = ${userCode} AND status = 'pending' AND expires_at > now()
-          FOR UPDATE`,
-    );
-    const row = rows.rows[0] as
-      | {
-          id: string;
-          requested_name: string;
-          requested_workspace: string;
-          device_code_sha256: Buffer;
-          invite_token_sha256: Buffer | null;
-        }
-      | undefined;
-    if (!row) {
-      return null;
-    }
-    // The invitation weave: a flow that carries an invite token accepts the invitation INSIDE
-    // this same fence when the approver is its rightful addressee — so a typed-code approval
-    // (never having visited the invitation page) still lands sign-in → accept → approve as one
-    // act, and the seat requirement below then finds the seat the accept just wrote. A token
-    // that resolves to nothing, or an approver the accept fences refuse (wrong account,
-    // unverified mailbox), changes NOTHING here — the seat check stays the sole authority.
-    if (row.invite_token_sha256 !== null) {
-      const inv = await lockPendingInvitationTx(
-        tx,
-        sql`i.token_sha256 = ${row.invite_token_sha256}`,
+  try {
+    return await getDb().transaction(async (tx) => {
+      const rows = await tx.execute(
+        sql`SELECT id, requested_name, requested_workspace, device_code_sha256,
+                   invite_token_sha256
+            FROM ${deviceAuthSession}
+            WHERE user_code = ${userCode} AND status = 'pending' AND expires_at > now()
+            FOR UPDATE`,
       );
-      if (inv !== null) {
-        await acceptInvitationTx(tx, inv, await sessionAccountTx(tx, approver), {
-          mailboxProven: false,
-        });
+      const row = rows.rows[0] as
+        | {
+            id: string;
+            requested_name: string;
+            requested_workspace: string;
+            device_code_sha256: Buffer;
+            invite_token_sha256: Buffer | null;
+          }
+        | undefined;
+      if (!row) {
+        return null;
       }
-    }
-    const resolved = await seatedFlowWorkspaceTx(tx, row.requested_workspace, approver.userId);
-    if (resolved === null) {
+      // The invitation weave: a flow that carries an invite token accepts the invitation INSIDE
+      // this same fence when the approver is its rightful addressee — so a typed-code approval
+      // (never having visited the invitation page) still lands sign-in → accept → approve as one
+      // act, and the seat requirement below then finds the seat the accept just wrote. A token
+      // that resolves to nothing, or an approver the accept fences refuse (wrong account,
+      // unverified mailbox), seats nothing.
+      let acceptedWorkspaceId: string | null = null;
+      if (row.invite_token_sha256 !== null) {
+        const inv = await lockPendingInvitationTx(
+          tx,
+          sql`i.token_sha256 = ${row.invite_token_sha256}`,
+        );
+        if (inv !== null) {
+          const outcome = await acceptInvitationTx(tx, inv, await sessionAccountTx(tx, approver), {
+            mailboxProven: false,
+          });
+          if (outcome.outcome === "accepted") {
+            acceptedWorkspaceId = outcome.workspaceId;
+          }
+        }
+      }
+      const resolved = await seatedFlowWorkspaceTx(tx, row.requested_workspace, approver.userId);
+      // The seat is the sole authority — a seatless approver's approval cannot complete. But an
+      // invite-weave accept may have already seated + consumed inside this tx, so a bare return
+      // would COMMIT that while the poll reports refused: throw to roll it back instead.
+      if (resolved === null) {
+        throw APPROVE_ABORT;
+      }
+      // Consistency: an accepted invitation must be for the SAME workspace this approval
+      // resolves to — otherwise the accept seated + consumed in a workspace the device is not
+      // being approved toward (a crafted flow: invite for A, requested_workspace naming B).
+      // Roll the whole thing back rather than commit a split-brain enrollment.
+      if (acceptedWorkspaceId !== null && acceptedWorkspaceId !== resolved.workspaceId) {
+        throw APPROVE_ABORT;
+      }
+      const deviceId = mintDeviceId();
+      await tx.insert(device).values({
+        id: deviceId,
+        userId: approver.userId,
+        displayName: row.requested_name,
+        credentialSha256: row.device_code_sha256,
+      });
+      await tx.execute(
+        sql`UPDATE ${deviceAuthSession}
+            SET status = 'approved', approved_by = ${approver.userId}, device_id = ${deviceId},
+                approved_workspace_id = ${resolved.workspaceId}
+            WHERE id = ${row.id}`,
+      );
+      await auditInTx(tx, {
+        workspaceId: resolved.workspaceId,
+        actor: { userId: approver.userId, display: approver.display },
+        kind: "device_approved",
+        subject: deviceId,
+        outcome: "ok",
+        details: { requestedName: row.requested_name },
+      });
+      return { deviceId, requestedName: row.requested_name };
+    });
+  } catch (error) {
+    // The clean-refusal rollback surfaces as the uniform null (the same answer an expired code
+    // gets); any other error is a real fault and propagates.
+    if (error === APPROVE_ABORT) {
       return null;
     }
-    const deviceId = mintDeviceId();
-    await tx.insert(device).values({
-      id: deviceId,
-      userId: approver.userId,
-      displayName: row.requested_name,
-      credentialSha256: row.device_code_sha256,
-    });
-    await tx.execute(
-      sql`UPDATE ${deviceAuthSession}
-          SET status = 'approved', approved_by = ${approver.userId}, device_id = ${deviceId},
-              approved_workspace_id = ${resolved.workspaceId}
-          WHERE id = ${row.id}`,
-    );
-    await auditInTx(tx, {
-      workspaceId: resolved.workspaceId,
-      actor: { userId: approver.userId, display: approver.display },
-      kind: "device_approved",
-      subject: deviceId,
-      outcome: "ok",
-      details: { requestedName: row.requested_name },
-    });
-    return { deviceId, requestedName: row.requested_name };
-  });
+    throw error;
+  }
 }
 
 /**

--- a/web/app/lib/db/identity.server.ts
+++ b/web/app/lib/db/identity.server.ts
@@ -281,6 +281,10 @@ export const DEVICE_AUTH_EXPIRES_IN_SECS = DEVICE_AUTH_TTL_MS / 1000;
 export async function startDeviceAuth(
   requestedName: string,
   requestedWorkspace: string,
+  /** The invite-link token a `follow <invite-url>` enrollment carries — hashed and RECORDED,
+   * never validated here (the unauthenticated start must not be a token oracle); the approval
+   * resolves it under its own fence. */
+  inviteToken?: string,
 ): Promise<{ deviceCode: string; userCode: string; expiresInSecs: number }> {
   const db = getDb();
   // Opportunistic reap: every new enrollment first clears expired ceremony rows (there is no
@@ -298,6 +302,9 @@ export async function startDeviceAuth(
         deviceCodeSha256: sql`${sha256OfText(deviceCode)}` as never,
         requestedName,
         requestedWorkspace,
+        ...(inviteToken === undefined
+          ? {}
+          : { inviteTokenSha256: sql`${sha256OfText(inviteToken)}` as never }),
         expiresAt,
       });
       return { deviceCode, userCode, expiresInSecs: DEVICE_AUTH_EXPIRES_IN_SECS };
@@ -311,6 +318,13 @@ export async function startDeviceAuth(
   throw new Error("device auth start: user_code space exhausted");
 }
 
+/** The first-destination hint an accepted invitation carried, decorated onto a granted poll
+ * (`kind` is the bundle catalog's own tag — 'skill' today — or the literal 'channel'). */
+export interface DeviceGrantHint {
+  kind: string;
+  name: string;
+}
+
 export type DevicePollResult =
   | { status: "pending" }
   | { status: "denied" }
@@ -322,6 +336,8 @@ export type DevicePollResult =
        * route's `workspace` decoration reads this immutable id, so a slug rename or a
        * delete+recreate inside the TTL can never re-point a granted flow. */
       approvedWorkspaceId: string | null;
+      /** The invitation hint, when the flow carried a token whose invitation names one. */
+      hint: DeviceGrantHint | null;
     };
 
 /**
@@ -335,7 +351,8 @@ export type DevicePollResult =
  */
 export async function pollDeviceAuth(deviceCode: string): Promise<DevicePollResult> {
   const rows = await getDb().execute(
-    sql`SELECT status, device_id, approved_workspace_id, expires_at < now() AS expired
+    sql`SELECT status, device_id, approved_workspace_id, invite_token_sha256,
+               expires_at < now() AS expired
         FROM ${deviceAuthSession}
         WHERE device_code_sha256 = ${sha256OfText(deviceCode)}`,
   );
@@ -344,6 +361,7 @@ export async function pollDeviceAuth(deviceCode: string): Promise<DevicePollResu
         status: string;
         device_id: string | null;
         approved_workspace_id: string | null;
+        invite_token_sha256: Buffer | null;
         expired: boolean;
       }
     | undefined;
@@ -360,10 +378,41 @@ export async function pollDeviceAuth(deviceCode: string): Promise<DevicePollResu
       status: "granted",
       deviceId: row.device_id,
       approvedWorkspaceId: row.approved_workspace_id,
+      hint:
+        row.invite_token_sha256 === null ? null : await inviteHintByHash(row.invite_token_sha256),
     };
   }
   // pending — expired pending is terminal (the human never approved in time).
   return row.expired ? { status: "expired" } : { status: "pending" };
+}
+
+/**
+ * The first-destination hint of the invitation a token hash names — ANY status (a granted
+ * flow's invitation was consumed by its own approval), the hinted thing resolved to its
+ * display name, active bundles only. The token hash is retained on the row for exactly this
+ * read.
+ */
+async function inviteHintByHash(tokenSha256: Buffer): Promise<DeviceGrantHint | null> {
+  const rows = await getDb().execute(
+    sql`SELECT b.kind AS bundle_kind, b.name AS bundle_name, c.name AS channel_name
+        FROM web.invitation i
+        LEFT JOIN web.bundle b ON b.id = i.hint_bundle_id AND b.status = 'active'
+        LEFT JOIN web.channel c ON c.id = i.hint_channel_id
+        WHERE i.token_sha256 = ${tokenSha256}`,
+  );
+  const row = rows.rows[0] as
+    | { bundle_kind: string | null; bundle_name: string | null; channel_name: string | null }
+    | undefined;
+  if (!row) {
+    return null;
+  }
+  if (row.bundle_name !== null) {
+    return { kind: row.bundle_kind ?? "skill", name: row.bundle_name };
+  }
+  if (row.channel_name !== null) {
+    return { kind: "channel", name: row.channel_name };
+  }
+  return null;
 }
 
 /**
@@ -432,7 +481,8 @@ export async function approveDeviceAuth(
 ): Promise<{ deviceId: string; requestedName: string } | null> {
   return await getDb().transaction(async (tx) => {
     const rows = await tx.execute(
-      sql`SELECT id, requested_name, requested_workspace, device_code_sha256
+      sql`SELECT id, requested_name, requested_workspace, device_code_sha256,
+                 invite_token_sha256
           FROM ${deviceAuthSession}
           WHERE user_code = ${userCode} AND status = 'pending' AND expires_at > now()
           FOR UPDATE`,
@@ -443,10 +493,28 @@ export async function approveDeviceAuth(
           requested_name: string;
           requested_workspace: string;
           device_code_sha256: Buffer;
+          invite_token_sha256: Buffer | null;
         }
       | undefined;
     if (!row) {
       return null;
+    }
+    // The invitation weave: a flow that carries an invite token accepts the invitation INSIDE
+    // this same fence when the approver is its rightful addressee — so a typed-code approval
+    // (never having visited the invitation page) still lands sign-in → accept → approve as one
+    // act, and the seat requirement below then finds the seat the accept just wrote. A token
+    // that resolves to nothing, or an approver the accept fences refuse (wrong account,
+    // unverified mailbox), changes NOTHING here — the seat check stays the sole authority.
+    if (row.invite_token_sha256 !== null) {
+      const inv = await lockPendingInvitationTx(
+        tx,
+        sql`i.token_sha256 = ${row.invite_token_sha256}`,
+      );
+      if (inv !== null) {
+        await acceptInvitationTx(tx, inv, await sessionAccountTx(tx, approver), {
+          mailboxProven: false,
+        });
+      }
     }
     const resolved = await seatedFlowWorkspaceTx(tx, row.requested_workspace, approver.userId);
     if (resolved === null) {
@@ -514,18 +582,69 @@ export async function denyDeviceAuth(
   });
 }
 
+/** The verify page's resolved request: what is asking, the code for the glance-check, and —
+ * when the flow carries an invite token that still resolves — the workspace the invitation
+ * would join (disclosed to the code-holder, who is the token-holder's own terminal). */
+export interface PendingDeviceAuthView {
+  requestedName: string;
+  requestedWorkspace: string;
+  userCode: string;
+  inviteWorkspace: { name: string; displayName: string } | null;
+}
+
 /** The verify page's lookup: the pending request a typed user_code names (display only). */
-export async function pendingDeviceAuth(
-  userCode: string,
-): Promise<{ requestedName: string; requestedWorkspace: string } | null> {
+export async function pendingDeviceAuth(userCode: string): Promise<PendingDeviceAuthView | null> {
+  return pendingDeviceAuthWhere(sql`user_code = ${userCode}`);
+}
+
+/**
+ * The loopback auto-open's lookup: the pending request whose device-code HASH the CLI put in
+ * the URL it opened (hex of the same SHA-256 this store already keys the row by — the code
+ * itself never enters a URL; a preimage is infeasible, so the challenge identifies without
+ * revealing). A malformed challenge is simply a miss.
+ */
+export async function pendingDeviceAuthByChallenge(
+  challengeHex: string,
+): Promise<PendingDeviceAuthView | null> {
+  if (!/^[0-9a-f]{64}$/.test(challengeHex)) {
+    return null;
+  }
+  return pendingDeviceAuthWhere(sql`device_code_sha256 = decode(${challengeHex}, 'hex')`);
+}
+
+async function pendingDeviceAuthWhere(
+  cond: ReturnType<typeof sql>,
+): Promise<PendingDeviceAuthView | null> {
   const rows = await getDb().execute(
-    sql`SELECT requested_name, requested_workspace FROM ${deviceAuthSession}
-        WHERE user_code = ${userCode} AND status = 'pending' AND expires_at > now()`,
+    sql`SELECT s.requested_name, s.requested_workspace, s.user_code,
+               w.name AS invite_ws_name, w.display_name AS invite_ws_display
+        FROM ${deviceAuthSession} s
+        LEFT JOIN web.invitation i ON i.token_sha256 = s.invite_token_sha256
+          AND i.status = 'pending' AND (i.expires_at IS NULL OR i.expires_at > now())
+        LEFT JOIN ${workspace} w ON w.id = i.workspace_id
+        WHERE ${cond} AND s.status = 'pending' AND s.expires_at > now()`,
   );
-  const row = rows.rows[0] as { requested_name: string; requested_workspace: string } | undefined;
-  return row
-    ? { requestedName: row.requested_name, requestedWorkspace: row.requested_workspace }
-    : null;
+  const row = rows.rows[0] as
+    | {
+        requested_name: string;
+        requested_workspace: string;
+        user_code: string;
+        invite_ws_name: string | null;
+        invite_ws_display: string | null;
+      }
+    | undefined;
+  if (!row) {
+    return null;
+  }
+  return {
+    requestedName: row.requested_name,
+    requestedWorkspace: row.requested_workspace,
+    userCode: row.user_code,
+    inviteWorkspace:
+      row.invite_ws_name === null
+        ? null
+        : { name: row.invite_ws_name, displayName: row.invite_ws_display ?? row.invite_ws_name },
+  };
 }
 
 // ── Step-up email confirmation (the password-less admin-ceremony rung) ──────────────────────
@@ -719,6 +838,436 @@ export async function bindInvitedSeats(
     }
     return bound;
   });
+}
+
+// ── The tokened invitation ceremonies (view · accept · decline) ─────────────────────────────
+//
+// The invite LINK is worth one invitation, never an account or a credential: viewing never
+// consumes (GET-safe for scanners), and the accept binds to the INVITED EMAIL's account — the
+// one sanctioned email comparison beside bindInvitedSeats above. Only the token's SHA-256 is
+// stored (the claim-code pattern); the plaintext travels in the invitation mail alone.
+
+/** Mint the single-use invite-link token (32 random bytes, base64url — URL-path-safe). The
+ * caller stores only its hash; the plaintext goes into the mailed link. */
+export function mintInviteToken(): string {
+  return mintSecret();
+}
+
+/**
+ * Supersede a DECLINED invitation record for an address being re-invited, inside the
+ * inviter's transaction — the audit trail keeps the permanent record; the members page stays
+ * clean. Email-keyed BY DESIGN (the same key the pending upsert conflicts on), which is why
+ * this row op lives here in the sanctioned module and not in the DAL.
+ */
+export async function supersedeDeclinedInvitationTx(
+  tx: Tx,
+  workspaceId: string,
+  email: string,
+): Promise<void> {
+  await tx.execute(
+    sql`DELETE FROM web.invitation
+        WHERE workspace_id = ${workspaceId} AND email = ${email} AND status = 'declined'`,
+  );
+}
+
+/** What the invitation page shows BEFORE accept: who invited, where to, the role, and what it
+ * delivers. Resolved only for a live (pending, unexpired) token — every other state is the one
+ * constant page, so nothing here leaks on a miss. */
+export interface InvitationView {
+  workspaceId: string;
+  workspaceName: string;
+  workspaceDisplayName: string;
+  /** The invited address (shown to the token-holder — the mailbox the link was sent to). */
+  email: string;
+  role: string;
+  inviterDisplay: string | null;
+  /** The first-destination hint (`kind` = the bundle catalog's tag, or 'channel'). */
+  hint: DeviceGrantHint | null;
+  /** Active bundles the default channels deliver to every member — the pre-accept summary. */
+  deliveredCount: number;
+  /** The default channels delivering them (usually just 'everyone'). */
+  viaChannels: string[];
+}
+
+/** The invitation a live token names, for the pre-accept summary. Null = the constant page. */
+export async function invitationByToken(token: string): Promise<InvitationView | null> {
+  const rows = await getDb().execute(
+    sql`SELECT i.workspace_id, i.email, i.role, w.name, w.display_name,
+               COALESCE(NULLIF(btrim(u.name), ''), u.email) AS inviter_display,
+               b.kind AS bundle_kind, b.name AS bundle_name, c.name AS channel_name
+        FROM web.invitation i
+        JOIN ${workspace} w ON w.id = i.workspace_id
+        LEFT JOIN web."user" u ON u.id = i.invited_by
+        LEFT JOIN web.bundle b ON b.id = i.hint_bundle_id AND b.status = 'active'
+        LEFT JOIN web.channel c ON c.id = i.hint_channel_id
+        WHERE i.token_sha256 = ${sha256OfText(token)} AND i.status = 'pending'
+          AND (i.expires_at IS NULL OR i.expires_at > now())`,
+  );
+  const row = rows.rows[0] as
+    | {
+        workspace_id: string;
+        email: string;
+        role: string;
+        name: string;
+        display_name: string;
+        inviter_display: string | null;
+        bundle_kind: string | null;
+        bundle_name: string | null;
+        channel_name: string | null;
+      }
+    | undefined;
+  if (!row) {
+    return null;
+  }
+  const delivered = await getDb().execute(
+    sql`SELECT c.name, count(DISTINCT cb.bundle_id)::int AS bundles
+        FROM web.channel c
+        JOIN web.channel_bundle cb ON cb.channel_id = c.id
+        JOIN web.bundle b ON b.id = cb.bundle_id AND b.status = 'active'
+        WHERE c.workspace_id = ${row.workspace_id} AND c.is_default
+        GROUP BY c.name`,
+  );
+  const via = delivered.rows as { name: string; bundles: number }[];
+  return {
+    workspaceId: row.workspace_id,
+    workspaceName: row.name,
+    workspaceDisplayName: row.display_name,
+    email: row.email,
+    role: row.role,
+    inviterDisplay: row.inviter_display,
+    hint:
+      row.bundle_name !== null
+        ? { kind: row.bundle_kind ?? "skill", name: row.bundle_name }
+        : row.channel_name !== null
+          ? { kind: "channel", name: row.channel_name }
+          : null,
+    deliveredCount: via.reduce((n, r) => n + r.bundles, 0),
+    viaChannels: via.map((r) => r.name),
+  };
+}
+
+/**
+ * Which arm the invitation page shows a visitor — decided HERE so the email-binding predicate
+ * never leaves this module (the route renders branches, it compares nothing):
+ *  - `anon_new` — no session, no account under the invited address: the account-minting accept;
+ *  - `anon_existing` — no session, the address has an account: sign in first, then return;
+ *  - `match` — signed in AS the invited address, mailbox proven: the one-click accept;
+ *  - `match_unverified` — signed in as the invited address but the mailbox was never proven:
+ *     one verification round-trip first (the true owner passes; a squatter cannot);
+ *  - `other` — signed in as a DIFFERENT account: the switch page (never accepts as current);
+ *  - `member` — signed in as the invited address AND already seated: redirect into the
+ *     workspace (the loader's redirect; nothing consumed on a GET).
+ */
+export type InvitationPageBranch =
+  | "anon_new"
+  | "anon_existing"
+  | "match"
+  | "match_unverified"
+  | "other"
+  | "member";
+
+/** The invitation page's whole server-side read: the view + the visitor's branch. */
+export async function invitationPageView(
+  token: string,
+  sessionUserId: string | null,
+): Promise<{ view: InvitationView; branch: InvitationPageBranch } | null> {
+  const view = await invitationByToken(token);
+  if (view === null) {
+    return null;
+  }
+  if (sessionUserId === null) {
+    const rows = await getDb().execute(
+      sql`SELECT 1 FROM web."user" WHERE lower(email) = ${view.email} LIMIT 1`,
+    );
+    return { view, branch: rows.rows.length > 0 ? "anon_existing" : "anon_new" };
+  }
+  const rows = await getDb().execute(
+    sql`SELECT email, email_verified FROM web."user" WHERE id = ${sessionUserId}`,
+  );
+  const row = rows.rows[0] as { email: string; email_verified: boolean } | undefined;
+  if (!row || row.email.trim().toLowerCase() !== view.email) {
+    return { view, branch: "other" };
+  }
+  const seated = await seatOf(sessionUserId, view.workspaceId);
+  if (seated !== undefined) {
+    return { view, branch: "member" };
+  }
+  return { view, branch: row.email_verified ? "match" : "match_unverified" };
+}
+
+/** The session account an accept fences against — email + its verification state alongside the
+ * branded actor facts. Resolved server-side from the user id, never from a form. */
+export interface SessionAccount {
+  userId: string;
+  display: string;
+  email: string;
+  emailVerified: boolean;
+}
+
+/** Read the acting account's email facts inside the caller's transaction (a deleted user reads
+ * as an empty account no invitation can match — fail-closed). */
+async function sessionAccountTx(
+  tx: Tx,
+  actor: { userId: string; display: string },
+): Promise<SessionAccount> {
+  const rows = await tx.execute(
+    sql`SELECT email, email_verified FROM web."user" WHERE id = ${actor.userId}`,
+  );
+  const row = rows.rows[0] as { email: string; email_verified: boolean } | undefined;
+  return {
+    userId: actor.userId,
+    display: actor.display,
+    email: row?.email ?? "",
+    emailVerified: row?.email_verified ?? false,
+  };
+}
+
+/** The row an accept/decline fence locks. */
+interface LockedInvitation {
+  id: string;
+  workspaceId: string;
+  email: string;
+  role: string;
+  invitedBy: string | null;
+  hintBundleId: string | null;
+  hintChannelId: string | null;
+}
+
+/** Lock ONE live (pending, unexpired) invitation row by an arbitrary predicate — the shared
+ * FOR-UPDATE fence of accept, decline, and the device-approval weave. */
+async function lockPendingInvitationTx(
+  tx: Tx,
+  cond: ReturnType<typeof sql>,
+): Promise<LockedInvitation | null> {
+  const rows = await tx.execute(
+    sql`SELECT i.id, i.workspace_id, i.email, i.role, i.invited_by,
+               i.hint_bundle_id, i.hint_channel_id
+        FROM web.invitation i
+        WHERE ${cond} AND i.status = 'pending'
+          AND (i.expires_at IS NULL OR i.expires_at > now())
+        FOR UPDATE`,
+  );
+  const row = rows.rows[0] as
+    | {
+        id: string;
+        workspace_id: string;
+        email: string;
+        role: string;
+        invited_by: string | null;
+        hint_bundle_id: string | null;
+        hint_channel_id: string | null;
+      }
+    | undefined;
+  if (!row) {
+    return null;
+  }
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    email: row.email,
+    role: row.role,
+    invitedBy: row.invited_by,
+    hintBundleId: row.hint_bundle_id,
+    hintChannelId: row.hint_channel_id,
+  };
+}
+
+export type InviteAcceptOutcome =
+  /** Consumed + seated (or already seated) — the landing facts ride along. */
+  | {
+      outcome: "accepted";
+      workspaceId: string;
+      workspaceName: string;
+      workspaceDisplayName: string;
+      hint: DeviceGrantHint | null;
+      alreadyMember: boolean;
+    }
+  /** No live invitation under this token — the one constant page. */
+  | { outcome: "gone" }
+  /** The session account is not the invited address — the switch page; never accepts. */
+  | { outcome: "wrong_account" }
+  /** The invited address's account never proved its mailbox — one round-trip first (the true
+   * owner passes; a squatter cannot). */
+  | { outcome: "unverified" };
+
+/**
+ * FENCE — the invitation accept, ONE transaction beside bindInvitedSeats: the email-binding
+ * predicate, the unverified-squat fence, consume the row, write the seat, apply the hint
+ * effects AFTER the seat (the seat-anchoring invariant: a follow without the workspace stays
+ * unrepresentable), audit — all under the caller's FOR-UPDATE lock on the invitation row, so
+ * two racing accepts serialize and exactly one consumes.
+ *
+ * `mailboxProven` marks the account-minting path, where possession of the mailed token IS the
+ * mailbox proof: the fence is satisfied and the account's email_verified flips true here.
+ */
+async function acceptInvitationTx(
+  tx: Tx,
+  inv: LockedInvitation,
+  account: SessionAccount,
+  opts: { mailboxProven: boolean },
+): Promise<InviteAcceptOutcome> {
+  if (account.email.trim().toLowerCase() !== inv.email) {
+    return { outcome: "wrong_account" };
+  }
+  if (!account.emailVerified && !opts.mailboxProven) {
+    return { outcome: "unverified" };
+  }
+  if (opts.mailboxProven && !account.emailVerified) {
+    await tx.execute(sql`UPDATE web."user" SET email_verified = true WHERE id = ${account.userId}`);
+  }
+  await tx.execute(
+    sql`UPDATE web.invitation
+        SET status = 'accepted', accepted_by = ${account.userId}, accepted_at = now()
+        WHERE id = ${inv.id}`,
+  );
+  const seated = await tx.execute(
+    sql`INSERT INTO ${seat} (workspace_id, user_id, role, invited_by)
+        VALUES (${inv.workspaceId}, ${account.userId}, ${inv.role}, ${inv.invitedBy})
+        ON CONFLICT (workspace_id, user_id) DO NOTHING
+        RETURNING user_id`,
+  );
+  const alreadyMember = seated.rows.length === 0;
+  // Hint effects — AFTER the seat row, same transaction. The hinted thing may have been
+  // deleted since the invite (the FK cleared the column) or archived; then nothing lands.
+  let hint: DeviceGrantHint | null = null;
+  if (inv.hintBundleId !== null) {
+    const named = await tx.execute(
+      sql`SELECT kind, name FROM web.bundle
+          WHERE id = ${inv.hintBundleId} AND workspace_id = ${inv.workspaceId}
+            AND status = 'active'`,
+    );
+    const row = named.rows[0] as { kind: string; name: string } | undefined;
+    if (row) {
+      await tx.execute(
+        sql`INSERT INTO web.bundle_subscription (user_id, workspace_id, bundle_id, state)
+            VALUES (${account.userId}, ${inv.workspaceId}, ${inv.hintBundleId}, 'following')
+            ON CONFLICT (user_id, bundle_id)
+            DO UPDATE SET state = 'following', updated_at = now()`,
+      );
+      hint = { kind: row.kind, name: row.name };
+    }
+  } else if (inv.hintChannelId !== null) {
+    const named = await tx.execute(
+      sql`SELECT name FROM web.channel
+          WHERE id = ${inv.hintChannelId} AND workspace_id = ${inv.workspaceId}`,
+    );
+    const row = named.rows[0] as { name: string } | undefined;
+    if (row) {
+      await tx.execute(
+        sql`INSERT INTO web.channel_member (channel_id, workspace_id, user_id, added_by)
+            VALUES (${inv.hintChannelId}, ${inv.workspaceId}, ${account.userId},
+                    ${inv.invitedBy})
+            ON CONFLICT (channel_id, user_id) DO NOTHING`,
+      );
+      hint = { kind: "channel", name: row.name };
+    }
+  }
+  await auditInTx(tx, {
+    workspaceId: inv.workspaceId,
+    actor: { userId: account.userId, display: account.display },
+    kind: "invitation_accepted",
+    subject: inv.email,
+    outcome: "ok",
+    details: { role: inv.role, ...(hint === null ? {} : { hint }) },
+  });
+  const ws = await tx.execute(
+    sql`SELECT name, display_name FROM ${workspace} WHERE id = ${inv.workspaceId}`,
+  );
+  const wsRow = ws.rows[0] as { name: string; display_name: string } | undefined;
+  return {
+    outcome: "accepted",
+    workspaceId: inv.workspaceId,
+    workspaceName: wsRow?.name ?? "",
+    workspaceDisplayName: wsRow?.display_name ?? wsRow?.name ?? "",
+    hint,
+    alreadyMember,
+  };
+}
+
+/** The invitation page's accept: lock the live row by token, run the fence. */
+export async function acceptInvitationByToken(
+  token: string,
+  actor: { userId: string; display: string },
+  opts: { mailboxProven: boolean },
+): Promise<InviteAcceptOutcome> {
+  return await getDb().transaction(async (tx) => {
+    const inv = await lockPendingInvitationTx(tx, sql`i.token_sha256 = ${sha256OfText(token)}`);
+    if (inv === null) {
+      return { outcome: "gone" };
+    }
+    return acceptInvitationTx(tx, inv, await sessionAccountTx(tx, actor), opts);
+  });
+}
+
+/**
+ * Decline — recorded (the inviter sees it; re-inviting mints a fresh row), and deliberately
+ * SESSION-LESS: possession of the mailed token is the same proof the account mint accepts, and
+ * demanding an account to say "no thanks" would be hostile. Uniform miss otherwise.
+ */
+export async function declineInvitationByToken(token: string): Promise<"declined" | "gone"> {
+  return await getDb().transaction(async (tx) => {
+    const inv = await lockPendingInvitationTx(tx, sql`i.token_sha256 = ${sha256OfText(token)}`);
+    if (inv === null) {
+      return "gone";
+    }
+    await tx.execute(sql`UPDATE web.invitation SET status = 'declined' WHERE id = ${inv.id}`);
+    await auditInTx(tx, {
+      workspaceId: inv.workspaceId,
+      actor: { display: inv.email },
+      kind: "invitation_declined",
+      subject: inv.email,
+      outcome: "ok",
+    });
+    return "declined";
+  });
+}
+
+/**
+ * The PERSON-scoped device resolve: credential → device → user, NO seat requirement — the
+ * guard of the device lane's invitation accept, where the caller by definition has no seat yet
+ * in the invitation's workspace. Fail-closed on a revoked device; last_seen_at rides along.
+ */
+export async function devicePerson(credential: string): Promise<SessionAccount | null> {
+  const rows = await getDb().execute(
+    sql`UPDATE ${device} d SET last_seen_at = now()
+        FROM web."user" u
+        WHERE d.credential_sha256 = ${sha256OfText(credential)}
+          AND d.revoked_at IS NULL
+          AND u.id = d.user_id
+        RETURNING d.user_id,
+          COALESCE(NULLIF(btrim(u.name), ''), u.email) AS user_display,
+          u.email, u.email_verified`,
+  );
+  const row = rows.rows[0] as
+    | { user_id: string; user_display: string; email: string; email_verified: boolean }
+    | undefined;
+  if (!row) {
+    return null;
+  }
+  return {
+    userId: row.user_id,
+    display: row.user_display,
+    email: row.email,
+    emailVerified: row.email_verified,
+  };
+}
+
+/**
+ * The passwordless account mint's bridge: park a single-use sign-in token in Better Auth's own
+ * verification store, shaped exactly as the magic-link plugin's verify endpoint consumes it —
+ * so the invitation page can mint the invited email's account + session THROUGH Better Auth's
+ * own door (hooks included) without sending any mail: the invite token's delivery to that
+ * mailbox already IS the proof. Short TTL; consumed atomically by the verify call.
+ */
+export async function mintInvitationSignIn(email: string): Promise<string> {
+  const token = mintSecret();
+  const expiresAt = new Date(Date.now() + 2 * 60 * 1000);
+  await getDb().execute(
+    sql`INSERT INTO web.verification (id, identifier, value, expires_at)
+        VALUES (${`iv_${randomBytes(16).toString("hex")}`}, ${token},
+                ${JSON.stringify({ email })}, ${expiresAt})`,
+  );
+  return token;
 }
 
 /** The admission read: the seat a user holds in a workspace (undefined = no admission). */

--- a/web/app/lib/db/queries.lane.server.ts
+++ b/web/app/lib/db/queries.lane.server.ts
@@ -12,6 +12,8 @@ import {
   entitledBundlesSql,
   mintChannelId,
   mintInvitationId,
+  mintInviteToken,
+  supersedeDeclinedInvitationTx,
 } from "@/lib/db/identity.server";
 import { getDb } from "@/lib/db/index.server";
 import { personDisplayLeftSql } from "@/lib/db/person-display.server";
@@ -809,26 +811,33 @@ export async function laneAckNotices(actor: DeviceActor, ids: string[]): Promise
 
 // ── Invitations (a claim on a FUTURE user; requires armed mail — the route gates that) ─────
 
-export type LaneInviteOutcome = "invited" | "owner_role_required" | "unknown_channel" | "bad_email";
+/** The device lane's minted invitations (folded address + fresh link token per address). */
+export type LaneInviteOutcome =
+  | { outcome: "invited"; minted: { email: string; token: string }[] }
+  | { outcome: "owner_role_required" }
+  | { outcome: "unknown_skill" }
+  | { outcome: "unknown_channel" }
+  | { outcome: "bad_email" };
 
 /**
  * The device lane's invitation write. The invite-policy gate runs against the actor's seat
- * role; every named channel must exist (resolve-all-or-apply-none — the old refusal, kept).
- * Channel PRE-PLACEMENT is gone with the identity unification: memberships are seat-anchored,
- * and an invitee has no seat until the verified sign-up binds one — the names are validated
- * and recorded on the audit row only.
+ * role. The optional FIRST-DESTINATION hint (at most one — a skill or a channel of this
+ * workspace, named by the caller) must resolve (all-or-none), lands on the invitation row, and
+ * is delivered by the accept ceremony: the seat first, then the direct follow / channel
+ * membership in the same transaction. Each invitation mints a fresh single-use link token
+ * (hash-stored); re-inviting an address supersedes its old link and any declined record.
  */
 export async function laneInvite(
   actor: DeviceActor,
   emails: string[],
-  channels: string[],
+  hint: { skill?: string; channel?: string },
 ): Promise<LaneInviteOutcome> {
   const ws = actor.workspaceId;
   const folded: string[] = [];
   for (const email of emails) {
     const canonical = foldInviteEmail(email);
     if (canonical === null) {
-      return "bad_email";
+      return { outcome: "bad_email" };
     }
     folded.push(canonical);
   }
@@ -839,25 +848,50 @@ export async function laneInvite(
       .where(eq(workspace.id, ws))
       .limit(1);
     if (wsRows[0]?.invitePolicy === "owners" && actor.role !== "owner") {
-      return "owner_role_required";
+      return { outcome: "owner_role_required" };
     }
-    for (const name of channels) {
+    let hintBundleId: string | null = null;
+    let hintChannelId: string | null = null;
+    if (hint.skill !== undefined) {
+      const rows = await tx
+        .select({ id: bundle.id })
+        .from(bundle)
+        .where(
+          and(eq(bundle.workspaceId, ws), eq(bundle.name, hint.skill), eq(bundle.status, "active")),
+        )
+        .limit(1);
+      if (rows.length === 0) {
+        return { outcome: "unknown_skill" };
+      }
+      hintBundleId = rows[0]?.id ?? null;
+    } else if (hint.channel !== undefined) {
       const rows = await tx
         .select({ id: channel.id })
         .from(channel)
-        .where(and(eq(channel.workspaceId, ws), eq(channel.name, name)))
+        .where(and(eq(channel.workspaceId, ws), eq(channel.name, hint.channel)))
         .limit(1);
       if (rows.length === 0) {
-        return "unknown_channel";
+        return { outcome: "unknown_channel" };
       }
+      hintChannelId = rows[0]?.id ?? null;
     }
     const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
+    const minted: { email: string; token: string }[] = [];
     for (const email of folded) {
+      const token = mintInviteToken();
+      await supersedeDeclinedInvitationTx(tx, ws, email);
       await tx.execute(sql`
-        insert into ${invitation} (id, workspace_id, email, role, status, invited_by, expires_at)
-        values (${mintInvitationId()}, ${ws}, ${email}, 'member', 'pending', ${actor.userId}, ${expiresAt})
+        insert into ${invitation}
+          (id, workspace_id, email, role, status, invited_by, expires_at,
+           token_sha256, hint_bundle_id, hint_channel_id)
+        values (${mintInvitationId()}, ${ws}, ${email}, 'member', 'pending', ${actor.userId},
+                ${expiresAt}, sha256(convert_to(${token}, 'UTF8')),
+                ${hintBundleId}, ${hintChannelId})
         on conflict (email, workspace_id) where status = 'pending'
         do update set invited_by = excluded.invited_by, expires_at = excluded.expires_at,
+                      token_sha256 = excluded.token_sha256,
+                      hint_bundle_id = excluded.hint_bundle_id,
+                      hint_channel_id = excluded.hint_channel_id,
                       created_at = now()
       `);
       await auditInTx(tx, {
@@ -866,10 +900,14 @@ export async function laneInvite(
         kind: "invitation_created",
         subject: email,
         outcome: "ok",
-        details: channels.length > 0 ? { channels } : {},
+        details: {
+          ...(hint.skill !== undefined ? { hint: { kind: "skill", name: hint.skill } } : {}),
+          ...(hint.channel !== undefined ? { hint: { kind: "channel", name: hint.channel } } : {}),
+        },
       });
+      minted.push({ email, token });
     }
-    return "invited";
+    return { outcome: "invited", minted };
   });
 }
 

--- a/web/app/lib/db/queries.roster.server.ts
+++ b/web/app/lib/db/queries.roster.server.ts
@@ -1,6 +1,11 @@
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import type { MemberActor } from "@/lib/auth/guards.server";
-import { auditInTx, mintInvitationId } from "@/lib/db/identity.server";
+import {
+  auditInTx,
+  mintInvitationId,
+  mintInviteToken,
+  supersedeDeclinedInvitationTx,
+} from "@/lib/db/identity.server";
 import { getDb } from "@/lib/db/index.server";
 import { personDisplaySql } from "@/lib/db/person-display.server";
 import { invitation, seat } from "@/lib/db/schema.app";
@@ -50,19 +55,44 @@ export async function rosterOf(actor: MemberActor): Promise<RosterSeat[]> {
 
 export type InvitationRow = typeof invitation.$inferSelect;
 
-/** The PENDING invitations (status + expiry render on the members page), newest first. */
+/**
+ * The OPEN invitations the members page shows: pending ones (with expiry), plus DECLINED ones —
+ * the recorded "no thanks" the inviter should see (re-inviting the address supersedes the
+ * declined row). Pending first, then by age.
+ */
 export async function pendingInvitationsOf(actor: MemberActor): Promise<InvitationRow[]> {
   return getDb()
     .select()
     .from(invitation)
-    .where(and(eq(invitation.workspaceId, actor.workspaceId), eq(invitation.status, "pending")))
-    .orderBy(asc(invitation.createdAt));
+    .where(
+      and(
+        eq(invitation.workspaceId, actor.workspaceId),
+        inArray(invitation.status, ["pending", "declined"]),
+      ),
+    )
+    .orderBy(sql`(${invitation.status} = 'pending') desc`, asc(invitation.createdAt));
 }
 
 /** Invitations lapse after seven days; re-inviting re-arms the clock. */
 export const INVITATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-export type InviteOutcome = "invited" | "owner_role_required" | "bad_email";
+/** One freshly minted invitation: the folded address + the single-use link token (the caller
+ * composes the mailed URL; only the token's hash is stored). */
+export interface MintedInvitation {
+  email: string;
+  token: string;
+}
+
+/** The optional first-destination hint, pre-resolved to a row id in the actor's workspace. */
+export interface InviteHintRef {
+  bundleId?: string;
+  channelId?: string;
+}
+
+export type InviteOutcome =
+  | { outcome: "invited"; minted: MintedInvitation[] }
+  | { outcome: "owner_role_required" }
+  | { outcome: "bad_email" };
 
 const MAX_EMAIL_LEN = 128;
 /** Path-safe + the mailbox specials — the same closed charset the wire folds. */
@@ -79,35 +109,47 @@ export function foldInviteEmail(email: string): string | null {
 
 /**
  * Seat one or more addresses as PENDING invitations (7-day lapse; re-inviting upserts onto the
- * pending partial-unique and re-arms the clock + the inviter attribution). The invite-policy
- * gate runs HERE against the actor's role (policy 'owners' refuses a plain member); the
- * mail-armed gate and the notice send run in the route. Every write lands its audit row in the
- * same transaction.
+ * pending partial-unique, re-arms the clock + the inviter attribution, and mints a FRESH link
+ * token — the old link dies with its hash). A prior DECLINED row for the address is superseded
+ * (deleted; the audit trail keeps the record). The invite-policy gate runs HERE against the
+ * actor's role (policy 'owners' refuses a plain member); the mail-armed gate and the notice
+ * send run in the route. Every write lands its audit row in the same transaction.
  */
 export async function createInvitations(
   actor: MemberActor,
   emails: string[],
   invitePolicy: "members" | "owners",
+  hint: InviteHintRef = {},
 ): Promise<InviteOutcome> {
   if (invitePolicy === "owners" && actor.role !== "owner") {
-    return "owner_role_required";
+    return { outcome: "owner_role_required" };
   }
   const folded: string[] = [];
   for (const email of emails) {
     const canonical = foldInviteEmail(email);
     if (canonical === null) {
-      return "bad_email";
+      return { outcome: "bad_email" };
     }
     folded.push(canonical);
   }
   const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
+  const minted: MintedInvitation[] = [];
   await getDb().transaction(async (tx) => {
     for (const email of folded) {
+      const token = mintInviteToken();
+      await supersedeDeclinedInvitationTx(tx, actor.workspaceId, email);
       await tx.execute(sql`
-        insert into ${invitation} (id, workspace_id, email, role, status, invited_by, expires_at)
-        values (${mintInvitationId()}, ${actor.workspaceId}, ${email}, 'member', 'pending', ${actor.userId}, ${expiresAt})
+        insert into ${invitation}
+          (id, workspace_id, email, role, status, invited_by, expires_at,
+           token_sha256, hint_bundle_id, hint_channel_id)
+        values (${mintInvitationId()}, ${actor.workspaceId}, ${email}, 'member', 'pending',
+                ${actor.userId}, ${expiresAt}, sha256(convert_to(${token}, 'UTF8')),
+                ${hint.bundleId ?? null}, ${hint.channelId ?? null})
         on conflict (email, workspace_id) where status = 'pending'
         do update set invited_by = excluded.invited_by, expires_at = excluded.expires_at,
+                      token_sha256 = excluded.token_sha256,
+                      hint_bundle_id = excluded.hint_bundle_id,
+                      hint_channel_id = excluded.hint_channel_id,
                       created_at = now()
       `);
       await auditInTx(tx, {
@@ -117,9 +159,10 @@ export async function createInvitations(
         subject: email,
         outcome: "ok",
       });
+      minted.push({ email, token });
     }
   });
-  return "invited";
+  return { outcome: "invited", minted };
 }
 
 export type RevokeInvitationOutcome = "revoked" | "missing";

--- a/web/app/lib/db/schema.app.ts
+++ b/web/app/lib/db/schema.app.ts
@@ -105,6 +105,12 @@ export const deviceAuthSession = webSchema.table(
      * mutable slug (a rename or delete+recreate inside the TTL must not re-point the flow).
      */
     approvedWorkspaceId: text("approved_workspace_id"),
+    /**
+     * SHA-256 of the invitation token a `follow <invite-url>` enrollment carries — recorded
+     * UNVALIDATED at the unauthenticated start (no token oracle); the approval resolves it
+     * under its own fence and weaves accept-the-invitation into the same transaction.
+     */
+    inviteTokenSha256: bytea("invite_token_sha256"),
     status: text("status").default("pending").notNull(),
     approvedBy: text("approved_by").references(() => user.id, { onDelete: "set null" }),
     deviceId: text("device_id").references(() => device.id, { onDelete: "cascade" }),
@@ -117,6 +123,10 @@ export const deviceAuthSession = webSchema.table(
     check(
       "device_auth_session_device_code_sha256_check",
       sql`octet_length(${table.deviceCodeSha256}) = 32`,
+    ),
+    check(
+      "device_auth_session_invite_token_sha256_check",
+      sql`${table.inviteTokenSha256} is null or octet_length(${table.inviteTokenSha256}) = 32`,
     ),
     check(
       "device_auth_session_status_check",
@@ -201,8 +211,15 @@ export const seat = webSchema.table(
 );
 
 /**
- * A claim on a FUTURE user; requires armed SMTP; binds at verified sign-up → seat.
- * expires_at NULL = does not lapse; the ceremony sets the product's actual policy.
+ * A claim on a FUTURE user; requires armed SMTP; binds at verified sign-up → seat, OR redeems
+ * through the tokened invite link (only the token's SHA-256 is stored — the claim-code
+ * pattern; re-inviting mints a fresh token over the pending row, killing the old link).
+ * expires_at NULL = does not lapse; the ceremony sets the product's actual policy. An
+ * invitation may carry ONE optional first-destination hint — a bundle OR a channel of its own
+ * workspace (at most one; workspace coherence FK-pinned in the migration's raw SQL with a
+ * per-column SET NULL, so deleting the hinted thing clears the hint and never the invitation).
+ * The token hash is KEPT after consumption: the device-flow grant looks the accepted
+ * invitation up by it to decorate the hint.
  */
 export const invitation = webSchema.table(
   "invitation",
@@ -214,6 +231,11 @@ export const invitation = webSchema.table(
     email: text("email").notNull(),
     role: text("role").default("member").notNull(),
     status: text("status").default("pending").notNull(),
+    /** SHA-256 of the single-use invite-link token; the plaintext travels only in the mail. */
+    tokenSha256: bytea("token_sha256").unique(),
+    /** The optional first-destination hint: at most one of the two references is set. */
+    hintBundleId: text("hint_bundle_id"),
+    hintChannelId: text("hint_channel_id"),
     invitedBy: text("invited_by").references(() => user.id, { onDelete: "set null" }),
     acceptedBy: text("accepted_by").references(() => user.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
@@ -227,7 +249,18 @@ export const invitation = webSchema.table(
       .where(sql`status = 'pending'`),
     check("invitation_email_check", sql`${table.email} = lower(${table.email})`),
     check("invitation_role_check", sql`${table.role} in ('owner', 'reviewer', 'member')`),
-    check("invitation_status_check", sql`${table.status} in ('pending', 'accepted', 'revoked')`),
+    check(
+      "invitation_status_check",
+      sql`${table.status} in ('pending', 'accepted', 'revoked', 'declined')`,
+    ),
+    check(
+      "invitation_token_sha256_check",
+      sql`${table.tokenSha256} is null or octet_length(${table.tokenSha256}) = 32`,
+    ),
+    check(
+      "invitation_hint_one_check",
+      sql`${table.hintBundleId} is null or ${table.hintChannelId} is null`,
+    ),
     // Anchored on accepted_at, NOT accepted_by: accepted_by is SET NULL on user deletion,
     // and a CHECK on it would make that deletion impossible.
     check(

--- a/web/app/lib/mail/invite-mail.server.ts
+++ b/web/app/lib/mail/invite-mail.server.ts
@@ -5,10 +5,11 @@ import { recordDevMail } from "@/lib/mail/dev-outbox.server";
 import { escapeHtml, mailDelivery, sendMail } from "@/lib/mail/transport.server";
 
 /**
- * The invitation-mail seam. Invitation is already durable WITHOUT any email: the vault seats the
- * invited address (a roster row) and the workspace's ADDRESS is the shareable door — so this seam
- * carries a courtesy notice, never a credential. There is no tokened link anywhere in it: a
- * recipient joins by asking their agent to `follow <address>` and proving the invited email.
+ * The invitation-mail seam. The mail is where the single-use INVITE LINK travels — worth one
+ * invitation, never an account or a credential (only the token's hash is stored server-side;
+ * the inviter's own surfaces never show it). Three ways in, in this order: the browser link
+ * (accept in one click), the agent paste-block, and the terminal line — the same tokened URL
+ * all three times, so whichever the recipient grabs redeems the same invitation.
  *
  * Delivery rides the ONE mail transport (`transport.server.ts`): with the five
  * `TOPOS_MAIL_SMTP_*` set, `inviteMailDelivery().canSend` is true and production really sends;
@@ -16,22 +17,23 @@ import { escapeHtml, mailDelivery, sendMail } from "@/lib/mail/transport.server"
  * production the notice is recorded to its OWN file, `.invite-emails.jsonl` (NEVER
  * `.magic-links.jsonl`, whose reader parses every line and would hand a sign-in flow the wrong
  * thing), the full mail to the accumulating dev outbox, plus the dev-server terminal — the
- * sanctioned non-email surfaces. A missing or failed send never loses the invite, because the
- * seat + the address already stand.
+ * sanctioned non-email surfaces. A missing or failed send never loses the invite: the
+ * invitation row stands, and re-inviting the address mints a fresh link.
  */
 
 export interface InviteEmailInput {
   to: string;
   /** The workspace's human-readable name (shown in the notice; user-entered). */
   workspaceDisplayName: string;
-  /** The workspace's FULL address (`<origin>/<name>`) — the door: `follow <address>`. Already the
-   * complete follow target (the caller composes it from the public base); never a bare slug, never a
-   * credential. */
-  address: string;
+  /** The tokened invitation URL — the door all three CTAs share. */
+  inviteUrl: string;
   /** The deployment's agent-onboarding doc (`<origin>/agent`) — the agent paste-block fetches it. */
   agentUrl: string;
   /** The inviter's email (attribution). */
   invitedBy: string;
+  /** The optional first-destination hint the invitation leads with (`kind` is the bundle
+   * catalog's tag — 'skill' today — or 'channel'). */
+  hint?: { kind: string; name: string };
 }
 
 export interface InviteMailDelivery {
@@ -45,42 +47,58 @@ export function inviteMailDelivery(): InviteMailDelivery {
 }
 
 /** The notice body — shared by the text mail and the dev recording (user-entered fields escaped
- * only in the HTML mirror). `address` is ALREADY the full follow target (`<origin>/<name>`), so both
- * the primary line and the terminal line render `topos follow <address>` verbatim — no origin is
- * ever prepended. */
-function inviteLines({ workspaceDisplayName, address, agentUrl, invitedBy }: InviteEmailInput): {
+ * only in the HTML mirror). The hint leads: a hinted invitation names its first destination in
+ * the subject and the opening line, because that is what the invitee was invited FOR. */
+function inviteLines({
+  workspaceDisplayName,
+  inviteUrl,
+  agentUrl,
+  invitedBy,
+  hint,
+}: InviteEmailInput): {
   subject: string;
   text: string;
   html: string;
 } {
-  const subject = `You've been invited to ${workspaceDisplayName} on Topos`;
-  const agentPaste = `Set up Topos for us: fetch ${agentUrl} and follow it. Our workspace: ${address}`;
+  const hintLead = hint === undefined ? "" : ` — starting with the ${hint.name} ${hint.kind}`;
+  const subject = `You're invited to ${workspaceDisplayName} on Topos${hintLead}`;
+  const intro =
+    `${invitedBy} invited you to ${workspaceDisplayName} on Topos — shared skills for your AI agents.` +
+    (hint === undefined ? "" : ` First up: the ${hint.name} ${hint.kind}.`);
+  const agentPaste = `Set up Topos for us: fetch ${agentUrl} and follow it. Our invite: ${inviteUrl}`;
   const text =
-    `${invitedBy} invited you to ${workspaceDisplayName} on Topos — shared skills for your AI agents.\n\n` +
-    `Ask your agent to join — paste this to it:\n\n` +
+    `${intro}\n\n` +
+    `Accept in your browser:\n\n` +
+    `  ${inviteUrl}\n\n` +
+    `Or ask your agent to join — paste this to it:\n\n` +
     `  ${agentPaste}\n\n` +
-    `Or from a terminal: topos follow ${address}\n\n` +
-    `If you weren't expecting this, you can ignore this email.\n`;
+    `Or from a terminal: topos follow ${inviteUrl}\n\n` +
+    `This link is for you alone and lapses after a while. If you weren't expecting it, you can ignore this email.\n`;
   const html =
-    `<p>${escapeHtml(invitedBy)} invited you to <strong>${escapeHtml(workspaceDisplayName)}</strong> on Topos — shared skills for your AI agents.</p>` +
-    `<p>Ask your agent to join — paste this to it:</p>` +
+    `<p>${escapeHtml(invitedBy)} invited you to <strong>${escapeHtml(workspaceDisplayName)}</strong> on Topos — shared skills for your AI agents.${
+      hint === undefined
+        ? ""
+        : ` First up: the <strong>${escapeHtml(hint.name)}</strong> ${escapeHtml(hint.kind)}.`
+    }</p>` +
+    `<p><a href="${escapeHtml(inviteUrl)}">Accept in your browser</a></p>` +
+    `<p>Or ask your agent to join — paste this to it:</p>` +
     `<p><code>${escapeHtml(agentPaste)}</code></p>` +
-    `<p>Or from a terminal: <code>topos follow ${escapeHtml(address)}</code></p>` +
-    `<p>If you weren't expecting this, you can ignore this email.</p>`;
+    `<p>Or from a terminal: <code>topos follow ${escapeHtml(inviteUrl)}</code></p>` +
+    `<p>This link is for you alone and lapses after a while. If you weren't expecting it, you can ignore this email.</p>`;
   return { subject, text, html };
 }
 
 /**
- * Send (or record, outside production) an invitation notice carrying the workspace display name +
- * ADDRESS. Callers may treat a throw as "notice not sent" and keep the seat + the address
- * standing — a mail-seam fault never fails an invite.
+ * Send (or record, outside production) an invitation notice carrying the tokened invite link.
+ * Callers may treat a throw as "notice not sent" — the invitation row stands regardless, and
+ * re-inviting mints a fresh link.
  */
 export async function sendInviteEmail(input: InviteEmailInput): Promise<void> {
   const appEnv = serverEnv().APP_ENV;
   if (appEnv === "production") {
     if (!mailDelivery().canSend) {
-      // No transport wired — the deliberate no-op posture: the invite is durable regardless
-      // (the roster seat + the shareable address already stand) and `mailed` honestly said so.
+      // No transport wired — the deliberate no-op posture: the invitation row is durable and
+      // the honest `mailed` flag already said nothing was delivered.
       return;
     }
     const { subject, text, html } = inviteLines(input);
@@ -89,14 +107,14 @@ export async function sendInviteEmail(input: InviteEmailInput): Promise<void> {
   }
   // Dev/test: record the notice to its OWN file so a flow can assert it (never a send, never the
   // magic-link file), plus the full mail to the accumulating dev outbox. The recorded fields
-  // carry the full workspace address (`<origin>/<name>`), never a token.
-  const { to, workspaceDisplayName, address, invitedBy } = input;
-  const line = `${JSON.stringify({ to, workspaceDisplayName, address, invitedBy })}\n`;
+  // carry the tokened invite URL — the dev-mode stand-in for the recipient's mailbox.
+  const { to, workspaceDisplayName, inviteUrl, invitedBy, hint } = input;
+  const line = `${JSON.stringify({ to, workspaceDisplayName, inviteUrl, invitedBy, ...(hint === undefined ? {} : { hint }) })}\n`;
   await fs.appendFile(path.join(process.cwd(), ".invite-emails.jsonl"), line, "utf8");
   const { subject, text, html } = inviteLines(input);
   await recordDevMail("invite", { to, subject, text, html });
   if (appEnv === "development") {
     // biome-ignore lint/suspicious/noConsole: the deliberate dev-only invite surface.
-    console.log(`\n  Invite for ${to} (dev — mail suppressed): follow ${address}\n`);
+    console.log(`\n  Invite for ${to} (dev — mail suppressed): ${inviteUrl}\n`);
   }
 }

--- a/web/app/lib/plane/contract/schema.d.ts
+++ b/web/app/lib/plane/contract/schema.d.ts
@@ -485,6 +485,18 @@ export interface components {
              */
             version_id: string;
         };
+        /**
+         * @description The first-destination HINT an accepted invitation named — decorated onto a `granted` poll (and
+         *     the direct-accept answer) so the enrolled client's post-accept subscribe can target it. `kind`
+         *     is the bundle catalog's own tag (`skill` today) or the literal `channel` — displayed and routed
+         *     on, never trusted as authority.
+         */
+        DeviceAuthHint: {
+            /** @description What the hinted thing is: the catalog's `kind` tag, or `channel`. */
+            kind: string;
+            /** @description The hinted bundle's or channel's name in the joined workspace. */
+            name: string;
+        };
         /** @description `POST /v1/device/token` body — poll a device-authorization flow for its outcome. */
         DeviceAuthPollRequest: {
             /** @description The SECRET device code from `device/authorize`. */
@@ -503,6 +515,7 @@ export interface components {
             credential?: string | null;
             /** @description The registered device's id — present ONLY when `status` is `granted`. */
             device_id?: string | null;
+            hint?: null | components["schemas"]["DeviceAuthHint"];
             /** @description The poll status. */
             status: components["schemas"]["DeviceAuthPollStatus"];
             workspace?: null | components["schemas"]["DeviceAuthWorkspace"];
@@ -519,6 +532,12 @@ export interface components {
          *     the same flow to the same uniform denial.
          */
         DeviceAuthStartRequest: {
+            /**
+             * @description The invitation-link token a `follow <invite-url>` enrollment carries. Recorded on the flow
+             *     (as its hash) UNVALIDATED — this unauthenticated start is never a token oracle; the approval
+             *     ceremony resolves it and weaves the invitation accept into its own fence.
+             */
+            invite_token?: string | null;
             /**
              * @description A human-readable device name shown on the approval page (a confused-deputy guard, not
              *     authority) and kept as the device's display name once approved.
@@ -553,13 +572,11 @@ export interface components {
              *     secret).
              */
             user_code: string;
-            /** @description The approval URL a signed-in human visits. */
-            verification_uri: string;
             /**
-             * @description The approval URL with the user code already embedded — the one link to open; a client uses
-             *     it VERBATIM when present.
+             * @description The approval URL a signed-in human visits. The code NEVER rides a URL: the client prints
+             *     this bare address and the short code on separate lines, and the page's lookup is a POST.
              */
-            verification_uri_complete: string;
+            verification_uri: string;
         };
         /**
          * @description The workspace context a `granted` poll carries — everything the CLI needs to record what it
@@ -590,8 +607,9 @@ export interface components {
             workspace_id: string;
         };
         /**
-         * @description `POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the workspace
-         *     ADDRESS (the whole invitation besides the roster rows themselves).
+         * @description `POST /v1/workspaces/{ws}/invitations` success `data` — what the inviter pastes onward: the
+         *     workspace ADDRESS. Deliberately NOT the tokened link: the link travels only in the invitation
+         *     mail, so the inviter's receipt can never stand in for the invitee's mailbox.
          */
         InvitationData: {
             /** @description The workspace address (the share link — it carries nothing; the roster is the lock). */
@@ -602,20 +620,47 @@ export interface components {
             mailed: boolean;
         };
         /**
-         * @description `POST /v1/workspaces/{ws}/invitations` body — invitation as a ROSTER WRITE: seat each email as an
-         *     invited member (recording who invited whom) and optionally pre-place the person into channels.
-         *     There is no invite link and no role field — every CLI invitee starts as a member (roles are raised
-         *     later, on the web), and joining is `follow <address>` plus proof of the invited email. Member-level
-         *     unless the workspace's invite policy restricts inviting to owners.
+         * @description `POST /v1/workspaces/{ws}/invitations` body — invitation as an INVITATION-ROW write: each email
+         *     becomes a pending 7-day claim redeemable through the single-use link the server MAILS (the token
+         *     never appears in this exchange — the mailbox is its one channel). At most ONE optional
+         *     first-destination hint (a skill or a channel of this workspace) rides the invitation and is
+         *     delivered by the accept. No role field — every CLI invitee starts as a member (roles are raised
+         *     later, on the web). Member-level unless the workspace's invite policy restricts inviting to
+         *     owners.
          */
         InvitationRequest: {
             /**
-             * @description Channel names to pre-place each invitee into (re-inviting restores placements; the structural
-             *     `everyone` needs no placement and is accepted as a no-op).
+             * @description The first-destination CHANNEL hint (a channel name in this workspace). At most one of
+             *     `skill`/`channel` may be set.
              */
-            channels?: string[];
+            channel?: string | null;
             /** @description The emails to seat as invited members (folded to the canonical lowercase form server-side). */
             emails: string[];
+            /**
+             * @description The first-destination SKILL hint (a bundle name in this workspace). At most one of
+             *     `skill`/`channel` may be set.
+             */
+            skill?: string | null;
+        };
+        /**
+         * @description `POST /v1/invitations/accept` success `data` — the joined workspace + the optional
+         *     first-destination hint the client's post-accept subscribe targets. Nothing lands on any device
+         *     from this accept: bytes still move only through the device-side two-phase describe/consent.
+         */
+        InviteAcceptData: {
+            hint?: null | components["schemas"]["DeviceAuthHint"];
+            /** @description The workspace the accept seated the person in. */
+            workspace: components["schemas"]["DeviceAuthWorkspace"];
+        };
+        /**
+         * @description `POST /v1/invitations/accept` body — the ALREADY-ENROLLED device consuming an invite URL: the
+         *     bearer credential authenticates the person (seat-LESS by construction — the caller has no seat
+         *     in the invitation's workspace yet), and the token names the invitation. The same ceremony
+         *     fences as the browser accept apply; an invalid/expired/consumed token answers the uniform 404.
+         */
+        InviteAcceptRequest: {
+            /** @description The invitation-link token (the mailed single-use secret). */
+            token: string;
         };
         /**
          * @description The one common envelope every verb emits. Never prompts; prose (TTY) is rendered from the
@@ -1503,7 +1548,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description The device-authorization grant: the secret device_code to poll with (promoted to the device's ONE bearer credential on approval), the human-facing user_code, and the approval URLs. */
+            /** @description The device-authorization grant: the secret device_code to poll with (promoted to the device's ONE bearer credential on approval), the human-facing user_code, and the BARE approval URL (the code never rides a URL; the approval page's lookup is a POST). An invite_token in the body is recorded on the flow unvalidated — never a token oracle. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -1554,7 +1599,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description The poll status; `granted` carries the ONE bearer credential (the promoted device code), the device id, and the joined workspace. */
+            /** @description The poll status; `granted` carries the ONE bearer credential (the promoted device code), the device id, the joined workspace, and — when the flow carried an invitation naming one — the first-destination hint. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -2492,7 +2537,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description The invitation receipt — OK carries the InvitationData (address + invited + the honest mailed flag); a policy refusal is a 200 DENIED OWNER_ROLE_REQUIRED, an unknown channel a 200 DENIED UNKNOWN_CHANNEL. */
+            /** @description The invitation receipt — OK carries the InvitationData (address + invited + the honest mailed flag; the tokened invite link travels ONLY in the mail); a policy refusal is a 200 DENIED OWNER_ROLE_REQUIRED, an unresolvable hint a 200 DENIED UNKNOWN_SKILL / UNKNOWN_CHANNEL, an unarmed mail transport a 200 DENIED MAIL_NOT_CONFIGURED. */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/web/app/lib/ws-url.server.ts
+++ b/web/app/lib/ws-url.server.ts
@@ -37,3 +37,15 @@ export function workspaceAddress(request: Request, workspaceName: string): strin
 export function agentDocUrl(request: Request): string {
   return `${followBase(request)}/agent`;
 }
+
+/**
+ * The tokened invitation URL the invite mail carries — worth ONE invitation, never an account.
+ * Single tenancy → origin-rooted `/invite/<token>`; multi → `<origin>/<name>/invite/<token>`.
+ * Same origin resolution as the follow address (`followBase`), so the browser link, the agent
+ * paste-block, and the terminal line in one mail all root identically.
+ */
+export function inviteUrl(request: Request, workspaceName: string, token: string): string {
+  const base = followBase(request);
+  const root = composition.tenancy === "multi" ? `${base}/${workspaceName}` : base;
+  return `${root}/invite/${token}`;
+}

--- a/web/app/lib/ws-url.server.ts
+++ b/web/app/lib/ws-url.server.ts
@@ -43,6 +43,16 @@ export function agentDocUrl(request: Request): string {
  * Single tenancy → origin-rooted `/invite/<token>`; multi → `<origin>/<name>/invite/<token>`.
  * Same origin resolution as the follow address (`followBase`), so the browser link, the agent
  * paste-block, and the terminal line in one mail all root identically.
+ *
+ * SECURITY — this is a CAPABILITY url: the token in it is the invitation. Its trust is only as
+ * good as the origin it roots at, so a deployment that admits invitations MUST pin
+ * `TOPOS_PUBLIC_URL` (the canonical origin `followBase` then returns). Absent that pin,
+ * `followBase` falls back to the request's own Host — the same app-wide posture the claim link
+ * and the device-flow verification URL already carry — and behind a proxy that forwards
+ * arbitrary Host headers an authenticated inviter could root the mailed link at a host they
+ * control, phishing the invitee's click for the token. The compose stack and every hosted
+ * deployment set `TOPOS_PUBLIC_URL`; a single-node install serving one trusted origin is safe
+ * because there is no other host to forge.
  */
 export function inviteUrl(request: Request, workspaceName: string, token: string): string {
   const base = followBase(request);

--- a/web/app/routes/api.v1.device-authorize.ts
+++ b/web/app/routes/api.v1.device-authorize.ts
@@ -36,6 +36,7 @@ import { isWorkspaceNameShape } from "@/lib/workspace-name";
  */
 const BODY_CAP = 8 * 1024;
 const MAX_REQUESTED_NAME = 200;
+const MAX_INVITE_TOKEN = 512;
 
 export async function action({ request }: ActionFunctionArgs): Promise<Response> {
   const belted = checkBelt(request);
@@ -55,7 +56,7 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   } catch {
     return badRequest("malformed JSON body");
   }
-  const body = parsed as { requested_name?: unknown; workspace?: unknown };
+  const body = parsed as { requested_name?: unknown; workspace?: unknown; invite_token?: unknown };
   if (
     typeof parsed !== "object" ||
     parsed === null ||
@@ -65,6 +66,17 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
     typeof body.workspace !== "string"
   ) {
     return badRequest("malformed device authorize body");
+  }
+  // The optional invitation token a `follow <invite-url>` enrollment carries: recorded (as its
+  // hash) UNVALIDATED — this start is unauthenticated and must not be a token oracle. The
+  // approval resolves it under its own fence.
+  if (
+    body.invite_token !== undefined &&
+    (typeof body.invite_token !== "string" ||
+      body.invite_token.length === 0 ||
+      body.invite_token.length > MAX_INVITE_TOKEN)
+  ) {
+    return badRequest("malformed device authorize body: invite_token");
   }
 
   let requestedWorkspace: string;
@@ -87,13 +99,19 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
     requestedWorkspace = ws.name;
   }
 
-  const flow = await startDeviceAuth(body.requested_name.trim(), requestedWorkspace);
+  const flow = await startDeviceAuth(
+    body.requested_name.trim(),
+    requestedWorkspace,
+    body.invite_token as string | undefined,
+  );
   const origin = followBase(request);
+  // The code never enters ANY URL: the CLI prints the bare /verify address and the short code
+  // on separate lines, and the human types the code into the page's POST form (the retired
+  // `verification_uri_complete` embedded it in a GET — a leak into history/logs, gone).
   return Response.json({
     device_code: flow.deviceCode,
     user_code: flow.userCode,
     verification_uri: `${origin}/verify`,
-    verification_uri_complete: `${origin}/verify?code=${encodeURIComponent(flow.userCode)}`,
     expires_in_secs: flow.expiresInSecs,
     interval_secs: DEVICE_AUTH_POLL_INTERVAL_SECS,
   });

--- a/web/app/routes/api.v1.device-token.ts
+++ b/web/app/routes/api.v1.device-token.ts
@@ -47,6 +47,9 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   }
   const ws =
     result.approvedWorkspaceId === null ? null : await workspaceRowById(result.approvedWorkspaceId);
+  // `hint` decorates a grant whose flow carried an invitation naming a first destination — the
+  // CLI's post-enrollment subscribe targets it (else the workspace set), through the ordinary
+  // two-phase describe.
   return Response.json({
     status: "granted",
     credential: deviceCode,
@@ -60,6 +63,7 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
             display_name: ws.displayName,
           },
         }),
+    ...(result.hint === null ? {} : { hint: result.hint }),
   });
 }
 

--- a/web/app/routes/api.v1.invitation-accept.ts
+++ b/web/app/routes/api.v1.invitation-accept.ts
@@ -1,0 +1,86 @@
+import type { ActionFunctionArgs } from "react-router";
+import { checkBelt } from "@/lib/api/belt.server";
+import { deniedCodeEnvelope, okDataEnvelope } from "@/lib/api/row-envelopes.server";
+import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
+import { requireDevicePerson } from "@/lib/auth/guards.server";
+import { acceptInvitationByToken } from "@/lib/db/identity.server";
+
+/**
+ * `POST /api/v1/invitations/accept` — the ALREADY-ENROLLED device consuming an invite URL: it
+ * is authenticated (Bearer → device → person, seat-LESS by construction — the caller has no
+ * seat in the invitation's workspace yet), so the accept runs directly over the device lane
+ * with no browser. The same ceremony fences apply as on the invitation page: the invitation
+ * binds to the invited email's account (wrong account → a typed DENIED naming no address), an
+ * unverified mailbox is refused toward the browser link, and an invalid/expired/consumed token
+ * answers the uniform wire 404 — no token oracle.
+ *
+ * The OK answer carries the joined workspace and the optional first-destination hint — what
+ * the CLI's post-accept subscribe describes. Nothing lands on any device from this accept:
+ * bytes still move only through the device-side two-phase describe/consent.
+ */
+const BODY_CAP = 8 * 1024;
+const MAX_TOKEN = 512;
+
+export async function action({ request }: ActionFunctionArgs): Promise<Response> {
+  const belted = checkBelt(request);
+  if (belted !== null) {
+    return belted;
+  }
+  if (request.method !== "POST") {
+    return uniformNotFound();
+  }
+  const raw = await readCappedBody(request, BODY_CAP, "invitation accept body");
+  if (raw instanceof Response) {
+    return raw;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return badRequest("malformed JSON body");
+  }
+  const token = (parsed as { token?: unknown }).token;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof token !== "string" ||
+    token.length === 0 ||
+    token.length > MAX_TOKEN
+  ) {
+    return badRequest("malformed invitation accept body");
+  }
+
+  const person = await requireDevicePerson(request);
+  const result = await acceptInvitationByToken(
+    token,
+    { userId: person.userId, display: person.display },
+    { mailboxProven: false },
+  );
+  switch (result.outcome) {
+    case "accepted":
+      return okDataEnvelope("invite_accept", {
+        workspace: {
+          workspace_id: result.workspaceId,
+          name: result.workspaceName,
+          display_name: result.workspaceDisplayName,
+        },
+        ...(result.hint === null ? {} : { hint: result.hint }),
+      });
+    case "wrong_account":
+      // The caller HOLDS the token (the mailed link), so refusing typed is honest — but the
+      // refusal names no address on either side.
+      return deniedCodeEnvelope("invite_accept", "INVITE_OTHER_ACCOUNT");
+    case "unverified":
+      return deniedCodeEnvelope("invite_accept", "EMAIL_UNVERIFIED");
+    default:
+      // gone — invalid, expired, revoked, or already consumed: the uniform non-answer.
+      return uniformNotFound();
+  }
+}
+
+/** Any other HTTP method on this served path is the uniform 404 — the door owns it, so a
+ * wrong-method probe answers the same envelope as a miss, never react-router's 400/405 (which
+ * would leak the route's existence and, in dev, a stack). */
+export function loader(): Response {
+  return uniformNotFound();
+}

--- a/web/app/routes/api.v1.invitations.ts
+++ b/web/app/routes/api.v1.invitations.ts
@@ -5,19 +5,20 @@ import { badRequest, internalError, readCappedBody, uniformNotFound } from "@/li
 import { requireDeviceActor } from "@/lib/auth/guards.server";
 import { laneInvite, laneMe } from "@/lib/db/queries.lane.server";
 import { inviteMailDelivery, sendInviteEmail } from "@/lib/mail/invite-mail.server";
-import { agentDocUrl, workspaceAddress } from "@/lib/ws-url.server";
+import { agentDocUrl, inviteUrl, workspaceAddress } from "@/lib/ws-url.server";
 
 /**
  * `POST /api/v1/workspaces/{ws}/invitations` — invitation as an INVITATION-ROW write: each
- * email becomes a pending 7-day claim on a future user, and the answer carries the workspace
- * ADDRESS (the roster is the lock; there is no invite link). Member-level unless the workspace
- * restricts inviting to owners.
+ * email becomes a pending 7-day claim on a future user, redeemable through the single-use link
+ * the mail carries (the link travels ONLY in the mail — the inviter's receipt shows the
+ * workspace address, never the token). At most ONE optional first-destination hint (`skill` or
+ * `channel`, a name in this workspace) rides the invitation and is delivered by the accept.
+ * Member-level unless the workspace restricts inviting to owners.
  *
- * INVITING REQUIRES ARMED MAIL now: the mailbox round-trip is the invited sign-up's identity
- * rung, so on an unarmed deployment the op refuses TYPED (`MAIL_NOT_CONFIGURED`) — an
- * invitation that could never be verified would admit nothing and mislead the inviter.
- * ORDERING mirrors the door's posture: a malformed body is a 400 BEFORE the credential
- * resolve; a malformed email is a 400 AFTER auth.
+ * INVITING REQUIRES ARMED MAIL: the mailbox is where the tokened link travels, so on an
+ * unarmed deployment the op refuses TYPED (`MAIL_NOT_CONFIGURED`) — an invitation nobody could
+ * receive would mislead the inviter. ORDERING mirrors the door's posture: a malformed body is
+ * a 400 BEFORE the credential resolve; a malformed email is a 400 AFTER auth.
  */
 const BODY_CAP = 64 * 1024;
 
@@ -42,16 +43,18 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (typeof parsed !== "object" || parsed === null) {
     return badRequest("malformed invitation body");
   }
-  const body = parsed as { emails?: unknown; channels?: unknown };
+  const body = parsed as { emails?: unknown; skill?: unknown; channel?: unknown };
   if (!Array.isArray(body.emails) || !body.emails.every((e) => typeof e === "string")) {
     return badRequest("malformed invitation body: emails");
   }
-  let channels: string[] = [];
-  if (body.channels !== undefined) {
-    if (!Array.isArray(body.channels) || !body.channels.every((c) => typeof c === "string")) {
-      return badRequest("malformed invitation body: channels");
-    }
-    channels = body.channels as string[];
+  if (body.skill !== undefined && typeof body.skill !== "string") {
+    return badRequest("malformed invitation body: skill");
+  }
+  if (body.channel !== undefined && typeof body.channel !== "string") {
+    return badRequest("malformed invitation body: channel");
+  }
+  if (body.skill !== undefined && body.channel !== undefined) {
+    return badRequest("an invitation carries at most one first destination — skill OR channel");
   }
 
   const actor = await requireDeviceActor(request, params.ws ?? "");
@@ -62,30 +65,48 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (me === null) {
     return uniformNotFound();
   }
-  const outcome = await laneInvite(actor, body.emails as string[], channels);
-  if (outcome === "bad_email") {
+  const hint = {
+    ...(body.skill !== undefined ? { skill: body.skill as string } : {}),
+    ...(body.channel !== undefined ? { channel: body.channel as string } : {}),
+  };
+  const outcome = await laneInvite(actor, body.emails as string[], hint);
+  if (outcome.outcome === "bad_email") {
     return badRequest("malformed invitee email");
   }
-  if (outcome === "invited") {
+  if (outcome.outcome === "invited") {
     const address = workspaceAddress(request, me.name);
-    const invited = (body.emails as string[]).map((e) => e.trim().toLowerCase());
+    const mailHint =
+      body.skill !== undefined
+        ? { kind: "skill", name: body.skill as string }
+        : body.channel !== undefined
+          ? { kind: "channel", name: body.channel as string }
+          : undefined;
     // Fire-and-forget invitation mail per invitee (the rows already stand; a mail fault never
-    // fails the invite — the lapse clock simply runs).
-    for (const to of invited) {
+    // fails the invite — re-inviting mints a fresh link). The tokened URL goes ONLY into the
+    // mail; the receipt below carries the workspace address.
+    for (const one of outcome.minted) {
       void sendInviteEmail({
-        to,
-        address,
+        to: one.email,
+        inviteUrl: inviteUrl(request, me.name, one.token),
         agentUrl: agentDocUrl(request),
         workspaceDisplayName: me.displayName,
         invitedBy: actor.display,
+        ...(mailHint === undefined ? {} : { hint: mailHint }),
       }).catch(() => {});
     }
-    return okDataEnvelope("invite", { address, invited, mailed: true });
+    return okDataEnvelope("invite", {
+      address,
+      invited: outcome.minted.map((m) => m.email),
+      mailed: true,
+    });
   }
-  if (outcome === "owner_role_required") {
+  if (outcome.outcome === "owner_role_required") {
     return deniedCodeEnvelope("invite", "OWNER_ROLE_REQUIRED");
   }
-  if (outcome === "unknown_channel") {
+  if (outcome.outcome === "unknown_skill") {
+    return deniedCodeEnvelope("invite", "UNKNOWN_SKILL");
+  }
+  if (outcome.outcome === "unknown_channel") {
     return deniedCodeEnvelope("invite", "UNKNOWN_CHANNEL");
   }
   return internalError();

--- a/web/app/routes/invite-redeem.tsx
+++ b/web/app/routes/invite-redeem.tsx
@@ -108,6 +108,27 @@ function acceptLanding(
   return wsPathServer(workspaceName);
 }
 
+/**
+ * This page's own address, rebuilt from scratch: the request pathname is normalized (React
+ * Router's single-fetch client requests address `<path>.data`, and a redirect built from that
+ * raw pathname would compound the suffix into a broken token) and only the VALIDATED
+ * pass-through params ride the query — never whatever else the URL carried.
+ */
+function selfInvitePath(url: URL, device: DeviceParams | null): string {
+  const pathname = url.pathname.replace(/\.data$/, "");
+  if (device === null) {
+    return pathname;
+  }
+  const qs = new URLSearchParams({ device: device.device });
+  if (device.port !== null) {
+    qs.set("port", device.port);
+  }
+  if (device.state !== null) {
+    qs.set("state", device.state);
+  }
+  return `${pathname}?${qs.toString()}`;
+}
+
 export async function loader({ request, params }: LoaderFunctionArgs) {
   requireBelt(request);
   const token = params.token ?? "";
@@ -128,8 +149,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return {
     state: "view" as const,
     branch,
-    /** This page's own path+query — the sign-in return target, computed server-side. */
-    selfPath: `${url.pathname}${url.search}`,
+    /** This page's own path (+ validated params) — the sign-in return target. */
+    selfPath: selfInvitePath(url, device),
     // The invited address is shown to the token-holder (it is their own mailbox' mail);
     // the session's own email backs the switch page's "you are signed in as".
     invitedEmail: view.email,
@@ -154,7 +175,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const token = params.token ?? "";
   const url = new URL(request.url);
   const device = deviceParamsFrom(url);
-  const self = `${url.pathname}${url.search}`;
+  const self = selfInvitePath(url, device);
   const form = await request.formData();
   const intent = String(form.get("intent") ?? "");
   const auth = getAuth();

--- a/web/app/routes/invite-redeem.tsx
+++ b/web/app/routes/invite-redeem.tsx
@@ -1,0 +1,598 @@
+import type { ReactNode } from "react";
+import {
+  type ActionFunctionArgs,
+  Form,
+  Link,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+  redirect,
+  useActionData,
+  useLoaderData,
+  useNavigation,
+} from "react-router";
+import { buttonClasses, Chip } from "@/components/ui";
+import { composition } from "@/composition.server";
+import { actorFromSession, notFound } from "@/lib/auth/guards.server";
+import { withInvitationCeremony } from "@/lib/auth/registration.server";
+import { getAuth } from "@/lib/auth/server";
+import {
+  acceptInvitationByToken,
+  type DeviceGrantHint,
+  declineInvitationByToken,
+  invitationPageView,
+  mintInvitationSignIn,
+} from "@/lib/db/identity.server";
+import { mailDelivery } from "@/lib/mail/transport.server";
+import { personDisplay } from "@/lib/person-display";
+import { allowPublicRead, clientKeyFromXff } from "@/lib/rate-limit.server";
+import { wsPathServer } from "@/lib/ws-url.server";
+
+export const meta: MetaFunction = () => [{ title: "Invitation · Topos" }];
+
+/**
+ * The tokened INVITATION page — the mailed link's landing. The link is worth one invitation,
+ * never an account or a credential: viewing NEVER consumes (GET-safe for mail scanners);
+ * accept and decline are explicit POSTs. The invitation binds to the INVITED EMAIL's account:
+ * signed in as it → one-click accept; no such account → this page mints it (email locked to
+ * the invited address; passwordless where a mail sign-in rung exists — the token's delivery to
+ * that mailbox IS the proof, so no verification mail); signed in as someone else → the switch
+ * page, never an accept as the current account. Every dead token — invalid, expired, revoked,
+ * already used — renders ONE constant message that names neither the workspace nor any email.
+ *
+ * A terminal-first arrival (the CLI's `follow <invite-url>`) rides the same page carrying the
+ * device-flow pass-through params; after the accept it continues into `/verify` so sign-in →
+ * accept → device approval land as one visit.
+ */
+
+/** The URL carries the single-use token — never cached, never indexed. */
+export function headers() {
+  return { "Cache-Control": "no-store", "X-Robots-Tag": "noindex" };
+}
+
+/** The public-probe belt (the claim page's posture): a belted client gets the uniform miss. */
+function requireBelt(request: Request): void {
+  if (!allowPublicRead(clientKeyFromXff(request.headers.get("x-forwarded-for")))) {
+    notFound();
+  }
+}
+
+/** The ONE constant answer for every dead link — nothing about the workspace or the email. */
+const GONE =
+  "This invitation link isn't active. It may have been used already, expired, or been replaced by a newer one — ask whoever invited you for a fresh link.";
+
+/** The device-flow pass-through params a CLI-started arrival carries (all non-secret; the
+ * short code itself never enters a URL). Validated by shape, dropped otherwise. */
+interface DeviceParams {
+  device: string;
+  port: string | null;
+  state: string | null;
+}
+
+function deviceParamsFrom(url: URL): DeviceParams | null {
+  const device = url.searchParams.get("device") ?? "";
+  if (!/^[0-9a-f]{64}$/.test(device)) {
+    return null;
+  }
+  const port = url.searchParams.get("port");
+  const state = url.searchParams.get("state");
+  return {
+    device,
+    port: port !== null && /^\d{4,5}$/.test(port) ? port : null,
+    state: state !== null && /^[A-Za-z0-9_-]{8,128}$/.test(state) ? state : null,
+  };
+}
+
+/** Where an accepted invitation lands: the /verify weave when a device flow is waiting, else
+ * the hinted page, else the workspace root. */
+function acceptLanding(
+  workspaceName: string,
+  hint: DeviceGrantHint | null,
+  device: DeviceParams | null,
+): string {
+  if (device !== null) {
+    const qs = new URLSearchParams({ device: device.device });
+    if (device.port !== null) {
+      qs.set("port", device.port);
+    }
+    if (device.state !== null) {
+      qs.set("state", device.state);
+    }
+    return `/verify?${qs.toString()}`;
+  }
+  if (hint !== null) {
+    return wsPathServer(
+      workspaceName,
+      hint.kind === "channel" ? `channels/${hint.name}` : `skills/${hint.name}`,
+    );
+  }
+  return wsPathServer(workspaceName);
+}
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  requireBelt(request);
+  const token = params.token ?? "";
+  const url = new URL(request.url);
+  const device = deviceParamsFrom(url);
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  const actor = actorFromSession(session);
+  const resolved = token === "" ? null : await invitationPageView(token, actor?.userId ?? null);
+  if (resolved === null) {
+    return { state: "gone" as const, message: GONE };
+  }
+  const { view, branch } = resolved;
+  if (branch === "member") {
+    // Already a member: straight into the workspace (the hinted page when one is named).
+    // Nothing consumed — a GET stays a view.
+    throw redirect(acceptLanding(view.workspaceName, view.hint, device));
+  }
+  return {
+    state: "view" as const,
+    branch,
+    /** This page's own path+query — the sign-in return target, computed server-side. */
+    selfPath: `${url.pathname}${url.search}`,
+    // The invited address is shown to the token-holder (it is their own mailbox' mail);
+    // the session's own email backs the switch page's "you are signed in as".
+    invitedEmail: view.email,
+    signedInEmail: branch === "other" ? (session?.user?.email ?? "") : null,
+    workspaceDisplayName: view.workspaceDisplayName,
+    inviterDisplay: view.inviterDisplay,
+    role: view.role,
+    deliveredCount: view.deliveredCount,
+    viaChannels: view.viaChannels,
+    hint: view.hint,
+    // Account-mint mode: passwordless when a mail sign-in rung exists, else a password field.
+    passwordless: Boolean(composition.auth.magicLink),
+    mailArmed: mailDelivery().canSend,
+    hasDeviceFlow: device !== null,
+  };
+}
+
+const CREATE_FAILED = "Couldn't finish accepting the invitation. Try the link again.";
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  requireBelt(request);
+  const token = params.token ?? "";
+  const url = new URL(request.url);
+  const device = deviceParamsFrom(url);
+  const self = `${url.pathname}${url.search}`;
+  const form = await request.formData();
+  const intent = String(form.get("intent") ?? "");
+  const auth = getAuth();
+
+  if (intent === "decline") {
+    // Deliberately session-less: possession of the mailed token is the proof, and saying
+    // "no thanks" must not require creating an account first.
+    const declined = await declineInvitationByToken(token);
+    if (declined === "gone") {
+      throw redirect(self);
+    }
+    return { kind: "declined" as const };
+  }
+
+  if (intent === "switch") {
+    // Sign the CURRENT account out and return here — the page then offers sign-in or the
+    // account mint for the invited address. Never accepts as the current account.
+    const out = await auth.api.signOut({ headers: request.headers, returnHeaders: true });
+    const headers = new Headers();
+    for (const cookie of out.headers.getSetCookie()) {
+      headers.append("set-cookie", cookie);
+    }
+    throw redirect(self, { headers });
+  }
+
+  if (intent === "send-verification") {
+    const session = await auth.api.getSession({ headers: request.headers });
+    const email = session?.user?.email;
+    if (typeof email !== "string" || email.length === 0 || !mailDelivery().canSend) {
+      throw redirect(self);
+    }
+    await auth.api
+      .sendVerificationEmail({ body: { email }, headers: request.headers })
+      .catch(() => {});
+    return { kind: "verification_sent" as const };
+  }
+
+  if (intent === "accept") {
+    const session = await auth.api.getSession({ headers: request.headers });
+    const actor = actorFromSession(session);
+    if (actor === null) {
+      throw redirect(self);
+    }
+    const result = await acceptInvitationByToken(
+      token,
+      { userId: actor.userId, display: actor.display },
+      { mailboxProven: false },
+    );
+    if (result.outcome !== "accepted") {
+      // The loader recomputes the honest state for every refusal (gone → the constant page,
+      // wrong account → the switch page, unverified → the round-trip prompt).
+      throw redirect(self);
+    }
+    throw redirect(acceptLanding(result.workspaceName, result.hint, device));
+  }
+
+  if (intent === "accept-new") {
+    // The account-minting accept — only for a visitor with NO session, and only while the
+    // invited address has NO account (decision: the link never signs into an existing
+    // account). Both re-checked server-side; the loader's branch is just UI.
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (actorFromSession(session) !== null) {
+      throw redirect(self);
+    }
+    const resolved = await invitationPageView(token, null);
+    if (resolved === null) {
+      throw redirect(self);
+    }
+    if (resolved.branch !== "anon_new") {
+      throw redirect(self);
+    }
+    const invitedEmail = resolved.view.email;
+    const name = String(form.get("name") ?? "").trim();
+    const passwordless = Boolean(composition.auth.magicLink);
+
+    let userId: string;
+    let display: string;
+    const cookieHeaders = new Headers();
+    if (passwordless) {
+      // Mint the account THROUGH Better Auth's own magic-link door, no mail involved: the
+      // invite token's delivery to this mailbox is already the proof, so a server-minted
+      // single-use sign-in token bridges straight to the verify endpoint (which creates the
+      // user with a proven mailbox and mints the session).
+      const signIn = await mintInvitationSignIn(invitedEmail);
+      const result = await withInvitationCeremony(() =>
+        auth.api.magicLinkVerify({
+          query: { token: signIn },
+          headers: request.headers,
+          returnHeaders: true,
+        }),
+      ).catch(() => null);
+      if (result === null) {
+        return { kind: "error" as const, message: CREATE_FAILED };
+      }
+      for (const cookie of result.headers.getSetCookie()) {
+        cookieHeaders.append("set-cookie", cookie);
+      }
+      userId = result.response.user.id;
+      display = personDisplay(name, invitedEmail);
+      if (name.length > 0) {
+        // The optional display name rides the account (the magic-link mint is born with '').
+        await auth.api
+          .updateUser({ body: { name }, headers: sessionHeaders(request, cookieHeaders) })
+          .catch(() => {});
+      }
+    } else {
+      const password = String(form.get("password") ?? "");
+      if (password.length < 8) {
+        return {
+          kind: "error" as const,
+          message: "Choose a password of at least 8 characters.",
+        };
+      }
+      display = personDisplay(name, invitedEmail);
+      const result = await withInvitationCeremony(() =>
+        auth.api.signUpEmail({
+          body: { email: invitedEmail, password, name: display },
+          returnHeaders: true,
+        }),
+      ).catch(() => null);
+      if (result === null) {
+        return { kind: "error" as const, message: CREATE_FAILED };
+      }
+      for (const cookie of result.headers.getSetCookie()) {
+        cookieHeaders.append("set-cookie", cookie);
+      }
+      userId = result.response.user.id;
+    }
+
+    // The accept itself — mailboxProven: holding the mailed token IS the mailbox round-trip,
+    // so the fresh account's address is marked verified inside the same transaction.
+    const accepted = await acceptInvitationByToken(
+      token,
+      { userId, display },
+      { mailboxProven: true },
+    );
+    if (accepted.outcome !== "accepted") {
+      // A race consumed the token between the resolve and the accept: the account stands (a
+      // harmless orphan that can sign in and admits nothing); the page answers constantly.
+      throw redirect(self, { headers: cookieHeaders });
+    }
+    throw redirect(acceptLanding(accepted.workspaceName, accepted.hint, device), {
+      headers: cookieHeaders,
+    });
+  }
+
+  throw redirect(self);
+}
+
+/** Merge freshly minted session cookies into a follow-up same-request API call's headers. */
+function sessionHeaders(request: Request, minted: Headers): Headers {
+  const headers = new Headers(request.headers);
+  const cookies: string[] = [];
+  const existing = request.headers.get("cookie");
+  if (existing !== null) {
+    cookies.push(existing);
+  }
+  for (const setCookie of minted.getSetCookie()) {
+    const pair = setCookie.split(";")[0];
+    if (pair !== undefined) {
+      cookies.push(pair);
+    }
+  }
+  headers.set("cookie", cookies.join("; "));
+  return headers;
+}
+
+const INPUT =
+  "block h-11 w-full rounded-md border border-line px-3 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25";
+
+export default function InvitePage() {
+  const data = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+
+  if (actionData?.kind === "declined") {
+    return (
+      <Shell>
+        <PlainState heading="Invitation declined">
+          Nothing was joined, and whoever invited you can see you passed. If you change your mind,
+          ask them to invite you again.
+        </PlainState>
+      </Shell>
+    );
+  }
+
+  if (data.state === "gone") {
+    return (
+      <Shell>
+        <PlainState heading="Nothing to accept here">{data.message}</PlainState>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <div className="flex flex-col gap-6">
+        <Summary data={data} />
+        {actionData?.kind === "error" && (
+          <p className="text-center text-red-600 text-sm" role="alert">
+            {actionData.message}
+          </p>
+        )}
+        {actionData?.kind === "verification_sent" && (
+          <p className="text-center text-dim text-sm" role="status">
+            Verification mail sent — open it, confirm, then come back to this link.
+          </p>
+        )}
+        <BranchArm data={data} />
+      </div>
+    </Shell>
+  );
+}
+
+type ViewData = Extract<Awaited<ReturnType<typeof loader>>, { state: "view" }>;
+
+/** The pre-accept summary: who invited, where to, the role, and what it delivers. */
+function Summary({ data }: { data: ViewData }) {
+  const delivers =
+    data.deliveredCount > 0
+      ? `${data.deliveredCount} shared ${data.deliveredCount === 1 ? "skill" : "skills"} via ${data.viaChannels.map((c) => `#${c}`).join(", ")}`
+      : "the team's shared skills as they land";
+  return (
+    <div className="flex flex-col gap-3 text-center">
+      <p className="font-medium text-faint text-xs uppercase tracking-wide">Invitation</p>
+      <h1 className="font-display font-semibold text-ink text-lg tracking-[-0.02em]">
+        {data.inviterDisplay ?? "A member"} invited you to {data.workspaceDisplayName}
+      </h1>
+      {data.hint !== null && (
+        <p className="text-ink text-sm">
+          First up: <span className="font-medium">{data.hint.name}</span> ({data.hint.kind}) —
+          accepting follows it for you.
+        </p>
+      )}
+      <p className="text-dim text-sm">
+        Joining seats you as <Chip tone="accent">{data.role}</Chip> and delivers {delivers} to your
+        AI agents — kept current automatically.
+      </p>
+      <p className="text-faint text-xs">
+        This invitation is for <span className="font-mono">{data.invitedEmail}</span>.
+      </p>
+    </div>
+  );
+}
+
+function BranchArm({ data }: { data: ViewData }) {
+  switch (data.branch) {
+    case "match":
+      return <OneClickAccept />;
+    case "match_unverified":
+      return <UnverifiedFence mailArmed={data.mailArmed} />;
+    case "other":
+      return <SwitchAccount invitedEmail={data.invitedEmail} signedInEmail={data.signedInEmail} />;
+    case "anon_existing":
+      return <SignInFirst invitedEmail={data.invitedEmail} selfPath={data.selfPath} />;
+    default:
+      return <CreateAccount passwordless={data.passwordless} />;
+  }
+}
+
+/** Signed in as the invited address — a live session plus the explicit click is the ceremony. */
+function OneClickAccept() {
+  const busy = useNavigation().state !== "idle";
+  return (
+    <div className="flex flex-col gap-3">
+      <Form method="post">
+        <input type="hidden" name="intent" value="accept" />
+        <button
+          type="submit"
+          disabled={busy}
+          className={`${buttonClasses("primary")} min-h-11 w-full`}
+        >
+          {busy ? "Working…" : "Accept invitation"}
+        </button>
+      </Form>
+      <DeclineArm />
+    </div>
+  );
+}
+
+/** A brand-new person: the account mint, email locked to the invited address. */
+function CreateAccount({ passwordless }: { passwordless: boolean }) {
+  const busy = useNavigation().state !== "idle";
+  return (
+    <div className="flex flex-col gap-3">
+      <Form method="post" className="flex flex-col gap-3">
+        <input type="hidden" name="intent" value="accept-new" />
+        <label className="block">
+          <span className="mb-1 block font-medium text-dim text-sm">Your name (optional)</span>
+          <input
+            type="text"
+            name="name"
+            autoComplete="name"
+            className={INPUT}
+            placeholder="Ada Lovelace"
+          />
+        </label>
+        {!passwordless && (
+          <label className="block">
+            <span className="mb-1 block font-medium text-dim text-sm">Choose a password</span>
+            <input
+              type="password"
+              name="password"
+              required
+              minLength={8}
+              autoComplete="new-password"
+              className={INPUT}
+              placeholder="••••••••"
+            />
+          </label>
+        )}
+        <button
+          type="submit"
+          disabled={busy}
+          className={`${buttonClasses("primary")} min-h-11 w-full`}
+        >
+          {busy ? "Working…" : "Accept and create my account"}
+        </button>
+        {passwordless && (
+          <p className="text-center text-faint text-xs">
+            No password needed — this link came to your mailbox, and future sign-ins go the same
+            way.
+          </p>
+        )}
+      </Form>
+      <DeclineArm />
+    </div>
+  );
+}
+
+/** The invited address already has an account — sign in first, then return here. */
+function SignInFirst({ invitedEmail, selfPath }: { invitedEmail: string; selfPath: string }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <Link
+        to={`/login?next=${encodeURIComponent(selfPath)}`}
+        className={`${buttonClasses("primary")} flex min-h-11 w-full items-center justify-center`}
+      >
+        Sign in as {invitedEmail} to accept
+      </Link>
+      <DeclineArm />
+    </div>
+  );
+}
+
+/** Signed in as someone else — name the invited address, offer switching; never accept. */
+function SwitchAccount({
+  invitedEmail,
+  signedInEmail,
+}: {
+  invitedEmail: string;
+  signedInEmail: string | null;
+}) {
+  const busy = useNavigation().state !== "idle";
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-center text-dim text-sm">
+        You're signed in as <span className="font-mono text-ink">{signedInEmail ?? "…"}</span>, but
+        this invitation is for <span className="font-mono text-ink">{invitedEmail}</span>. Switch
+        accounts to accept it.
+      </p>
+      <Form method="post">
+        <input type="hidden" name="intent" value="switch" />
+        <button
+          type="submit"
+          disabled={busy}
+          className={`${buttonClasses("primary")} min-h-11 w-full`}
+        >
+          Sign out and continue as {invitedEmail}
+        </button>
+      </Form>
+      <DeclineArm />
+    </div>
+  );
+}
+
+/** Signed in as the invited address, but the mailbox was never proven — one round-trip first. */
+function UnverifiedFence({ mailArmed }: { mailArmed: boolean }) {
+  const busy = useNavigation().state !== "idle";
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-center text-dim text-sm">
+        Your account hasn't verified this address yet — confirm it once and the invitation is yours
+        to accept.
+      </p>
+      {mailArmed ? (
+        <Form method="post">
+          <input type="hidden" name="intent" value="send-verification" />
+          <button
+            type="submit"
+            disabled={busy}
+            className={`${buttonClasses("primary")} min-h-11 w-full`}
+          >
+            Send the verification mail
+          </button>
+        </Form>
+      ) : (
+        <p className="text-center text-faint text-xs">
+          This server has no outgoing mail set up — ask its operator to arm SMTP, or to verify your
+          address another way.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** The quiet decline — recorded; whoever invited you sees it; re-invitable. */
+function DeclineArm() {
+  const busy = useNavigation().state !== "idle";
+  return (
+    <Form method="post" className="text-center">
+      <input type="hidden" name="intent" value="decline" />
+      <button
+        type="submit"
+        disabled={busy}
+        className="text-faint text-xs underline-offset-2 hover:underline"
+      >
+        Decline this invitation
+      </button>
+    </Form>
+  );
+}
+
+function PlainState({ heading, children }: { heading: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col items-center gap-2 text-center">
+      <p className="font-medium text-faint text-xs uppercase tracking-wide">Invitation</p>
+      <h1 className="font-display font-semibold text-ink text-lg tracking-[-0.02em]">{heading}</h1>
+      <p className="text-dim text-sm">{children}</p>
+    </div>
+  );
+}
+
+function Shell({ children }: { children: ReactNode }) {
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col justify-center px-4 py-10">
+      <div className="rounded-lg border border-line-soft bg-panel p-6 shadow-sm sm:p-8">
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/web/app/routes/skill-current.tsx
+++ b/web/app/routes/skill-current.tsx
@@ -1,16 +1,29 @@
-import type { LoaderFunctionArgs } from "react-router";
-import { redirect, useLoaderData } from "react-router";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { data, redirect, useLoaderData } from "react-router";
 import { VersionFiles } from "@/components/browse/version-files";
 import { SkillHeader } from "@/components/skill/skill-header";
+import { SkillInviteAffordance } from "@/components/skill/skill-invite";
 import { SkillTabs } from "@/components/skill/skill-tabs";
 import { Card } from "@/components/ui";
-import { actorFromSession, memberInScope, notFound } from "@/lib/auth/guards.server";
+import {
+  actorFromSession,
+  type MemberActor,
+  memberInScope,
+  notFound,
+  requireMemberInScope,
+  type ScopedWorkspace,
+} from "@/lib/auth/guards.server";
 import { getAuth } from "@/lib/auth/server";
 import { loadVersionFilesData } from "@/lib/browse/version-files.server";
+import { recordAdminEvent } from "@/lib/db/audit.server";
+import { workspacePolicyOf } from "@/lib/db/queries.policy.server";
+import { createInvitations, foldInviteEmail } from "@/lib/db/queries.roster.server";
 import { skillIndexRow } from "@/lib/db/queries.server";
 import { resolveSkillName } from "@/lib/db/resolve.server";
+import { sendInviteEmail } from "@/lib/mail/invite-mail.server";
+import { mailDelivery } from "@/lib/mail/transport.server";
 import { useWsPath } from "@/lib/ws-path";
-import { wsPathServer } from "@/lib/ws-url.server";
+import { agentDocUrl, inviteUrl, wsPathServer } from "@/lib/ws-url.server";
 
 export function meta({ params }: { params: { skill?: string } }) {
   return [{ title: `${params.skill ?? "skill"} · Topos` }];
@@ -50,10 +63,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     notFound();
   }
 
-  const versionFiles =
+  const [policy, versionFiles] = await Promise.all([
+    workspacePolicyOf(memberActor),
     row.versionId !== null
-      ? await loadVersionFilesData(memberActor, row.skillId, row.versionId)
-      : null;
+      ? loadVersionFilesData(memberActor, row.skillId, row.versionId)
+      : Promise.resolve(null),
+  ]);
 
   return {
     face: "page" as const,
@@ -65,7 +80,96 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     openProposals: row.openProposals,
     versionId: row.versionId,
     versionFiles,
+    // The invite affordance's gates, resolved once here and never re-read client-side: armed mail
+    // is the invitation's identity rung, and the invite-policy decides whether a plain member may
+    // invite at all — the same two facts the members page surfaces.
+    mailArmed: mailDelivery().canSend,
+    invitePolicy: policy.invitePolicy,
+    isOwner: memberActor.role === "owner",
   };
+}
+
+/**
+ * The skill face's action — ONE intent today, `invite`: minting an invitation whose FIRST
+ * destination is THIS skill (the affordance below). It RE-GUARDS from scratch — a loader's gate
+ * never carries into an action — with the member scope the face itself requires (an anonymous
+ * request bounces to the constant /login before any skill read; a non-member and an unknown slug
+ * land the same uniform 404). Member scope is the FLOOR; the invite branch re-reads the
+ * invite-policy against the actor's role itself. An unmatched intent is a 400 that only a member
+ * can ever reach.
+ */
+export async function action({ request, params }: ActionFunctionArgs) {
+  const { workspace, actor } = await requireMemberInScope(request, params);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+  if (intent === "invite") {
+    return inviteToSkillIntent(request, workspace, actor, params.skill as string, formData);
+  }
+  return data({ intent: "unknown" as const, status: "error" as const }, { status: 400 });
+}
+
+/**
+ * Invite a teammate to THIS skill. Inviting is a member op the invite-policy gates (createInvitations
+ * runs that gate against the actor's role) and it REQUIRES armed mail — the invitation's identity
+ * proof is a mailbox round-trip, so an unarmed deployment refuses honestly instead of seating a
+ * claim nobody can prove. The skill's catalog row supplies the invitation's first-destination hint
+ * (the bundle id stored on the row) AND the display facts the mail's subject/opening line lead with;
+ * an unknown skill name is the same uniform 404 the face throws. A send fault never loses the
+ * invitation — the row stands and re-inviting mints a fresh link — but the reply says so honestly.
+ */
+async function inviteToSkillIntent(
+  request: Request,
+  workspace: ScopedWorkspace,
+  actor: MemberActor,
+  skillName: string,
+  formData: FormData,
+) {
+  if (!mailDelivery().canSend) {
+    return { intent: "invite" as const, status: "mail_unarmed" as const };
+  }
+  const row = await skillIndexRow(actor, skillName);
+  if (row === undefined) {
+    notFound();
+  }
+  const raw = String(formData.get("email") ?? "");
+  const folded = foldInviteEmail(raw);
+  if (folded === null || !folded.includes("@")) {
+    return { intent: "invite" as const, status: "error" as const, submittedEmail: raw };
+  }
+
+  const policy = await workspacePolicyOf(actor);
+  const outcome = await createInvitations(actor, [folded], policy.invitePolicy, {
+    bundleId: row.skillId,
+  });
+  if (outcome.outcome === "owner_role_required") {
+    await recordAdminEvent(actor, {
+      kind: "invitation_created",
+      subject: folded,
+      detail: "owner_role_required",
+      outcome: "denied",
+    });
+    return { intent: "invite" as const, status: "owner_required" as const, submittedEmail: raw };
+  }
+  if (outcome.outcome !== "invited") {
+    return { intent: "invite" as const, status: "error" as const, submittedEmail: raw };
+  }
+
+  let emailSent = true;
+  try {
+    for (const one of outcome.minted) {
+      await sendInviteEmail({
+        to: one.email,
+        inviteUrl: inviteUrl(request, workspace.name, one.token),
+        agentUrl: agentDocUrl(request),
+        workspaceDisplayName: workspace.displayName,
+        invitedBy: actor.display,
+        hint: { kind: row.kind, name: row.name },
+      });
+    }
+  } catch {
+    emailSent = false;
+  }
+  return { intent: "invite" as const, status: "invited" as const, invited: folded, emailSent };
 }
 
 export default function SkillCurrentPage() {
@@ -82,6 +186,9 @@ function SkillCurrentContent({
   openProposals,
   versionId,
   versionFiles,
+  mailArmed,
+  invitePolicy,
+  isOwner,
 }: Extract<Awaited<ReturnType<typeof loader>>, { face: "page" }>) {
   const wsPath = useWsPath();
   return (
@@ -108,6 +215,7 @@ function SkillCurrentContent({
           </p>
         </Card>
       )}
+      <SkillInviteAffordance mailArmed={mailArmed} invitePolicy={invitePolicy} isOwner={isOwner} />
     </div>
   );
 }

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -15,53 +15,134 @@ import { composition } from "@/composition.server";
 import { actorFromSession, notFound, requireSession } from "@/lib/auth/guards.server";
 import { getAuth } from "@/lib/auth/server";
 import { announceCeremony } from "@/lib/ceremony-event";
-import { approveDeviceAuth, denyDeviceAuth, pendingDeviceAuth } from "@/lib/db/identity.server";
+import {
+  approveDeviceAuth,
+  denyDeviceAuth,
+  type PendingDeviceAuthView,
+  pendingDeviceAuth,
+  pendingDeviceAuthByChallenge,
+} from "@/lib/db/identity.server";
 import { membershipsFor } from "@/lib/db/queries.server";
 
 export const meta: MetaFunction = () => [{ title: "Approve a device · Topos" }];
 
 /**
- * The ONE device-approve ceremony (the gh-style device flow's browser half). A device that
- * wants to act as you shows a short code and points here; a SIGNED-IN person types (or arrives
- * with) that code, sees what is asking, and approves or denies. A LIVE SESSION plus the explicit
- * approve click IS the whole ceremony — approval mints the device's bearer credential (a
- * credential that acts as you), and being signed in and choosing Approve is the proof of who is
- * acting. Denying destroys a pending request and mints nothing.
+ * The ONE device-approve ceremony (the gh-style device flow's browser half), TWO-STATE: the
+ * code-entry form, or the resolved request card. A device that wants to act as you shows a
+ * short code and points here; a SIGNED-IN person types that code into a POST form — the code
+ * never enters ANY URL (no GET lookup, no code-embedding link) — sees exactly what is asking
+ * and EVERYWHERE the credential will reach, and approves or denies. A LIVE SESSION plus the
+ * explicit approve click IS the whole ceremony. Denying destroys a pending request and mints
+ * nothing.
  *
- * Signed out, the page bounces to /login carrying itself (code included) as the `next` path —
- * which a password OR a magic-link sign-in both honor, returning here to finish the approval.
- * An unknown or expired code is an honest in-page state, never a 404 — the person may have
- * mistyped and needs the form back.
+ * The LOOPBACK arrival (the CLI auto-opened this page): the URL carries `device` — the hex of
+ * the flow's device-code HASH (the same value the store keys the row by; identifying, never
+ * secret) — so the card resolves with zero typing, plus `port`/`state` naming the CLI's
+ * ephemeral 127.0.0.1 listener. The outcome then returns to the terminal via ONE state-bound
+ * localhost redirect; the CLI's poll stays the source of truth.
+ *
+ * A flow carrying an INVITATION token discloses the join on the card; the approval ceremony
+ * itself weaves accept-the-invitation → approve-the-device into one transaction (identity
+ * layer), so sign-in → accept → approve is one visit even for a brand-new invitee.
  */
 
+/** The loopback params a CLI-opened arrival carries (all non-secret), validated by shape. */
+interface Loopback {
+  port: string;
+  state: string;
+}
+
+function loopbackFrom(source: { get(name: string): string | null | FormDataEntryValue }): {
+  device: string | null;
+  loopback: Loopback | null;
+} {
+  const device = String(source.get("device") ?? "");
+  const port = String(source.get("port") ?? "");
+  const state = String(source.get("state") ?? "");
+  return {
+    device: /^[0-9a-f]{64}$/.test(device) ? device : null,
+    loopback:
+      /^\d{4,5}$/.test(port) &&
+      Number(port) >= 1024 &&
+      Number(port) <= 65535 &&
+      /^[A-Za-z0-9_-]{8,128}$/.test(state)
+        ? { port, state }
+        : null,
+  };
+}
+
+/** This page's own address, re-carrying only the validated pass-through params. */
+function selfPath(device: string | null, loopback: Loopback | null): string {
+  const qs = new URLSearchParams();
+  if (device !== null) {
+    qs.set("device", device);
+  }
+  if (loopback !== null) {
+    qs.set("port", loopback.port);
+    qs.set("state", loopback.state);
+  }
+  const search = qs.toString();
+  return `/verify${search === "" ? "" : `?${search}`}`;
+}
+
 /**
- * The loader's own sign-in bounce (not requireSession, whose bounce drops the query): the
- * `next` path carries the code, so a person landing here from a mailed/printed link signs in
- * and returns to the resolved request.
- *
- * MULTI tenancy adds the workspace-creation weave: a signed-in person with ZERO seats anywhere
- * cannot approve anything (approval requires a seat in the flow's workspace), so the loader
- * routes them through workspace creation and back — `/new` carries this page (code included)
- * as `next`, plus the flow's requested slug as a `name` prefill hint when one resolved. This
- * is the CLI-first path: the enrollment started toward a workspace that is created mid-flow.
+ * The resolved card's workspace-reach list: EVERY workspace the minted credential will act in —
+ * the approver's existing seats, plus the flow's requested workspace and any invitation join
+ * when those aren't seats yet. Full disclosure: the credential is device-wide, not
+ * workspace-scoped.
  */
+function reachOf(
+  memberships: { displayName: string; address: string }[],
+  pending: PendingDeviceAuthView,
+  multi: boolean,
+): { label: string; joining: boolean }[] {
+  const rows = memberships.map((m) => ({ label: m.displayName, joining: false }));
+  const seatAddresses = new Set(memberships.map((m) => m.address));
+  if (pending.inviteWorkspace !== null && !seatAddresses.has(pending.inviteWorkspace.name)) {
+    rows.push({ label: pending.inviteWorkspace.displayName, joining: true });
+  } else if (
+    multi &&
+    pending.requestedWorkspace !== "" &&
+    !seatAddresses.has(pending.requestedWorkspace)
+  ) {
+    rows.push({ label: pending.requestedWorkspace, joining: true });
+  }
+  return rows;
+}
+
 export async function loader({ request }: LoaderFunctionArgs) {
-  const code = (new URL(request.url).searchParams.get("code") ?? "").trim();
+  const url = new URL(request.url);
+  const { device, loopback } = loopbackFrom(url.searchParams);
+  const self = selfPath(device, loopback);
   const actor = actorFromSession(await getAuth().api.getSession({ headers: request.headers }));
-  const self = `/verify${code === "" ? "" : `?code=${encodeURIComponent(code)}`}`;
   if (actor === null) {
     throw redirect(`/login?next=${encodeURIComponent(self)}`);
   }
-  const pending = code === "" ? null : await pendingDeviceAuth(code);
+  const resolved = device === null ? null : await pendingDeviceAuthByChallenge(device);
   const multi = composition.tenancy === "multi";
-  if (multi && (await membershipsFor(actor)).length === 0) {
+  const memberships = await membershipsFor(actor);
+  if (
+    multi &&
+    memberships.length === 0 &&
+    (resolved === null || resolved.inviteWorkspace === null)
+  ) {
+    // The workspace-creation weave: a seatless approver cannot approve anything, so route them
+    // through `/new` and back — unless the flow carries an invitation, whose accept will seat
+    // them right here.
     const prefill =
-      pending !== null && pending.requestedWorkspace !== ""
-        ? `&name=${encodeURIComponent(pending.requestedWorkspace)}`
+      resolved !== null && resolved.requestedWorkspace !== ""
+        ? `&name=${encodeURIComponent(resolved.requestedWorkspace)}`
         : "";
     throw redirect(`/new?next=${encodeURIComponent(self)}${prefill}`);
   }
-  return { code, pending, multi };
+  return {
+    multi,
+    device,
+    loopback,
+    resolved:
+      resolved === null ? null : { ...resolved, reach: reachOf(memberships, resolved, multi) },
+    memberships: memberships.map((m) => ({ displayName: m.displayName, address: m.address })),
+  };
 }
 
 const REQUEST_GONE =
@@ -69,12 +150,42 @@ const REQUEST_GONE =
 
 export async function action({ request }: ActionFunctionArgs) {
   // A POST has no query to preserve — the plain guard's /login bounce is right here.
-  const actor = actorFromSession(await requireSession(request));
+  const session = await requireSession(request);
+  const actor = actorFromSession(session);
   if (actor === null) {
     notFound();
   }
   const form = await request.formData();
   const intent = String(form.get("intent") ?? "");
+  const { loopback } = loopbackFrom(form);
+
+  if (intent === "lookup") {
+    // The two-state page's first state: resolve the typed code into the request card. A POST,
+    // deliberately — the code never rides a URL (history, logs, referers all stay clean).
+    const userCode = String(form.get("code") ?? "")
+      .trim()
+      .toUpperCase();
+    if (userCode === "") {
+      throw data(null, { status: 400 });
+    }
+    const pending = await pendingDeviceAuth(userCode);
+    if (pending === null) {
+      return { kind: "miss" as const };
+    }
+    const memberships = await membershipsFor(actor);
+    return {
+      kind: "resolved" as const,
+      pending: {
+        ...pending,
+        reach: reachOf(
+          memberships.map((m) => ({ displayName: m.displayName, address: m.address })),
+          pending,
+          composition.tenancy === "multi",
+        ),
+      },
+    };
+  }
+
   const userCode = String(form.get("code") ?? "").trim();
   if (userCode === "" || (intent !== "approve" && intent !== "deny")) {
     throw data(null, { status: 400 });
@@ -83,13 +194,21 @@ export async function action({ request }: ActionFunctionArgs) {
   if (intent === "approve") {
     // No step-up: the live session + this explicit approve click is the whole ceremony. The
     // ceremony itself resolves the flow's workspace and requires the approver's seat in it —
-    // a refusal is indistinguishable from an expired code.
+    // accepting a carried invitation first when the approver is its addressee — and a refusal
+    // is indistinguishable from an expired code.
     const approved = await approveDeviceAuth(userCode, {
       userId: actor.userId,
       display: actor.display,
     });
     if (approved === null) {
       return data({ kind: "refused" as const, error: REQUEST_GONE }, { status: 400 });
+    }
+    if (loopback !== null) {
+      // The state-bound single-use localhost return: outcome only, no secret — the CLI's poll
+      // delivers the credential as always.
+      throw redirect(
+        `http://127.0.0.1:${loopback.port}/cb?state=${encodeURIComponent(loopback.state)}&outcome=approved`,
+      );
     }
     return { kind: "approved" as const, name: approved.requestedName };
   }
@@ -101,6 +220,11 @@ export async function action({ request }: ActionFunctionArgs) {
   if (!denied) {
     return data({ kind: "refused" as const, error: REQUEST_GONE }, { status: 400 });
   }
+  if (loopback !== null) {
+    throw redirect(
+      `http://127.0.0.1:${loopback.port}/cb?state=${encodeURIComponent(loopback.state)}&outcome=denied`,
+    );
+  }
   return { kind: "denied" as const };
 }
 
@@ -108,14 +232,15 @@ const INPUT =
   "block h-11 w-full rounded-md border border-line px-3 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25";
 
 export default function VerifyPage() {
-  const { code, pending, multi } = useLoaderData<typeof loader>();
+  const { resolved, loopback } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
 
   // The `device_approved` ceremony announcement, fired ONCE when the approval-success state
   // renders. Ref-guarded so dev strict-mode's doubled effect and re-renders of the same
   // success never re-dispatch; leaving the success state (a fresh lookup) re-arms it for the
   // next distinct approval.
-  const approved = actionData?.kind === "approved";
+  const approved =
+    actionData !== undefined && "kind" in actionData && actionData.kind === "approved";
   const announcedApproval = useRef(false);
   useEffect(() => {
     if (!approved) {
@@ -129,7 +254,7 @@ export default function VerifyPage() {
     announceCeremony("device_approved");
   }, [approved]);
 
-  if (actionData?.kind === "approved") {
+  if (actionData !== undefined && "kind" in actionData && actionData.kind === "approved") {
     return (
       <Shell>
         <PlainState heading="Device connected">
@@ -139,7 +264,7 @@ export default function VerifyPage() {
       </Shell>
     );
   }
-  if (actionData?.kind === "denied") {
+  if (actionData !== undefined && "kind" in actionData && actionData.kind === "denied") {
     return (
       <Shell>
         <PlainState heading="Request denied">
@@ -149,6 +274,12 @@ export default function VerifyPage() {
     );
   }
 
+  // The resolved card: from the loopback challenge (loader) or the typed-code lookup (action).
+  const card =
+    actionData !== undefined && "kind" in actionData && actionData.kind === "resolved"
+      ? actionData.pending
+      : resolved;
+
   return (
     <Shell>
       <div className="flex flex-col gap-6">
@@ -157,46 +288,41 @@ export default function VerifyPage() {
           <h1 className="font-display font-semibold text-ink text-lg tracking-[-0.02em]">
             Approve a device
           </h1>
-          <p className="text-dim text-sm">
-            Enter the code your device shows — it looks like{" "}
-            <code className="font-mono text-ink">AB29-CD34</code>.
-          </p>
+          {card === null && (
+            <p className="text-dim text-sm">
+              Enter the code your device shows — it looks like{" "}
+              <code className="font-mono text-ink">AB29-CD34</code>.
+            </p>
+          )}
         </div>
-        {actionData?.kind === "refused" && (
+        {actionData !== undefined && "kind" in actionData && actionData.kind === "refused" && (
           <p className="text-center text-red-600 text-sm" role="alert">
             {actionData.error}
           </p>
         )}
-        <CodeLookup code={code} />
-        {pending !== null ? (
-          <PendingRequest
-            code={code}
-            requestedName={pending.requestedName}
-            workspaceLabel={multi ? pending.requestedWorkspace : null}
-          />
-        ) : (
-          code !== "" && (
-            <p className="text-center text-dim text-sm" role="status">
-              No pending request for this code — it may have expired, or a character is off. Check
-              your terminal and try again.
-            </p>
-          )
+        {actionData !== undefined && "kind" in actionData && actionData.kind === "miss" && (
+          <p className="text-center text-dim text-sm" role="status">
+            No pending request for that code — it may have expired, or a character is off. Check
+            your terminal and try again.
+          </p>
         )}
+        {card !== null ? <PendingRequest card={card} loopback={loopback} /> : <CodeLookup />}
       </div>
     </Shell>
   );
 }
 
-/** The code form, a GET: submitting re-resolves the pending request server-side. */
-function CodeLookup({ code }: { code: string }) {
+/** State one: the code form — a POST, so the code never lands in a URL. */
+function CodeLookup() {
+  const busy = useNavigation().state !== "idle";
   return (
-    <Form method="get" className="flex items-end gap-2">
+    <Form method="post" className="flex items-end gap-2">
+      <input type="hidden" name="intent" value="lookup" />
       <label className="block flex-1">
         <span className="mb-1 block font-medium text-dim text-sm">Code</span>
         <input
           type="text"
           name="code"
-          defaultValue={code}
           required
           autoComplete="off"
           spellCheck={false}
@@ -204,58 +330,83 @@ function CodeLookup({ code }: { code: string }) {
           placeholder="AB29-CD34"
         />
       </label>
-      <button type="submit" className={`${buttonClasses("quiet")} min-h-11`}>
+      <button type="submit" disabled={busy} className={`${buttonClasses("quiet")} min-h-11`}>
         Look up
       </button>
     </Form>
   );
 }
 
+/** One resolved-card row shape shared by loader (challenge) and action (lookup) arrivals. */
+interface ResolvedCard extends PendingDeviceAuthView {
+  reach: { label: string; joining: boolean }[];
+}
+
 /**
- * The resolved request: what is asking, then the two arms. The approve form posts the RESOLVED
- * code as a hidden field — the approval applies to exactly the request shown, never to whatever
- * the lookup input holds at submit time. On a multi-tenant deployment the card also names the
- * workspace the flow targets ("in <slug>") — the request's own claim, echoed so the approver
- * sees where the credential will act before clicking.
+ * State two: the resolved request. What is asking, the CODE for the glance-check against the
+ * terminal, EVERY workspace the credential will reach, and the two arms. The approve form
+ * posts the RESOLVED code as a hidden field — the approval applies to exactly the request
+ * shown, never to whatever a lookup input held.
  */
-function PendingRequest({
-  code,
-  requestedName,
-  workspaceLabel,
-}: {
-  code: string;
-  requestedName: string;
-  workspaceLabel: string | null;
-}) {
+function PendingRequest({ card, loopback }: { card: ResolvedCard; loopback: Loopback | null }) {
   const navigation = useNavigation();
   const submitting = navigation.state !== "idle";
+  const passThrough = (
+    <>
+      {loopback !== null && (
+        <>
+          <input type="hidden" name="port" value={loopback.port} />
+          <input type="hidden" name="state" value={loopback.state} />
+        </>
+      )}
+    </>
+  );
   return (
     <div className="flex flex-col gap-4 rounded-md border border-line-soft bg-ground p-4">
       <p className="text-ink text-sm">
-        Device <span className="font-medium">“{requestedName}”</span> wants to act as you
-        {workspaceLabel !== null && workspaceLabel !== "" ? (
-          <>
-            {" "}
-            in <span className="font-medium">{workspaceLabel}</span>
-          </>
-        ) : null}
-        . Approving gives it a credential that publishes, follows, and reads with your seat until
-        you sign it out from your devices.
+        Device <span className="font-medium">“{card.requestedName}”</span> wants to act as you.
       </p>
+      <p className="text-dim text-sm">
+        Its code is <code className="font-mono text-ink">{card.userCode}</code> — confirm it matches
+        your terminal before approving.
+      </p>
+      <div className="text-dim text-sm">
+        <p className="mb-1">Approving gives it a credential that acts with your seat in:</p>
+        <ul className="list-inside list-disc">
+          {card.reach.map((row) => (
+            <li key={`${row.label}-${row.joining}`}>
+              <span className="text-ink">{row.label}</span>
+              {row.joining && <span className="text-faint"> — joins on approve</span>}
+            </li>
+          ))}
+        </ul>
+        {card.inviteWorkspace !== null && (
+          <p className="mt-2">
+            This enrollment carries an invitation to{" "}
+            <span className="font-medium text-ink">{card.inviteWorkspace.displayName}</span> —
+            approving accepts it.
+          </p>
+        )}
+        <p className="mt-2">
+          It publishes, follows, and reads there until you sign it out from your devices.
+        </p>
+      </div>
       <Form method="post" className="flex flex-col gap-3">
         <input type="hidden" name="intent" value="approve" />
-        <input type="hidden" name="code" value={code} />
+        <input type="hidden" name="code" value={card.userCode} />
+        {passThrough}
         <button
           type="submit"
           disabled={submitting}
           className={`${buttonClasses("primary")} min-h-11 w-full`}
         >
-          {submitting ? "Working…" : `Approve “${requestedName}”`}
+          {submitting ? "Working…" : `Approve “${card.requestedName}”`}
         </button>
       </Form>
       <Form method="post">
         <input type="hidden" name="intent" value="deny" />
-        <input type="hidden" name="code" value={code} />
+        <input type="hidden" name="code" value={card.userCode} />
+        {passThrough}
         <button
           type="submit"
           disabled={submitting}

--- a/web/app/routes/workspace-members.tsx
+++ b/web/app/routes/workspace-members.tsx
@@ -32,7 +32,7 @@ import { workspaceById } from "@/lib/db/queries.server";
 import { sendInviteEmail } from "@/lib/mail/invite-mail.server";
 import { mailDelivery } from "@/lib/mail/transport.server";
 import { useWsPath } from "@/lib/ws-path";
-import { agentDocUrl, workspaceAddress } from "@/lib/ws-url.server";
+import { agentDocUrl, inviteUrl, workspaceAddress } from "@/lib/ws-url.server";
 
 export function meta({ params }: { params: { ws?: string } }) {
   return [{ title: `Members · ${params.ws ?? "Workspace"}` }];
@@ -68,6 +68,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const invitations: PendingInvitationView[] = pending.map((inv) => ({
     id: inv.id,
     email: inv.email,
+    status: inv.status === "declined" ? ("declined" as const) : ("pending" as const),
     invitedByDisplay:
       inv.invitedBy !== null ? (displayByUserId.get(inv.invitedBy) ?? "a former member") : "—",
     lapse: lapseLabel(inv.expiresAt, now),
@@ -150,7 +151,7 @@ async function inviteIntent(request: Request, ws: string, formData: FormData) {
 
   const policy = await workspacePolicyOf(actor);
   const outcome = await createInvitations(actor, emails, policy.invitePolicy);
-  if (outcome === "owner_role_required") {
+  if (outcome.outcome === "owner_role_required") {
     await recordAdminEvent(actor, {
       kind: "invitation_created",
       subject: emails.join(", "),
@@ -159,21 +160,21 @@ async function inviteIntent(request: Request, ws: string, formData: FormData) {
     });
     return { intent: "invite" as const, status: "owner_required" as const, submittedEmails: raw };
   }
-  if (outcome !== "invited") {
+  if (outcome.outcome !== "invited") {
     return { intent: "invite" as const, status: "error" as const, submittedEmails: raw };
   }
 
-  // The notice mail, per address. A send fault never loses the invitation — the row stands and
-  // re-inviting resends — but the reply says honestly when nothing went out.
+  // The invitation mail, per address — it carries the single-use invite LINK (the inviter's own
+  // surfaces never show it). A send fault never loses the invitation — the row stands and
+  // re-inviting mints a fresh link — but the reply says honestly when nothing went out.
   const workspace = await workspaceById(actor, ws);
-  const address = workspaceAddress(request, workspace?.name ?? ws);
   const workspaceName = workspace?.displayName ?? ws;
   let emailSent = true;
   try {
-    for (const email of emails) {
+    for (const one of outcome.minted) {
       await sendInviteEmail({
-        to: email,
-        address,
+        to: one.email,
+        inviteUrl: inviteUrl(request, workspace?.name ?? ws, one.token),
         agentUrl: agentDocUrl(request),
         workspaceDisplayName: workspaceName,
         invitedBy: actor.display,

--- a/web/app/topos-web/routes.ts
+++ b/web/app/topos-web/routes.ts
@@ -74,6 +74,12 @@ export function ossRoutes(options: OssRoutesOptions = {}): RouteConfigEntry[] {
     // `claim` is a reserved top-level segment that answers the house 404, so the `:ws` face can't
     // swallow it and it discloses nothing.
     tenancy === "multi" ? route("claim", file("reserved.tsx")) : route("claim", file("claim.tsx")),
+    // The tokened invitation page — GET-safe viewing, explicit accept/decline POSTs. Origin-
+    // rooted in single tenancy; nested under the workspace slug in multi (the static `invite`
+    // segment outranks the face routes' params, so no face ever swallows it).
+    tenancy === "multi"
+      ? route(":ws/invite/:token", file("invite-redeem.tsx"))
+      : route("invite/:token", file("invite-redeem.tsx")),
     // The ONE approve ceremony: a signed-in human confirms a device flow by its user code.
     route("verify", file("verify.tsx")),
     route("healthz", file("healthz.ts")),
@@ -98,6 +104,8 @@ export function ossRoutes(options: OssRoutesOptions = {}): RouteConfigEntry[] {
     // both tenancy modes. Static segments outrank the splat, which answers the uniform wire 404.
     route("api/v1/device/authorize", file("api.v1.device-authorize.ts")),
     route("api/v1/device/token", file("api.v1.device-token.ts")),
+    // The already-enrolled device's invite-URL accept — person-scoped (seat-less by design).
+    route("api/v1/invitations/accept", file("api.v1.invitation-accept.ts")),
     route("api/v1/publish", file("api.v1.publish.ts")),
     route("api/v1/proposals", file("api.v1.propose.ts")),
     route("api/v1/reverts", file("api.v1.reverts.ts")),

--- a/web/app/topos-web/segments.ts
+++ b/web/app/topos-web/segments.ts
@@ -49,6 +49,9 @@ export const FUTURE_RESERVED_SEGMENTS: readonly string[] = [
   "download",
   "help",
   "internal",
+  // In multi tenancy invitation pages nest under the workspace slug (`/<ws>/invite/<token>`),
+  // but the bare word stays reserved so no workspace address reads like an invitation door.
+  "invite",
   "legal",
   "mail",
   "oss",

--- a/web/drizzle/0003_invitation-redemption.sql
+++ b/web/drizzle/0003_invitation-redemption.sql
@@ -1,0 +1,22 @@
+ALTER TABLE "web"."invitation" DROP CONSTRAINT "invitation_status_check";--> statement-breakpoint
+ALTER TABLE "web"."device_auth_session" ADD COLUMN "invite_token_sha256" "bytea";--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD COLUMN "token_sha256" "bytea";--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD COLUMN "hint_bundle_id" text;--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD COLUMN "hint_channel_id" text;--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD CONSTRAINT "invitation_token_sha256_unique" UNIQUE("token_sha256");--> statement-breakpoint
+ALTER TABLE "web"."device_auth_session" ADD CONSTRAINT "device_auth_session_invite_token_sha256_check" CHECK ("web"."device_auth_session"."invite_token_sha256" is null or octet_length("web"."device_auth_session"."invite_token_sha256") = 32);--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD CONSTRAINT "invitation_token_sha256_check" CHECK ("web"."invitation"."token_sha256" is null or octet_length("web"."invitation"."token_sha256") = 32);--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD CONSTRAINT "invitation_hint_one_check" CHECK ("web"."invitation"."hint_bundle_id" is null or "web"."invitation"."hint_channel_id" is null);--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD CONSTRAINT "invitation_status_check" CHECK ("web"."invitation"."status" in ('pending', 'accepted', 'revoked', 'declined'));--> statement-breakpoint
+-- Workspace coherence for the hint references, hand-appended (drizzle-kit cannot express a
+-- per-column SET NULL): the composite FK pins the hinted bundle/channel to the invitation's
+-- OWN workspace, and deleting the hinted thing clears ONLY the hint column — the invitation
+-- (and its NOT NULL workspace_id) survive. MATCH SIMPLE semantics: a NULL hint disarms the FK.
+ALTER TABLE "web"."invitation" ADD CONSTRAINT "invitation_hint_bundle_fk"
+  FOREIGN KEY ("hint_bundle_id","workspace_id")
+  REFERENCES "web"."bundle"("id","workspace_id")
+  ON DELETE SET NULL ("hint_bundle_id");--> statement-breakpoint
+ALTER TABLE "web"."invitation" ADD CONSTRAINT "invitation_hint_channel_fk"
+  FOREIGN KEY ("hint_channel_id","workspace_id")
+  REFERENCES "web"."channel"("id","workspace_id")
+  ON DELETE SET NULL ("hint_channel_id");

--- a/web/drizzle/meta/0003_snapshot.json
+++ b/web/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,3065 @@
+{
+  "id": "cb4b4eec-a7b8-4386-a869-1c7d027ea3cf",
+  "prevId": "1bed9fa4-b55c-4ac1-a8f0-fb09034858cf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "web.account": {
+      "name": "account",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.session": {
+      "name": "session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_idx": {
+          "name": "session_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.user": {
+      "name": "user",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_email_lowercase": {
+          "name": "user_email_lowercase",
+          "value": "\"web\".\"user\".\"email\" = lower(\"web\".\"user\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.verification": {
+      "name": "verification",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expires_idx": {
+          "name": "verification_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.approval": {
+      "name": "approval",
+      "schema": "web",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer": {
+          "name": "reviewer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_reviewer_idx": {
+          "name": "approval_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_proposal_id_proposal_id_fk": {
+          "name": "approval_proposal_id_proposal_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "proposal",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_reviewer_user_id_fk": {
+          "name": "approval_reviewer_user_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "reviewer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "approval_proposal_id_reviewer_pk": {
+          "name": "approval_proposal_id_reviewer_pk",
+          "columns": [
+            "proposal_id",
+            "reviewer"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.audit_event": {
+      "name": "audit_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "audit_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_device_id": {
+          "name": "actor_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display": {
+          "name": "actor_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_ws_time": {
+          "name": "audit_ws_time",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_user": {
+          "name": "audit_actor_user",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_device": {
+          "name": "audit_actor_device",
+          "columns": [
+            {
+              "expression": "actor_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_device_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_event_actor_user_id_user_id_fk": {
+          "name": "audit_event_actor_user_id_user_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_event_actor_device_id_device_id_fk": {
+          "name": "audit_event_actor_device_id_device_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "device",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle": {
+      "name": "bundle",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "protection": {
+          "name": "protection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_name": {
+          "name": "base_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundle_workspace_id_workspace_id_fk": {
+          "name": "bundle_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_created_by_user_id_fk": {
+          "name": "bundle_created_by_user_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_workspace_id_name_unique": {
+          "name": "bundle_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "bundle_id_workspace_id_unique": {
+          "name": "bundle_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bundle_name_check": {
+          "name": "bundle_name_check",
+          "value": "\"web\".\"bundle\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"bundle\".\"name\") <= 200"
+        },
+        "bundle_status_check": {
+          "name": "bundle_status_check",
+          "value": "\"web\".\"bundle\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "bundle_protection_check": {
+          "name": "bundle_protection_check",
+          "value": "\"web\".\"bundle\".\"protection\" is null or \"web\".\"bundle\".\"protection\" in ('open', 'reviewed')"
+        },
+        "bundle_deleted_check": {
+          "name": "bundle_deleted_check",
+          "value": "(\"web\".\"bundle\".\"status\" = 'deleted') = (\"web\".\"bundle\".\"deleted_at\" is not null)"
+        },
+        "bundle_archived_check": {
+          "name": "bundle_archived_check",
+          "value": "\"web\".\"bundle\".\"status\" <> 'archived' or \"web\".\"bundle\".\"archived_at\" is not null"
+        },
+        "bundle_base_name_check": {
+          "name": "bundle_base_name_check",
+          "value": "\"web\".\"bundle\".\"base_name\" is null or \"web\".\"bundle\".\"status\" <> 'active'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.bundle_detachment": {
+      "name": "bundle_detachment",
+      "schema": "web",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_detachment_ws_idx": {
+          "name": "bundle_detachment_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_detachment_user_id_user_id_fk": {
+          "name": "bundle_detachment_user_id_user_id_fk",
+          "tableFrom": "bundle_detachment",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_detachment_bundle_fk": {
+          "name": "bundle_detachment_bundle_fk",
+          "tableFrom": "bundle_detachment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_detachment_user_id_bundle_id_pk": {
+          "name": "bundle_detachment_user_id_bundle_id_pk",
+          "columns": [
+            "user_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bundle_detachment_cause_check": {
+          "name": "bundle_detachment_cause_check",
+          "value": "\"web\".\"bundle_detachment\".\"cause\" in ('unfollow', 'channel_leave', 'membership_removed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.bundle_name_hint": {
+      "name": "bundle_name_hint",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renamed_by": {
+          "name": "renamed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_name_hint_bundle_idx": {
+          "name": "bundle_name_hint_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_name_hint_workspace_id_workspace_id_fk": {
+          "name": "bundle_name_hint_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_bundle_id_bundle_id_fk": {
+          "name": "bundle_name_hint_bundle_id_bundle_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_renamed_by_user_id_fk": {
+          "name": "bundle_name_hint_renamed_by_user_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "renamed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_name_hint_workspace_id_old_name_pk": {
+          "name": "bundle_name_hint_workspace_id_old_name_pk",
+          "columns": [
+            "workspace_id",
+            "old_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_subscription": {
+      "name": "bundle_subscription",
+      "schema": "web",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_subscription_bundle_idx": {
+          "name": "bundle_subscription_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_subscription_seat_fk": {
+          "name": "bundle_subscription_seat_fk",
+          "tableFrom": "bundle_subscription",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_subscription_bundle_fk": {
+          "name": "bundle_subscription_bundle_fk",
+          "tableFrom": "bundle_subscription",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_subscription_user_id_bundle_id_pk": {
+          "name": "bundle_subscription_user_id_bundle_id_pk",
+          "columns": [
+            "user_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bundle_subscription_state_check": {
+          "name": "bundle_subscription_state_check",
+          "value": "\"web\".\"bundle_subscription\".\"state\" in ('following', 'unfollowed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel": {
+      "name": "channel",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_one_default": {
+          "name": "channel_one_default",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_workspace_id_workspace_id_fk": {
+          "name": "channel_workspace_id_workspace_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_created_by_user_id_fk": {
+          "name": "channel_created_by_user_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "channel_workspace_id_name_unique": {
+          "name": "channel_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "channel_id_workspace_id_unique": {
+          "name": "channel_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "channel_mode_check": {
+          "name": "channel_mode_check",
+          "value": "\"web\".\"channel\".\"mode\" in ('open', 'curated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel_bundle": {
+      "name": "channel_bundle",
+      "schema": "web",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bundle_bundle_idx": {
+          "name": "channel_bundle_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bundle_added_by_user_id_fk": {
+          "name": "channel_bundle_added_by_user_id_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_channel_fk": {
+          "name": "channel_bundle_channel_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_bundle_fk": {
+          "name": "channel_bundle_bundle_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_bundle_channel_id_bundle_id_pk": {
+          "name": "channel_bundle_channel_id_bundle_id_pk",
+          "columns": [
+            "channel_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.channel_member": {
+      "name": "channel_member",
+      "schema": "web",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_member_user_idx": {
+          "name": "channel_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_member_added_by_user_id_fk": {
+          "name": "channel_member_added_by_user_id_fk",
+          "tableFrom": "channel_member",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_member_channel_fk": {
+          "name": "channel_member_channel_fk",
+          "tableFrom": "channel_member",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_member_seat_fk": {
+          "name": "channel_member_seat_fk",
+          "tableFrom": "channel_member",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_member_channel_id_user_id_pk": {
+          "name": "channel_member_channel_id_user_id_pk",
+          "columns": [
+            "channel_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.channel_optout": {
+      "name": "channel_optout",
+      "schema": "web",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_optout_user_idx": {
+          "name": "channel_optout_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_optout_channel_fk": {
+          "name": "channel_optout_channel_fk",
+          "tableFrom": "channel_optout",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_optout_seat_fk": {
+          "name": "channel_optout_seat_fk",
+          "tableFrom": "channel_optout",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_optout_channel_id_user_id_pk": {
+          "name": "channel_optout_channel_id_user_id_pk",
+          "columns": [
+            "channel_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.device": {
+      "name": "device",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_sha256": {
+          "name": "credential_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_user_idx": {
+          "name": "device_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_user_id_user_id_fk": {
+          "name": "device_user_id_user_id_fk",
+          "tableFrom": "device",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_credential_sha256_unique": {
+          "name": "device_credential_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_credential_sha256_check": {
+          "name": "device_credential_sha256_check",
+          "value": "octet_length(\"web\".\"device\".\"credential_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.device_auth_session": {
+      "name": "device_auth_session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_code_sha256": {
+          "name": "device_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_name": {
+          "name": "requested_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_workspace": {
+          "name": "requested_workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "approved_workspace_id": {
+          "name": "approved_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token_sha256": {
+          "name": "invite_token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "device_auth_live_code": {
+          "name": "device_auth_live_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_auth_expires_idx": {
+          "name": "device_auth_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_auth_session_approved_by_user_id_fk": {
+          "name": "device_auth_session_approved_by_user_id_fk",
+          "tableFrom": "device_auth_session",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "device_auth_session_device_id_device_id_fk": {
+          "name": "device_auth_session_device_id_device_id_fk",
+          "tableFrom": "device_auth_session",
+          "tableTo": "device",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_auth_session_device_code_sha256_unique": {
+          "name": "device_auth_session_device_code_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_auth_session_device_code_sha256_check": {
+          "name": "device_auth_session_device_code_sha256_check",
+          "value": "octet_length(\"web\".\"device_auth_session\".\"device_code_sha256\") = 32"
+        },
+        "device_auth_session_invite_token_sha256_check": {
+          "name": "device_auth_session_invite_token_sha256_check",
+          "value": "\"web\".\"device_auth_session\".\"invite_token_sha256\" is null or octet_length(\"web\".\"device_auth_session\".\"invite_token_sha256\") = 32"
+        },
+        "device_auth_session_status_check": {
+          "name": "device_auth_session_status_check",
+          "value": "\"web\".\"device_auth_session\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_auth_session_approved_check": {
+          "name": "device_auth_session_approved_check",
+          "value": "\"web\".\"device_auth_session\".\"status\" <> 'approved' or \"web\".\"device_auth_session\".\"device_id\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.device_bundle_state": {
+      "name": "device_bundle_state",
+      "schema": "web",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_version_id": {
+          "name": "applied_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_bundle_state_bundle_idx": {
+          "name": "device_bundle_state_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_bundle_state_device_id_device_id_fk": {
+          "name": "device_bundle_state_device_id_device_id_fk",
+          "tableFrom": "device_bundle_state",
+          "tableTo": "device",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_bundle_state_bundle_id_bundle_id_fk": {
+          "name": "device_bundle_state_bundle_id_bundle_id_fk",
+          "tableFrom": "device_bundle_state",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "device_bundle_state_device_id_bundle_id_pk": {
+          "name": "device_bundle_state_device_id_bundle_id_pk",
+          "columns": [
+            "device_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.device_exclusion": {
+      "name": "device_exclusion",
+      "schema": "web",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_exclusion_bundle_idx": {
+          "name": "device_exclusion_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_exclusion_device_id_device_id_fk": {
+          "name": "device_exclusion_device_id_device_id_fk",
+          "tableFrom": "device_exclusion",
+          "tableTo": "device",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_exclusion_bundle_id_bundle_id_fk": {
+          "name": "device_exclusion_bundle_id_bundle_id_fk",
+          "tableFrom": "device_exclusion",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "device_exclusion_device_id_bundle_id_pk": {
+          "name": "device_exclusion_device_id_bundle_id_pk",
+          "columns": [
+            "device_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.invitation": {
+      "name": "invitation",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_sha256": {
+          "name": "token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_bundle_id": {
+          "name": "hint_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_channel_id": {
+          "name": "hint_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_pending_once": {
+          "name": "invitation_pending_once",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_workspace_id_workspace_id_fk": {
+          "name": "invitation_workspace_id_workspace_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitation_accepted_by_user_id_fk": {
+          "name": "invitation_accepted_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_sha256_unique": {
+          "name": "invitation_token_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_email_check": {
+          "name": "invitation_email_check",
+          "value": "\"web\".\"invitation\".\"email\" = lower(\"web\".\"invitation\".\"email\")"
+        },
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"web\".\"invitation\".\"role\" in ('owner', 'reviewer', 'member')"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "\"web\".\"invitation\".\"status\" in ('pending', 'accepted', 'revoked', 'declined')"
+        },
+        "invitation_token_sha256_check": {
+          "name": "invitation_token_sha256_check",
+          "value": "\"web\".\"invitation\".\"token_sha256\" is null or octet_length(\"web\".\"invitation\".\"token_sha256\") = 32"
+        },
+        "invitation_hint_one_check": {
+          "name": "invitation_hint_one_check",
+          "value": "\"web\".\"invitation\".\"hint_bundle_id\" is null or \"web\".\"invitation\".\"hint_channel_id\" is null"
+        },
+        "invitation_accepted_check": {
+          "name": "invitation_accepted_check",
+          "value": "(\"web\".\"invitation\".\"status\" = 'accepted') = (\"web\".\"invitation\".\"accepted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.notice": {
+      "name": "notice",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notice_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notice_inbox": {
+          "name": "notice_inbox",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "acked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notice_ws_idx": {
+          "name": "notice_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notice_user_id_user_id_fk": {
+          "name": "notice_user_id_user_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notice_workspace_id_workspace_id_fk": {
+          "name": "notice_workspace_id_workspace_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.op_receipt": {
+      "name": "op_receipt",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_id": {
+          "name": "op_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_sha256": {
+          "name": "request_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "op_receipt_retention_idx": {
+          "name": "op_receipt_retention_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "op_receipt_device_id_device_id_fk": {
+          "name": "op_receipt_device_id_device_id_fk",
+          "tableFrom": "op_receipt",
+          "tableTo": "device",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "op_receipt_workspace_id_device_id_op_id_pk": {
+          "name": "op_receipt_workspace_id_device_id_op_id_pk",
+          "columns": [
+            "workspace_id",
+            "device_id",
+            "op_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "op_receipt_request_sha256_check": {
+          "name": "op_receipt_request_sha256_check",
+          "value": "octet_length(\"web\".\"op_receipt\".\"request_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal": {
+      "name": "proposal",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_version_id": {
+          "name": "candidate_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason": {
+          "name": "resolved_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_open": {
+          "name": "proposal_open",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_one_open_per_candidate": {
+          "name": "proposal_one_open_per_candidate",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_proposed_by_user_id_fk": {
+          "name": "proposal_proposed_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_resolved_by_user_id_fk": {
+          "name": "proposal_resolved_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_bundle_fk": {
+          "name": "proposal_bundle_fk",
+          "tableFrom": "proposal",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_status_check": {
+          "name": "proposal_status_check",
+          "value": "\"web\".\"proposal\".\"status\" in ('open', 'approved', 'rejected', 'withdrawn')"
+        },
+        "proposal_resolved_check": {
+          "name": "proposal_resolved_check",
+          "value": "(\"web\".\"proposal\".\"status\" = 'open') = (\"web\".\"proposal\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal_comment": {
+      "name": "proposal_comment",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display": {
+          "name": "author_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_comment_thread_idx": {
+          "name": "proposal_comment_thread_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_comment_author_user_id_user_id_fk": {
+          "name": "proposal_comment_author_user_id_user_id_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_comment_bundle_fk": {
+          "name": "proposal_comment_bundle_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_comment_body_check": {
+          "name": "proposal_comment_body_check",
+          "value": "char_length(\"web\".\"proposal_comment\".\"body\") between 1 and 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.seat": {
+      "name": "seat",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seat_user_idx": {
+          "name": "seat_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seat_workspace_id_workspace_id_fk": {
+          "name": "seat_workspace_id_workspace_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_user_id_user_id_fk": {
+          "name": "seat_user_id_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_invited_by_user_id_fk": {
+          "name": "seat_invited_by_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "seat_workspace_id_user_id_pk": {
+          "name": "seat_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "seat_role_check": {
+          "name": "seat_role_check",
+          "value": "\"web\".\"seat\".\"role\" in ('owner', 'reviewer', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.workspace": {
+      "name": "workspace",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_code_sha256": {
+          "name": "claim_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_policy": {
+          "name": "invite_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "protection_default": {
+          "name": "protection_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "staleness_window_ms": {
+          "name": "staleness_window_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800000
+        },
+        "registration": {
+          "name": "registration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_only'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_name_unique": {
+          "name": "workspace_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_name_check": {
+          "name": "workspace_name_check",
+          "value": "\"web\".\"workspace\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"workspace\".\"name\") <= 100"
+        },
+        "workspace_claim_code_sha256_check": {
+          "name": "workspace_claim_code_sha256_check",
+          "value": "\"web\".\"workspace\".\"claim_code_sha256\" is null or octet_length(\"web\".\"workspace\".\"claim_code_sha256\") = 32"
+        },
+        "workspace_invite_policy_check": {
+          "name": "workspace_invite_policy_check",
+          "value": "\"web\".\"workspace\".\"invite_policy\" in ('members', 'owners')"
+        },
+        "workspace_protection_default_check": {
+          "name": "workspace_protection_default_check",
+          "value": "\"web\".\"workspace\".\"protection_default\" in ('open', 'reviewed')"
+        },
+        "workspace_registration_check": {
+          "name": "workspace_registration_check",
+          "value": "\"web\".\"workspace\".\"registration\" in ('invite_only', 'open')"
+        },
+        "workspace_claim_state_check": {
+          "name": "workspace_claim_state_check",
+          "value": "(\"web\".\"workspace\".\"claimed_at\" is null) <> (\"web\".\"workspace\".\"claim_code_sha256\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "web": "web"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784179705411,
       "tag": "0002_device-auth-approved-workspace",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784613769623,
+      "tag": "0003_invitation-redemption",
+      "breakpoints": true
     }
   ]
 }

--- a/web/scripts/check-boundary.mjs
+++ b/web/scripts/check-boundary.mjs
@@ -278,6 +278,10 @@ const SESSIONLESS_ROUTES = new Set([
   // it); the belt is their gate and the flow rows are single-use, short-TTL.
   "api.v1.device-authorize",
   "api.v1.device-token",
+  // The tokened invitation page: sessionless BY DESIGN (the mailed single-use token is the
+  // proof; anonymous viewing + the account-minting accept are the point), uniform constant
+  // page on a miss, public-read belted.
+  "invite-redeem",
   // The lane's catch-all answers the constant uniform 404 — it reads nothing.
   "api.v1.$",
 ]);
@@ -285,7 +289,7 @@ const SESSIONLESS_ROUTES = new Set([
 // membership-or-404 resolution the face modules call on their signed-in arm (their anonymous
 // arm resolves the session itself, teaser-or-404, so the require* wrappers cannot front them).
 const GUARD_CALL =
-  /\b(?:require(?:Session|MemberInScope|Member|OwnerInScope|WorkspaceOwner|Reviewer|DeviceActor)|memberInScope)\s*\(/;
+  /\b(?:require(?:Session|MemberInScope|Member|OwnerInScope|WorkspaceOwner|Reviewer|DeviceActor|DevicePerson)|memberInScope)\s*\(/;
 const READS_DATA = /export\s+(?:async\s+)?(?:function|const)\s+(?:loader|action)\b/;
 for (const { rel, text, base } of files) {
   if (!rel.startsWith(ROUTES_DIR)) {

--- a/web/tests/e2e/invite-redemption.spec.ts
+++ b/web/tests/e2e/invite-redemption.spec.ts
@@ -1,0 +1,383 @@
+import { randomBytes } from "node:crypto";
+import { expect, type Page, test } from "@playwright/test";
+import { MEMBER_EMAIL } from "./env";
+import {
+  adminQuery,
+  ensureAccount,
+  ensureBundle,
+  ensureSeatedUser,
+  latestMail,
+  mintDevice,
+  theWorkspace,
+} from "./seed";
+import { gotoSettled, signIn } from "./sign-in";
+
+/**
+ * The tokened INVITATION page at /invite/:token — the mailed link's landing, redeemed end to
+ * end. One link is worth ONE invitation, never an account or a credential: viewing never
+ * consumes, accept/decline are explicit POSTs, and the page reshapes itself to the visitor —
+ *
+ *   - a brand-new person mints their account inline (PASSWORDLESS here, since SMTP is armed and
+ *     the mail sign-in rung exists — the token's delivery to the mailbox is the proof);
+ *   - a signed-in account whose verified email IS the invited address accepts in one click;
+ *   - a signed-out visitor whose address already has an account is sent to sign in and back;
+ *   - a session on a DIFFERENT address gets the switch page and never accepts as the wrong one;
+ *   - decline is recorded (the inviter sees it); every dead token is ONE constant page that
+ *     names neither the workspace nor any email; an already-member arrival just redirects in;
+ *   - a skill-hinted invitation frames the skill, subscribes on accept, and lands on it.
+ *
+ * The invite arranges through two lanes: the real /members form + the device lane (where the
+ * INVITE flow is the subject, tests 1 and 8) and superuser SQL that seeds a pending row with a
+ * known token (mere arrangement, the redemption being the subject). Each test uses a UNIQUE
+ * address and its own fresh signed-out context; the suite's default storage state is the owner.
+ */
+
+let seq = 0;
+/** A fresh, charset-legal invitee address, unique across the run. */
+function uniqueEmail(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${Date.now().toString(36)}-${seq}@example.com`;
+}
+
+/** The claimed owner's user id — the seeded invitations' inviter (realistic attribution). */
+async function ownerUserId(): Promise<string> {
+  const rows = await adminQuery<{ id: string }>(`select id from web."user" where email = $1`, [
+    MEMBER_EMAIL,
+  ]);
+  const id = rows[0]?.id;
+  if (id === undefined) {
+    throw new Error("owner user row not found — did auth.setup run?");
+  }
+  return id;
+}
+
+/**
+ * Seed ONE pending invitation with a known plaintext token (hashed in Postgres exactly as the
+ * app hashes it) and return the origin-rooted redeem path. Arrangement for the redemption tests.
+ */
+async function seedInvitation(
+  email: string,
+  opts: { hintBundleId?: string } = {},
+): Promise<string> {
+  const ws = await theWorkspace();
+  const invitedBy = await ownerUserId();
+  const token = randomBytes(32).toString("base64url");
+  const id = `inv_${randomBytes(12).toString("hex")}`;
+  // A stale pending row from a reused local stack would trip the (email, ws) pending-once index.
+  await adminQuery(`delete from web.invitation where email = $1 and workspace_id = $2`, [
+    email.toLowerCase(),
+    ws.id,
+  ]);
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  await adminQuery(
+    `insert into web.invitation
+       (id, workspace_id, email, role, status, token_sha256, invited_by, hint_bundle_id, expires_at)
+     values ($1, $2, $3, 'member', 'pending', sha256(convert_to($4, 'UTF8')), $5, $6, $7)`,
+    [id, ws.id, email.toLowerCase(), token, invitedBy, opts.hintBundleId ?? null, expiresAt],
+  );
+  return `/invite/${token}`;
+}
+
+/** Invite through the real /members form as the owner (test 1's arranged path). */
+async function inviteViaMembers(page: Page, email: string): Promise<void> {
+  await gotoSettled(page, "/members");
+  await page.getByLabel("Invite by email").fill(email);
+  await page.getByRole("button", { name: "Invite", exact: true }).click();
+  await expect(page.getByRole("status").filter({ hasText: `Invited ${email}` })).toBeVisible();
+}
+
+/** Fish the tokened invite URL out of the dev outbox and return its origin-rooted path. */
+async function fishInvitePath(email: string): Promise<string> {
+  const mail = await latestMail("invite", email);
+  const match = mail.text.match(/Accept in your browser:\s+(\S+)/);
+  if (!match?.[1]) {
+    throw new Error(`no invite URL in the mail for ${email}: ${mail.text}`);
+  }
+  return new URL(match[1]).pathname;
+}
+
+async function seatRole(email: string): Promise<string | undefined> {
+  const rows = await adminQuery<{ role: string }>(
+    `select s.role from web.seat s join web."user" u on u.id = s.user_id where u.email = $1`,
+    [email.toLowerCase()],
+  );
+  return rows[0]?.role;
+}
+
+async function invitationStatus(email: string): Promise<string | undefined> {
+  const rows = await adminQuery<{ status: string }>(
+    `select status from web.invitation where email = $1 order by created_at desc limit 1`,
+    [email.toLowerCase()],
+  );
+  return rows[0]?.status;
+}
+
+async function emailVerified(email: string): Promise<boolean | undefined> {
+  const rows = await adminQuery<{ email_verified: boolean }>(
+    `select email_verified from web."user" where email = $1`,
+    [email.toLowerCase()],
+  );
+  return rows[0]?.email_verified;
+}
+
+test("a new person accepts passwordlessly end-to-end", async ({ page, browser }) => {
+  const email = uniqueEmail("redeem-new");
+  await inviteViaMembers(page, email);
+  const invitePath = await fishInvitePath(email);
+  const ws = await theWorkspace();
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await p.goto(invitePath);
+
+    // The pre-accept summary: who invited, where to, the role, and who the link is for.
+    await expect(p.getByRole("heading", { level: 1 })).toContainText(
+      `invited you to ${ws.displayName}`,
+    );
+    await expect(p.getByText(/This invitation is for/)).toBeVisible();
+    await expect(p.getByText(email).first()).toBeVisible();
+    await expect(p.getByText("member", { exact: true })).toBeVisible();
+
+    // The account-mint arm is PASSWORDLESS — no password field is rendered.
+    await expect(p.locator('input[name="password"]')).toHaveCount(0);
+    const accept = p.getByRole("button", { name: "Accept and create my account" });
+    await expect(accept).toBeVisible();
+    await accept.click();
+
+    // The redirect lands in the app, signed in, at the workspace root (the shell chrome renders).
+    await p.waitForURL((u) => u.pathname === "/");
+    await expect(p.getByRole("banner")).toBeVisible();
+  } finally {
+    await context.close();
+  }
+
+  // The seat is real, and holding the mailed token proved the mailbox (email_verified flips true).
+  expect(await seatRole(email)).toBe("member");
+  expect(await emailVerified(email)).toBe(true);
+});
+
+test("a signed-in matching account accepts in one click", async ({ browser }) => {
+  const email = uniqueEmail("redeem-match");
+  await ensureAccount(email);
+  // The one-click arm is the VERIFIED-match branch — prove the mailbox so it isn't the fence.
+  await adminQuery(`update web."user" set email_verified = true where email = $1`, [
+    email.toLowerCase(),
+  ]);
+  const invitePath = await seedInvitation(email);
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await signIn(p, email);
+    await p.goto(invitePath);
+    const accept = p.getByRole("button", { name: "Accept invitation" });
+    await expect(accept).toBeVisible();
+    await accept.click();
+    await p.waitForURL((u) => u.pathname === "/");
+  } finally {
+    await context.close();
+  }
+  expect(await seatRole(email)).toBe("member");
+});
+
+test("signed out with an existing account: sign-in-first returns", async ({ browser }) => {
+  const email = uniqueEmail("redeem-existing");
+  await ensureAccount(email);
+  await adminQuery(`update web."user" set email_verified = true where email = $1`, [
+    email.toLowerCase(),
+  ]);
+  const invitePath = await seedInvitation(email);
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await p.goto(invitePath);
+    // The invited address already has an account: sign in first, then return here to accept.
+    const signInLink = p.getByRole("link", { name: "Sign in as", exact: false });
+    await expect(signInLink).toBeVisible();
+    await expect(signInLink).toContainText(email);
+    // The link carries THIS page as the sign-in return target.
+    await expect(signInLink).toHaveAttribute("href", /^\/login\?next=%2Finvite%2F/);
+
+    // Sign in (the returns-here wiring), come back, and the one-click accept now renders.
+    await signIn(p, email);
+    await p.goto(invitePath);
+    await expect(p.getByRole("button", { name: "Accept invitation" })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});
+
+/**
+ * The switch arm signs the CURRENT account out and returns HERE — the page then renders the
+ * signed-out account-mint arm for the invited address. (The self-redirect normalizes the
+ * single-fetch `.data` suffix and rebuilds only the validated pass-through params, so the
+ * post-sign-out reload lands on the real token path.) This test uses a DEDICATED signed-in
+ * identity, never the shared owner storage state, so its sign-out can never invalidate the
+ * session other tests ride.
+ */
+test("the wrong account gets the switch page and never accepts", async ({ browser }) => {
+  const invitee = uniqueEmail("redeem-wrong"); // a fresh address with NO account
+  const other = uniqueEmail("redeem-wrong-session"); // a DIFFERENT address, signed in below
+  await ensureAccount(other);
+  const invitePath = await seedInvitation(invitee);
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    // A session on a different address than the invitee gets the switch page — never an accept.
+    await signIn(p, other);
+    await p.goto(invitePath);
+    await expect(p.getByText(/This invitation is for/)).toBeVisible();
+    await expect(p.getByText(invitee).first()).toBeVisible();
+
+    const switchBtn = p.getByRole("button", { name: "Sign out and continue as", exact: false });
+    await expect(switchBtn).toBeVisible();
+    await expect(switchBtn).toContainText(invitee);
+    // Nothing was accepted just by landing on the switch page.
+    expect(await invitationStatus(invitee)).toBe("pending");
+    await switchBtn.click();
+
+    // Intended: signed out now, the invited address has no account, so the account-mint arm
+    // renders — never an accept as the current (wrong) account. (Blocked by the bug above.)
+    await expect(p.getByRole("button", { name: "Accept and create my account" })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+
+  // Nothing was accepted or seated — the claim is still open.
+  expect(await invitationStatus(invitee)).toBe("pending");
+  expect(await seatRole(invitee)).toBeUndefined();
+});
+
+test("decline is recorded and the inviter sees it", async ({ page, browser }) => {
+  const email = uniqueEmail("redeem-decline");
+  const invitePath = await seedInvitation(email);
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await p.goto(invitePath);
+    await p.getByRole("button", { name: "Decline this invitation" }).click();
+    await expect(p.getByRole("heading", { name: "Invitation declined" })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+  expect(await invitationStatus(email)).toBe("declined");
+
+  // The inviter (the owner) sees the recorded decline on the members page.
+  await gotoSettled(page, "/members");
+  const row = page.getByRole("listitem").filter({ hasText: email });
+  await expect(row.getByText("declined")).toBeVisible();
+});
+
+test("an expired link is the one constant page", async ({ browser }) => {
+  const email = uniqueEmail("redeem-expired");
+  const invitePath = await seedInvitation(email);
+  await adminQuery(
+    `update web.invitation set expires_at = now() - interval '1 minute' where email = $1`,
+    [email.toLowerCase()],
+  );
+  const ws = await theWorkspace();
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await p.goto(invitePath);
+    await expect(p.getByRole("heading", { name: "Nothing to accept here" })).toBeVisible();
+
+    // The dead page names NEITHER the workspace nor the invited email.
+    const body = (await p.locator("body").innerText()).toLowerCase();
+    expect(body).not.toContain(ws.displayName.toLowerCase());
+    expect(body).not.toContain(email.toLowerCase());
+
+    // Non-enumeration: a syntactically-valid but invented token is the SAME constant page.
+    const invented = `/invite/${randomBytes(32).toString("base64url")}`;
+    await p.goto(invented);
+    await expect(p.getByRole("heading", { name: "Nothing to accept here" })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});
+
+test("an already-member arrival redirects into the workspace", async ({ browser }) => {
+  const email = uniqueEmail("redeem-member");
+  await ensureSeatedUser(email, "member");
+  const invitePath = await seedInvitation(email);
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await signIn(p, email);
+    // Already seated: the loader redirects straight into the workspace root, consuming nothing.
+    await p.goto(invitePath);
+    await p.waitForURL((u) => u.pathname === "/");
+    await expect(p.getByRole("banner")).toBeVisible();
+  } finally {
+    await context.close();
+  }
+  // A GET stayed a view — the invitation is untouched.
+  expect(await invitationStatus(email)).toBe("pending");
+});
+
+test("a skill-hinted invitation frames, subscribes, and lands on the skill", async ({
+  page,
+  browser,
+}) => {
+  const email = uniqueEmail("redeem-skill");
+  const skillName = "redeem-skill-onboarding";
+  const bundleId = "bndl-redeem-skill-0001";
+  await ensureBundle({ id: bundleId, name: skillName, displayName: skillName });
+
+  // A device credential for the seated owner, so the device-lane invite carries the skill hint.
+  const ws = await theWorkspace();
+  const owner = await ownerUserId();
+  const credential = `cred-redeem-skill-${randomBytes(8).toString("hex")}`;
+  await mintDevice(
+    owner,
+    `dev-redeem-skill-${randomBytes(6).toString("hex")}`,
+    "skill-inviter",
+    credential,
+  );
+
+  const resp = await page.request.post(`/api/v1/workspaces/${ws.id}/invitations`, {
+    headers: { Authorization: `Bearer ${credential}` },
+    data: { emails: [email], skill: skillName },
+  });
+  expect(resp.ok(), `skill-hinted invite failed: ${resp.status()} ${await resp.text()}`).toBe(true);
+
+  // The hinted mail leads with the skill in its subject.
+  const mail = await latestMail("invite", email);
+  expect(mail.subject).toContain(skillName);
+  const match = mail.text.match(/Accept in your browser:\s+(\S+)/);
+  if (!match?.[1]) {
+    throw new Error(`no invite URL in the skill-hinted mail for ${email}: ${mail.text}`);
+  }
+  const invitePath = new URL(match[1]).pathname;
+
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await p.goto(invitePath);
+    // The summary names the skill as the first destination.
+    await expect(p.getByText("First up:", { exact: false })).toBeVisible();
+    await expect(p.getByText(skillName).first()).toBeVisible();
+
+    // Accept passwordlessly → the redirect lands on the hinted skill face.
+    await p.getByRole("button", { name: "Accept and create my account" }).click();
+    await p.waitForURL((u) => u.pathname === `/skills/${skillName}`);
+  } finally {
+    await context.close();
+  }
+
+  // Seated + subscribed: the accept followed the hinted skill for the new person.
+  expect(await seatRole(email)).toBe("member");
+  const sub = await adminQuery<{ state: string }>(
+    `select bs.state from web.bundle_subscription bs
+       join web."user" u on u.id = bs.user_id
+     where u.email = $1 and bs.bundle_id = $2`,
+    [email.toLowerCase(), bundleId],
+  );
+  expect(sub[0]?.state).toBe("following");
+});

--- a/web/tests/e2e/skill-invite.spec.ts
+++ b/web/tests/e2e/skill-invite.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { adminQuery, ensureBundle, latestMail, theWorkspace } from "./seed";
+import { gotoSettled } from "./sign-in";
+
+/**
+ * The skill face's "invite a teammate to this skill" affordance. A member expands the quiet
+ * button into a one-email form; submitting mints an invitation whose FIRST destination is THIS
+ * skill — the invitation row carries the skill's bundle id as its hint, and the notice mail leads
+ * with the skill in its subject. The suite runs MAIL-ARMED (all five TOPOS_MAIL_SMTP_* point at
+ * the sink, so `canSend` is true), so the affordance is enabled and the "sent" copy lands in the
+ * dev outbox. The default storage state is the claimed OWNER; the bare bundle (no published
+ * version — the affordance renders regardless) is this file's own arrangement.
+ */
+
+const SKILL_ID = "s_e2e_skill_invite";
+const SKILL = "invite-target";
+// Fresh per run: a reused local database must never hand this walk an already-pending row.
+const INVITED = `skill-invitee-${Date.now().toString(36)}@example.com`;
+
+test.beforeAll(async () => {
+  await ensureBundle({ id: SKILL_ID, name: SKILL });
+  await adminQuery(`delete from web.invitation where email = $1`, [INVITED]);
+});
+
+test("invite to this skill: the collapsed affordance, the hinted row, the skill-led mail", async ({
+  page,
+}) => {
+  await theWorkspace();
+  await gotoSettled(page, `/skills/${SKILL}`);
+
+  // The affordance is a quiet, collapsed button; expanding it reveals the one-email form.
+  await page.getByRole("button", { name: "Invite a teammate" }).click();
+  await page.getByLabel("Invite by email").fill(INVITED);
+  await page.getByRole("button", { name: "Invite", exact: true }).click();
+
+  // (a) The reply confirmation names the invited address and says the mail leads with the skill.
+  await expect(page.getByRole("status").filter({ hasText: `Invited ${INVITED}` })).toContainText(
+    "the mail leads with this skill",
+  );
+
+  // (b) The invitation row carries THIS skill's bundle id as its first-destination hint, and a
+  // single-use link token (only its hash is stored).
+  const rows = await adminQuery<{ hint_bundle_id: string | null; token_sha256: unknown }>(
+    `select hint_bundle_id, token_sha256 from web.invitation where email = $1`,
+    [INVITED],
+  );
+  expect(rows[0]?.hint_bundle_id).toBe(SKILL_ID);
+  expect(rows[0]?.token_sha256).toBeTruthy();
+
+  // (c) The notice mail LEADS with the skill in its subject and carries the tokened /invite/ link.
+  const mail = await latestMail("invite", INVITED);
+  expect(mail.subject).toContain(`starting with the ${SKILL} skill`);
+  expect(mail.text).toContain("/invite/");
+});

--- a/web/tests/e2e/verify.spec.ts
+++ b/web/tests/e2e/verify.spec.ts
@@ -3,11 +3,12 @@ import { MEMBER_EMAIL, WORKSPACE_ADDRESS } from "./env";
 import { adminQuery } from "./seed";
 
 /**
- * The gh-style DEVICE-APPROVE ceremony end to end: the CLI half is the real `/api/v1/device/*`
- * flow (start → poll), the browser half is /verify — a signed-in person resolves the short
- * user code, sees what is asking, and approves with a PLAIN ACCEPT (a live session plus the
- * explicit click mints a credential that acts as them) or denies. Terminal poll answers are
- * delivered ONCE.
+ * The gh-style DEVICE-APPROVE ceremony end to end, over the TWO-STATE /verify page: the CLI half
+ * is the real `/api/v1/device/*` flow (start → poll), the browser half is /verify — a signed-in
+ * person TYPES the short user code into a POST lookup form (the code never rides a URL anymore),
+ * sees exactly what is asking and everywhere the credential will reach, and approves with a PLAIN
+ * ACCEPT (a live session plus the explicit click mints a credential that acts as them) or denies.
+ * Terminal poll answers are delivered ONCE.
  *
  * Runs with the suite's default storage state (the claimed owner) except the signed-out leg.
  */
@@ -17,8 +18,8 @@ test.describe.configure({ mode: "serial" });
 interface DeviceFlowStart {
   device_code: string;
   user_code: string;
-  verification_uri: string;
-  verification_uri_complete: string;
+  /** The whole start response — asserted against for the retired code-embedding URL. */
+  raw: Record<string, unknown>;
 }
 
 async function startDeviceFlow(page: Page, requestedName: string): Promise<DeviceFlowStart> {
@@ -26,7 +27,8 @@ async function startDeviceFlow(page: Page, requestedName: string): Promise<Devic
     data: { requested_name: requestedName, workspace: WORKSPACE_ADDRESS },
   });
   expect(response.ok(), `device authorize failed: ${response.status()}`).toBe(true);
-  return (await response.json()) as DeviceFlowStart;
+  const raw = (await response.json()) as Record<string, unknown>;
+  return { device_code: String(raw.device_code), user_code: String(raw.user_code), raw };
 }
 
 async function pollDeviceFlow(
@@ -45,36 +47,57 @@ async function pollDeviceFlow(
   return response.json();
 }
 
+/** State one → two: type the code into the POST lookup form so the resolved card renders. */
+async function lookUp(page: Page, userCode: string): Promise<void> {
+  await page.goto("/verify");
+  await page.getByLabel("Code").fill(userCode);
+  await page.getByRole("button", { name: "Look up" }).click();
+}
+
 test.describe("signed out", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test("the verify page bounces to /login carrying itself — code included — as the next path", async ({
+  test("the verify page bounces to /login carrying itself — the device pass-through included — as the next path", async ({
     page,
   }) => {
-    await page.goto("/verify?code=AB12-CD34");
+    // The loopback device-code HASH the CLI auto-opens with (identifying, never secret): the
+    // signed-out bounce re-carries it as `next` so the sign-in returns to finish the approval.
+    // The short code is NOT a URL param anymore, so nothing about it appears here.
+    const device = "ab".repeat(32); // 64 hex — the device-code-hash shape the loader validates
+    await page.goto(`/verify?device=${device}`);
     await page.waitForURL((u) => u.pathname === "/login");
     const next = new URL(page.url()).searchParams.get("next");
-    expect(next).toBe("/verify?code=AB12-CD34");
+    expect(next).toBe(`/verify?device=${device}`);
   });
 });
 
 test("an unknown code is an honest in-page state, never a 404", async ({ page }) => {
-  await page.goto("/verify?code=ZZZZ-9999");
+  await lookUp(page, "ZZZZ-9999");
   await expect(page.getByRole("heading", { name: "Approve a device" })).toBeVisible();
-  await expect(page.getByText("No pending request for this code")).toBeVisible();
+  await expect(page.getByText("No pending request for that code")).toBeVisible();
 });
 
 test("approve is a plain signed-in accept: the click mints the credential the poll delivers", async ({
   page,
 }) => {
   const flow = await startDeviceFlow(page, "e2e-laptop");
-  expect(flow.verification_uri_complete).toContain(`/verify?code=`);
+  // The reworked start: the code never enters ANY URL — the retired `verification_uri_complete`
+  // (which embedded the code in a GET) is gone, and `verification_uri` is the bare /verify page.
+  expect(flow.raw.verification_uri_complete).toBeUndefined();
+  expect(String(flow.raw.verification_uri).endsWith("/verify")).toBe(true);
+  expect(String(flow.raw.verification_uri)).not.toContain("code");
 
-  await page.goto(`/verify?code=${encodeURIComponent(flow.user_code)}`);
-  // The resolved request names what is asking, honestly (the name also rides the approve
-  // button's label, so pin the disclosure span exactly).
+  // Before approval the terminal's poll is still pending.
+  expect((await pollDeviceFlow(page, flow.device_code)).status).toBe("pending");
+
+  await lookUp(page, flow.user_code);
+  // The resolved request names what is asking, honestly (the name also rides the approve button's
+  // label, so pin the disclosure span exactly), shows the CODE for the terminal glance-check, and
+  // lists everywhere the credential will reach.
   await expect(page.getByText("“e2e-laptop”", { exact: true })).toBeVisible();
   await expect(page.getByText("wants to act as you", { exact: false })).toBeVisible();
+  await expect(page.getByText(flow.user_code, { exact: false }).first()).toBeVisible();
+  await expect(page.getByText("acts with your seat in:", { exact: false })).toBeVisible();
 
   // A live session plus the explicit click is the whole ceremony — no step-up, no password.
   await page.getByRole("button", { name: "Approve “e2e-laptop”" }).click();
@@ -106,7 +129,7 @@ test("deny destroys the pending request and mints nothing — no step-up needed"
   page,
 }) => {
   const flow = await startDeviceFlow(page, "e2e-stranger");
-  await page.goto(`/verify?code=${encodeURIComponent(flow.user_code)}`);
+  await lookUp(page, flow.user_code);
   await expect(page.getByText("“e2e-stranger”", { exact: true })).toBeVisible();
 
   await page.getByRole("button", { name: "Deny — this isn’t my device" }).click();

--- a/web/tests/unit/api-v1-routes.test.ts
+++ b/web/tests/unit/api-v1-routes.test.ts
@@ -1206,12 +1206,9 @@ describe("device authorize + token", () => {
       "interval_secs",
       "user_code",
       "verification_uri",
-      "verification_uri_complete",
     ]);
+    // The code never enters ANY URL — the bare /verify address is all the wire carries.
     expect(flow.verification_uri).toBe("http://x/verify");
-    expect(flow.verification_uri_complete).toBe(
-      `http://x/verify?code=${encodeURIComponent(flow.user_code as string)}`,
-    );
     expect(flow.expires_in_secs).toBe(900);
     expect(flow.interval_secs).toBe(5);
 

--- a/web/tests/unit/dev-outbox.test.ts
+++ b/web/tests/unit/dev-outbox.test.ts
@@ -53,7 +53,7 @@ describe("the dev outbox accumulates across mail kinds", () => {
       await invite.sendInviteEmail({
         to: "carol@example.com",
         workspaceDisplayName: "Acme",
-        address: "https://topos.example/acme",
+        inviteUrl: "https://topos.example/invite/tok-abc",
         agentUrl: "https://topos.example/agent",
         invitedBy: "owner@example.com",
       });

--- a/web/tests/unit/identity-core.test.ts
+++ b/web/tests/unit/identity-core.test.ts
@@ -139,6 +139,8 @@ describe("the device flow", () => {
     expect(await identity.pendingDeviceAuth(flow.userCode)).toEqual({
       requestedName: "laptop",
       requestedWorkspace: "",
+      userCode: flow.userCode,
+      inviteWorkspace: null,
     });
     const approved = await identity.approveDeviceAuth(flow.userCode, {
       userId: owner,
@@ -411,6 +413,7 @@ describe("registrationDecision", () => {
                     policy,
                     tenancy,
                     inClaimCeremony,
+                    inInvitationCeremony: false,
                     registrationKnob,
                     pendingInvitation,
                     mailArmed,
@@ -434,6 +437,7 @@ describe("registrationDecision", () => {
         policy: "gated",
         tenancy: "multi",
         inClaimCeremony: false,
+        inInvitationCeremony: false,
         registrationKnob: "open",
         pendingInvitation: false,
         mailArmed: true,
@@ -445,6 +449,7 @@ describe("registrationDecision", () => {
         policy: "gated",
         tenancy: "single",
         inClaimCeremony: false,
+        inInvitationCeremony: false,
         registrationKnob: "invite_only",
         pendingInvitation: true,
         mailArmed: false,
@@ -456,6 +461,7 @@ describe("registrationDecision", () => {
         policy: "open",
         tenancy: "multi",
         inClaimCeremony: false,
+        inInvitationCeremony: false,
         registrationKnob: null,
         pendingInvitation: false,
         mailArmed: false,

--- a/web/tests/unit/invitation-redemption.test.ts
+++ b/web/tests/unit/invitation-redemption.test.ts
@@ -103,9 +103,7 @@ describe("mint + view", () => {
        WHERE email = 'expired@x.test'`,
       [],
     );
-    const { invitationByToken, acceptInvitationByToken } = await import(
-      "@/lib/db/identity.server"
-    );
+    const { invitationByToken, acceptInvitationByToken } = await import("@/lib/db/identity.server");
     expect(await invitationByToken(token)).toBeNull();
     await verifiedUser("u_expired", "expired@x.test");
     const result = await acceptInvitationByToken(
@@ -233,9 +231,7 @@ describe("accept", () => {
   it("the wrong account never accepts — and consumes nothing", async () => {
     const token = await invite("intended@x.test");
     await verifiedUser("u_intruder", "someoneelse@x.test");
-    const { acceptInvitationByToken, invitationByToken } = await import(
-      "@/lib/db/identity.server"
-    );
+    const { acceptInvitationByToken, invitationByToken } = await import("@/lib/db/identity.server");
     const result = await acceptInvitationByToken(
       token,
       { userId: "u_intruder", display: "I" },
@@ -278,10 +274,7 @@ describe("decline", () => {
     // Dead afterwards — and declining again answers the same constant miss.
     expect(await invitationByToken(token)).toBeNull();
     expect(await declineInvitationByToken(token)).toBe("gone");
-    const rows = await db.q(
-      `SELECT status FROM web.invitation WHERE email = 'decline@x.test'`,
-      [],
-    );
+    const rows = await db.q(`SELECT status FROM web.invitation WHERE email = 'decline@x.test'`, []);
     expect(rows[0]?.status).toBe("declined");
     // Re-inviting supersedes the declined record with a fresh pending row.
     const fresh = await invite("decline@x.test");

--- a/web/tests/unit/invitation-redemption.test.ts
+++ b/web/tests/unit/invitation-redemption.test.ts
@@ -387,6 +387,35 @@ describe("the device-flow weave", () => {
     expect(await identity.invitationByToken(token)).not.toBeNull();
   });
 
+  it("a failed approval rolls back the invitation accept — never a split-brain commit", async () => {
+    // The invited person IS the addressee (the accept would seat them), but the flow's device
+    // code has already been made unresolvable (past expiry) so the approval's own liveness gate
+    // refuses under the lock. The accept must NOT commit while the poll reports refused.
+    const token = await invite("rollback@x.test");
+    await verifiedUser("u_rollback", "rollback@x.test");
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startDeviceAuth("laptop", "", token);
+    // Expire the flow after minting (the FOR-UPDATE liveness gate then finds no live row → the
+    // whole approval — accept included — rolls back).
+    await db.q(
+      `UPDATE web.device_auth_session SET expires_at = now() - interval '1 minute'
+       WHERE user_code = $1`,
+      [flow.userCode],
+    );
+    const approved = await identity.approveDeviceAuth(flow.userCode, {
+      userId: "u_rollback",
+      display: "R",
+    });
+    expect(approved).toBeNull();
+    // The invitation is STILL pending (never consumed) and no seat was written.
+    expect(await identity.invitationByToken(token)).not.toBeNull();
+    const seat = await db.q(
+      `SELECT 1 FROM web.seat s JOIN web."user" u ON u.id = s.user_id WHERE u.email = 'rollback@x.test'`,
+      [],
+    );
+    expect(seat.length).toBe(0);
+  });
+
   it("devicePerson resolves a credential seat-lessly, fail-closed", async () => {
     const identity = await import("@/lib/db/identity.server");
     await seedUser(db, "u_dev", "Dev", "dev@x.test");

--- a/web/tests/unit/invitation-redemption.test.ts
+++ b/web/tests/unit/invitation-redemption.test.ts
@@ -1,0 +1,408 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  asMember,
+  bootWorkspace,
+  createScratchDb,
+  placeInDefault,
+  type ScratchDb,
+  seatUser,
+  seedBundle,
+  seedChannel,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * The tokened invitation ceremonies: mint (only the hash stored; re-inviting supersedes),
+ * the GET-safe view, the FOR-UPDATE-fenced accept (email-bound, unverified-squat-fenced,
+ * hint effects after the seat, race-safe), the session-less decline, and the device-flow
+ * weave (the flow row carries the token; approval accepts inside its own fence; the granted
+ * poll decorates the hint). Every dead-token read answers the same null — the constant page.
+ */
+
+let db: ScratchDb;
+let ws: string;
+
+/** The inviter's member actor (seeded once). */
+const INVITER = "u_inviter";
+
+beforeAll(async () => {
+  db = await createScratchDb("invredeem");
+  ws = await bootWorkspace();
+  await seedUser(db, INVITER, "Inviter", "inviter@acme.test");
+  await seatUser(db, ws, INVITER, "owner");
+  await seedBundle(db, ws, "s_deploy", "deploy");
+  await placeInDefault(db, ws, "s_deploy");
+  await seedChannel(db, ws, "c_eng", "eng");
+}, 60_000);
+
+afterAll(async () => {
+  await db?.drop();
+});
+
+/** Mint ONE invitation via the roster ceremony; return its plaintext token. */
+async function invite(
+  email: string,
+  hint: { bundleId?: string; channelId?: string } = {},
+): Promise<string> {
+  const { createInvitations } = await import("@/lib/db/queries.roster.server");
+  const outcome = await createInvitations(asMember(ws, INVITER, "owner"), [email], "members", hint);
+  if (outcome.outcome !== "invited") {
+    throw new Error(`invite refused: ${outcome.outcome}`);
+  }
+  const minted = outcome.minted[0];
+  if (minted === undefined) {
+    throw new Error("nothing minted");
+  }
+  return minted.token;
+}
+
+/** A verified account for `email` (the invited persona most tests act as). */
+async function verifiedUser(id: string, email: string): Promise<void> {
+  await seedUser(db, id, "", email);
+  await db.q(`UPDATE web."user" SET email_verified = true WHERE id = $1`, [id]);
+}
+
+describe("mint + view", () => {
+  it("stores only the token hash; the view resolves a live token and nothing else", async () => {
+    const token = await invite("viewer@x.test", { bundleId: "s_deploy" });
+    const rows = await db.q(
+      `SELECT token_sha256 = sha256(convert_to($1, 'UTF8')) AS hashed, hint_bundle_id
+       FROM web.invitation WHERE email = 'viewer@x.test' AND status = 'pending'`,
+      [token],
+    );
+    expect(rows[0]?.hashed).toBe(true);
+    expect(rows[0]?.hint_bundle_id).toBe("s_deploy");
+
+    const { invitationByToken } = await import("@/lib/db/identity.server");
+    const view = await invitationByToken(token);
+    expect(view).not.toBeNull();
+    expect(view?.email).toBe("viewer@x.test");
+    expect(view?.role).toBe("member");
+    expect(view?.inviterDisplay).toBe("Inviter");
+    expect(view?.hint).toEqual({ kind: "skill", name: "deploy" });
+    // The delivered summary: the default channel's one active bundle.
+    expect(view?.deliveredCount).toBe(1);
+    expect(view?.viaChannels).toEqual(["everyone"]);
+    // An invented token answers the same null every dead state does.
+    expect(await invitationByToken("not-a-token")).toBeNull();
+  });
+
+  it("re-inviting mints a fresh token and kills the old link", async () => {
+    const first = await invite("reinvite@x.test");
+    const second = await invite("reinvite@x.test");
+    expect(second).not.toBe(first);
+    const { invitationByToken } = await import("@/lib/db/identity.server");
+    expect(await invitationByToken(first)).toBeNull();
+    expect(await invitationByToken(second)).not.toBeNull();
+  });
+
+  it("an expired invitation is the same constant miss", async () => {
+    const token = await invite("expired@x.test");
+    await db.q(
+      `UPDATE web.invitation SET expires_at = now() - interval '1 minute'
+       WHERE email = 'expired@x.test'`,
+      [],
+    );
+    const { invitationByToken, acceptInvitationByToken } = await import(
+      "@/lib/db/identity.server"
+    );
+    expect(await invitationByToken(token)).toBeNull();
+    await verifiedUser("u_expired", "expired@x.test");
+    const result = await acceptInvitationByToken(
+      token,
+      { userId: "u_expired", display: "E" },
+      { mailboxProven: false },
+    );
+    expect(result.outcome).toBe("gone");
+  });
+
+  it("a revoked invitation's token is dead", async () => {
+    const token = await invite("revoked@x.test");
+    const { revokeInvitation } = await import("@/lib/db/queries.roster.server");
+    const rows = await db.q(`SELECT id FROM web.invitation WHERE email = 'revoked@x.test'`, []);
+    await revokeInvitation(asMember(ws, INVITER, "owner"), rows[0]?.id as string);
+    const { invitationByToken } = await import("@/lib/db/identity.server");
+    expect(await invitationByToken(token)).toBeNull();
+  });
+});
+
+describe("accept", () => {
+  it("binds to the invited email's account and lands seat + hint in one transaction", async () => {
+    const token = await invite("accept@x.test", { bundleId: "s_deploy" });
+    await verifiedUser("u_accept", "accept@x.test");
+    const { acceptInvitationByToken } = await import("@/lib/db/identity.server");
+    const result = await acceptInvitationByToken(
+      token,
+      { userId: "u_accept", display: "A" },
+      { mailboxProven: false },
+    );
+    expect(result.outcome).toBe("accepted");
+    if (result.outcome !== "accepted") {
+      return;
+    }
+    expect(result.workspaceId).toBe(ws);
+    expect(result.hint).toEqual({ kind: "skill", name: "deploy" });
+    expect(result.alreadyMember).toBe(false);
+    const seat = await db.q(
+      `SELECT role, invited_by FROM web.seat WHERE workspace_id = $1 AND user_id = 'u_accept'`,
+      [ws],
+    );
+    expect(seat[0]?.role).toBe("member");
+    expect(seat[0]?.invited_by).toBe(INVITER);
+    // The hint effect: the direct follow, written AFTER the seat, same transaction.
+    const sub = await db.q(
+      `SELECT state FROM web.bundle_subscription WHERE user_id = 'u_accept' AND bundle_id = 's_deploy'`,
+      [],
+    );
+    expect(sub[0]?.state).toBe("following");
+    // Consumed: the row flips accepted; the audit trail carries the act.
+    const inv = await db.q(
+      `SELECT status, accepted_by FROM web.invitation WHERE email = 'accept@x.test'`,
+      [],
+    );
+    expect(inv[0]?.status).toBe("accepted");
+    expect(inv[0]?.accepted_by).toBe("u_accept");
+    const audit = await db.q(
+      `SELECT count(*)::int AS n FROM web.audit_event
+       WHERE kind = 'invitation_accepted' AND subject = 'accept@x.test'`,
+      [],
+    );
+    expect(audit[0]?.n).toBe(1);
+  });
+
+  it("a channel hint joins the channel", async () => {
+    const token = await invite("chan@x.test", { channelId: "c_eng" });
+    await verifiedUser("u_chan", "chan@x.test");
+    const { acceptInvitationByToken } = await import("@/lib/db/identity.server");
+    const result = await acceptInvitationByToken(
+      token,
+      { userId: "u_chan", display: "C" },
+      { mailboxProven: false },
+    );
+    expect(result.outcome).toBe("accepted");
+    if (result.outcome === "accepted") {
+      expect(result.hint).toEqual({ kind: "channel", name: "eng" });
+    }
+    const member = await db.q(
+      `SELECT 1 FROM web.channel_member WHERE channel_id = 'c_eng' AND user_id = 'u_chan'`,
+      [],
+    );
+    expect(member.length).toBe(1);
+  });
+
+  it("an archived hint lands the seat and simply drops the hint", async () => {
+    await seedBundle(db, ws, "s_gone", "gone-skill", { status: "archived" });
+    const token = await invite("hintgone@x.test", { bundleId: "s_gone" });
+    await verifiedUser("u_hintgone", "hintgone@x.test");
+    const { acceptInvitationByToken } = await import("@/lib/db/identity.server");
+    const result = await acceptInvitationByToken(
+      token,
+      { userId: "u_hintgone", display: "H" },
+      { mailboxProven: false },
+    );
+    expect(result.outcome).toBe("accepted");
+    if (result.outcome === "accepted") {
+      expect(result.hint).toBeNull();
+    }
+    const sub = await db.q(
+      `SELECT 1 FROM web.bundle_subscription WHERE user_id = 'u_hintgone'`,
+      [],
+    );
+    expect(sub.length).toBe(0);
+  });
+
+  it("two racing accepts serialize — exactly one consumes", async () => {
+    const token = await invite("race@x.test");
+    await verifiedUser("u_race", "race@x.test");
+    const { acceptInvitationByToken } = await import("@/lib/db/identity.server");
+    const actor = { userId: "u_race", display: "R" };
+    const [a, b] = await Promise.all([
+      acceptInvitationByToken(token, actor, { mailboxProven: false }),
+      acceptInvitationByToken(token, actor, { mailboxProven: false }),
+    ]);
+    const outcomes = [a.outcome, b.outcome].sort();
+    expect(outcomes).toEqual(["accepted", "gone"]);
+    // One seat, one accepted row — never two consumptions.
+    const seats = await db.q(
+      `SELECT count(*)::int AS n FROM web.seat WHERE workspace_id = $1 AND user_id = 'u_race'`,
+      [ws],
+    );
+    expect(seats[0]?.n).toBe(1);
+  });
+
+  it("the wrong account never accepts — and consumes nothing", async () => {
+    const token = await invite("intended@x.test");
+    await verifiedUser("u_intruder", "someoneelse@x.test");
+    const { acceptInvitationByToken, invitationByToken } = await import(
+      "@/lib/db/identity.server"
+    );
+    const result = await acceptInvitationByToken(
+      token,
+      { userId: "u_intruder", display: "I" },
+      { mailboxProven: false },
+    );
+    expect(result.outcome).toBe("wrong_account");
+    expect(await invitationByToken(token)).not.toBeNull();
+  });
+
+  it("the unverified-squat fence demands the round-trip; the token-proven path passes and proves", async () => {
+    const token = await invite("squat@x.test");
+    await seedUser(db, "u_squat", "", "squat@x.test"); // email_verified defaults false
+    const { acceptInvitationByToken } = await import("@/lib/db/identity.server");
+    const refused = await acceptInvitationByToken(
+      token,
+      { userId: "u_squat", display: "S" },
+      { mailboxProven: false },
+    );
+    expect(refused.outcome).toBe("unverified");
+    // The token-holding path (the account-mint arm) IS the mailbox proof: the fence passes and
+    // the account's address flips verified inside the same transaction.
+    const proven = await acceptInvitationByToken(
+      token,
+      { userId: "u_squat", display: "S" },
+      { mailboxProven: true },
+    );
+    expect(proven.outcome).toBe("accepted");
+    const user = await db.q(`SELECT email_verified FROM web."user" WHERE id = 'u_squat'`, []);
+    expect(user[0]?.email_verified).toBe(true);
+  });
+});
+
+describe("decline", () => {
+  it("is recorded, session-less, re-invitable — and supersedes on re-invite", async () => {
+    const token = await invite("decline@x.test");
+    const { declineInvitationByToken, invitationByToken } = await import(
+      "@/lib/db/identity.server"
+    );
+    expect(await declineInvitationByToken(token)).toBe("declined");
+    // Dead afterwards — and declining again answers the same constant miss.
+    expect(await invitationByToken(token)).toBeNull();
+    expect(await declineInvitationByToken(token)).toBe("gone");
+    const rows = await db.q(
+      `SELECT status FROM web.invitation WHERE email = 'decline@x.test'`,
+      [],
+    );
+    expect(rows[0]?.status).toBe("declined");
+    // Re-inviting supersedes the declined record with a fresh pending row.
+    const fresh = await invite("decline@x.test");
+    const after = await db.q(
+      `SELECT status FROM web.invitation WHERE email = 'decline@x.test' ORDER BY status`,
+      [],
+    );
+    expect(after.map((r) => r.status)).toEqual(["pending"]);
+    expect(await invitationByToken(fresh)).not.toBeNull();
+  });
+});
+
+describe("the invitation page's branch resolve", () => {
+  it("resolves every visitor arm from the one sanctioned place", async () => {
+    const token = await invite("branch@x.test");
+    const { invitationPageView } = await import("@/lib/db/identity.server");
+    // Anonymous, no account under the address.
+    expect((await invitationPageView(token, null))?.branch).toBe("anon_new");
+    // Anonymous, the address has an account.
+    await seedUser(db, "u_branch", "", "branch@x.test");
+    expect((await invitationPageView(token, null))?.branch).toBe("anon_existing");
+    // Signed in as the invited address, unverified mailbox.
+    expect((await invitationPageView(token, "u_branch"))?.branch).toBe("match_unverified");
+    // Verified → the one-click arm.
+    await db.q(`UPDATE web."user" SET email_verified = true WHERE id = 'u_branch'`, []);
+    expect((await invitationPageView(token, "u_branch"))?.branch).toBe("match");
+    // A different signed-in account → the switch page.
+    expect((await invitationPageView(token, INVITER))?.branch).toBe("other");
+    // Already seated → the redirect arm.
+    await seatUser(db, ws, "u_branch", "member");
+    expect((await invitationPageView(token, "u_branch"))?.branch).toBe("member");
+    // A dead token resolves null whoever asks.
+    expect(await invitationPageView("dead-token", "u_branch")).toBeNull();
+  });
+});
+
+describe("the registration ceremony", () => {
+  it("admits the link's account mint on a gated deployment — and only inside the ceremony", async () => {
+    const { registrationDecision, withInvitationCeremony, assertRegistrationAllowed } =
+      await import("@/lib/auth/registration.server");
+    // The pure row: the invitation ceremony admits with every other fact closed.
+    expect(
+      registrationDecision({
+        policy: "gated",
+        tenancy: "single",
+        inClaimCeremony: false,
+        inInvitationCeremony: true,
+        registrationKnob: "invite_only",
+        pendingInvitation: false,
+        mailArmed: false,
+      }),
+    ).toBe("allow");
+    // The live hook: inside the wrapper the same email that refuses outside is admitted.
+    await expect(
+      withInvitationCeremony(() => assertRegistrationAllowed("nobody@x.test")),
+    ).resolves.toBeUndefined();
+    await expect(assertRegistrationAllowed("nobody@x.test")).rejects.toThrow();
+  });
+});
+
+describe("the device-flow weave", () => {
+  it("records the token; approval accepts the invitation inside its own fence; the poll carries the hint", async () => {
+    const token = await invite("weave@x.test", { bundleId: "s_deploy" });
+    await verifiedUser("u_weave", "weave@x.test");
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startDeviceAuth("weave laptop", "", token);
+    // The pending views disclose the invitation's workspace to the code/challenge holder.
+    const pending = await identity.pendingDeviceAuth(flow.userCode);
+    expect(pending?.inviteWorkspace?.name).toBeDefined();
+    // The challenge lookup resolves the same flow with zero typing.
+    const challenge = await db.q(
+      `SELECT encode(device_code_sha256, 'hex') AS hex FROM web.device_auth_session
+       WHERE user_code = $1`,
+      [flow.userCode],
+    );
+    const byChallenge = await identity.pendingDeviceAuthByChallenge(challenge[0]?.hex as string);
+    expect(byChallenge?.userCode).toBe(flow.userCode);
+    // The SEATLESS invited person approves: the weave accepts the invitation first, so the
+    // seat requirement passes in the same transaction.
+    const approved = await identity.approveDeviceAuth(flow.userCode, {
+      userId: "u_weave",
+      display: "W",
+    });
+    expect(approved).not.toBeNull();
+    const seat = await db.q(
+      `SELECT 1 FROM web.seat WHERE workspace_id = $1 AND user_id = 'u_weave'`,
+      [ws],
+    );
+    expect(seat.length).toBe(1);
+    // The granted poll decorates the hint the invitation named.
+    const poll = await identity.pollDeviceAuth(flow.deviceCode);
+    expect(poll.status).toBe("granted");
+    if (poll.status === "granted") {
+      expect(poll.hint).toEqual({ kind: "skill", name: "deploy" });
+    }
+  });
+
+  it("a wrong-account approver gains nothing from a token-carrying flow", async () => {
+    const token = await invite("weave2@x.test");
+    await verifiedUser("u_notmine", "other2@x.test");
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startDeviceAuth("laptop", "", token);
+    // Seatless AND not the addressee: the weave refuses the accept, the seat check refuses the
+    // approval — the same uniform null an expired code gets. The invitation stays live.
+    const approved = await identity.approveDeviceAuth(flow.userCode, {
+      userId: "u_notmine",
+      display: "N",
+    });
+    expect(approved).toBeNull();
+    expect(await identity.invitationByToken(token)).not.toBeNull();
+  });
+
+  it("devicePerson resolves a credential seat-lessly, fail-closed", async () => {
+    const identity = await import("@/lib/db/identity.server");
+    await seedUser(db, "u_dev", "Dev", "dev@x.test");
+    const { seedDevice } = await import("./helpers/scratch-db");
+    await seedDevice(db, "dk_person", "u_dev");
+    // The seeded credential hash derives from the id itself.
+    const person = await identity.devicePerson("dk_person");
+    expect(person?.userId).toBe("u_dev");
+    expect(person?.email).toBe("dev@x.test");
+    expect(await identity.devicePerson("dk_bogus")).toBeNull();
+  });
+});

--- a/web/tests/unit/invite-mail.test.ts
+++ b/web/tests/unit/invite-mail.test.ts
@@ -8,9 +8,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
  * OWN file, NEVER `.magic-links.jsonl` (whose reader parses every line of its file and would hand
  * a sign-in flow the wrong thing). Delivery rides the ONE transport: without the five
  * `TOPOS_MAIL_SMTP_*`, production is a deliberate no-op and `inviteMailDelivery().canSend` is
- * false; with them, production really sends. The notice carries the workspace ADDRESS + display
- * name — the full `<origin>/<name>` follow target rendered verbatim (never re-prefixed), never a
- * tokened link.
+ * false; with them, production really sends. The mail carries the TOKENED invite URL through
+ * three CTAs in a fixed order — the browser link first, the agent paste-block second, the
+ * terminal `topos follow` line third — and a hinted invitation leads with its first
+ * destination.
  */
 
 const { sendMailSpy, createTransportSpy } = vi.hoisted(() => {
@@ -48,9 +49,8 @@ async function importInviteMail(appEnv: string, smtp: Record<string, string> = {
 const INVITE = {
   to: "newbie@example.com",
   workspaceDisplayName: "Acme Platform",
-  // The FULL follow target (`<origin>/<name>`) the caller composes — the notice renders it
-  // verbatim, never re-prepending an origin.
-  address: "https://topos.example/acme-platform",
+  // The tokened invitation URL the caller composes — every CTA renders it verbatim.
+  inviteUrl: "https://topos.example/invite/tok-0123456789",
   // The deployment's own agent-onboarding doc — the agent paste-block tells it to fetch this.
   agentUrl: "https://topos.example/agent",
   invitedBy: "owner@example.com",
@@ -78,7 +78,7 @@ describe("inviteMailDelivery", () => {
 });
 
 describe("sendInviteEmail in test mode", () => {
-  it("appends {to,address,...} to .invite-emails.jsonl — never .magic-links.jsonl, never a send", async () => {
+  it("appends {to,inviteUrl,...} to .invite-emails.jsonl — never .magic-links.jsonl, never a send", async () => {
     const mail = await importInviteMail("test");
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
@@ -94,12 +94,9 @@ describe("sendInviteEmail in test mode", () => {
       const parsed = JSON.parse(lines[0] as string);
       expect(parsed).toMatchObject({
         to: INVITE.to,
-        address: INVITE.address,
+        inviteUrl: INVITE.inviteUrl,
         workspaceDisplayName: INVITE.workspaceDisplayName,
       });
-      // The address is the plain follow target — no tokened link machinery of any kind.
-      expect(lines[0]).not.toContain("/i/");
-      expect(lines[0]).not.toContain("token");
       // The accumulating dev outbox carries the FULL rendered mail, kind-tagged.
       const outbox = (await fs.readFile(path.join(dir, ".outbox.jsonl"), "utf8"))
         .trim()
@@ -108,15 +105,16 @@ describe("sendInviteEmail in test mode", () => {
       const recorded = JSON.parse(outbox[0] as string);
       expect(recorded.kind).toBe("invite");
       expect(recorded.to).toBe(INVITE.to);
-      expect(recorded.subject).toBe(
-        `You've been invited to ${INVITE.workspaceDisplayName} on Topos`,
+      expect(recorded.subject).toBe(`You're invited to ${INVITE.workspaceDisplayName} on Topos`);
+      // The three CTAs, in the decided order: browser link, agent paste-block, terminal line.
+      const browserAt = recorded.text.indexOf(`  ${INVITE.inviteUrl}`);
+      const agentAt = recorded.text.indexOf(
+        `Set up Topos for us: fetch ${INVITE.agentUrl} and follow it. Our invite: ${INVITE.inviteUrl}`,
       );
-      // The terminal line renders the full address verbatim — no origin is ever doubled onto it.
-      expect(recorded.text).toContain(`topos follow ${INVITE.address}`);
-      // The agent path is a complete paste-block: fetch the onboarding doc, then this address.
-      expect(recorded.text).toContain(
-        `Set up Topos for us: fetch ${INVITE.agentUrl} and follow it. Our workspace: ${INVITE.address}`,
-      );
+      const terminalAt = recorded.text.indexOf(`topos follow ${INVITE.inviteUrl}`);
+      expect(browserAt).toBeGreaterThan(-1);
+      expect(agentAt).toBeGreaterThan(browserAt);
+      expect(terminalAt).toBeGreaterThan(agentAt);
       await expect(fs.access(path.join(dir, ".magic-links.jsonl"))).rejects.toThrow();
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
@@ -148,7 +146,7 @@ describe("sendInviteEmail in production mode", () => {
     }
   });
 
-  it("really sends with the transport armed — the address in body, user-entered fields escaped in HTML", async () => {
+  it("really sends with the transport armed — the link in body, user-entered fields escaped in HTML", async () => {
     const mail = await importInviteMail("production", SMTP_ENV);
     await mail.sendInviteEmail({ ...INVITE, workspaceDisplayName: "Acme <Platform>" });
     expect(sendMailSpy).toHaveBeenCalledTimes(1);
@@ -159,10 +157,19 @@ describe("sendInviteEmail in production mode", () => {
       html?: string;
     };
     expect(message.to).toBe(INVITE.to);
-    expect(message.subject).toBe("You've been invited to Acme <Platform> on Topos");
-    expect(message.text).toContain(`topos follow ${INVITE.address}`);
-    // The notice carries the plain follow address — never a tokened link.
-    expect(message.text).not.toContain("/i/");
+    expect(message.subject).toBe("You're invited to Acme <Platform> on Topos");
+    expect(message.text).toContain(`topos follow ${INVITE.inviteUrl}`);
     expect(message.html).toContain("Acme &lt;Platform&gt;");
+  });
+
+  it("a hinted invitation leads with its first destination — subject and opening line", async () => {
+    const mail = await importInviteMail("production", SMTP_ENV);
+    await mail.sendInviteEmail({ ...INVITE, hint: { kind: "skill", name: "deploy" } });
+    expect(sendMailSpy).toHaveBeenCalledTimes(1);
+    const message = sendMailSpy.mock.calls[0]?.[0] as { subject: string; text: string };
+    expect(message.subject).toBe(
+      `You're invited to ${INVITE.workspaceDisplayName} on Topos — starting with the deploy skill`,
+    );
+    expect(message.text).toContain("First up: the deploy skill.");
   });
 });

--- a/web/tests/unit/queries-roster.test.ts
+++ b/web/tests/unit/queries-roster.test.ts
@@ -72,7 +72,7 @@ describe("createInvitations", () => {
         ["New@Acme.COM"],
         "members",
       ),
-    ).toBe("invited");
+    ).toMatchObject({ outcome: "invited" });
     const rows = await db.q<{
       email: string;
       status: string;
@@ -102,14 +102,14 @@ describe("createInvitations", () => {
     const queries = await q();
     expect(
       await queries.createInvitations(asMember(wsId, "u_ana"), ["gate@acme.com"], "owners"),
-    ).toBe("owner_role_required");
+    ).toMatchObject({ outcome: "owner_role_required" });
     expect(
       await queries.createInvitations(
         asMember(wsId, "u_owner", "owner"),
         ["gate@acme.com"],
         "owners",
       ),
-    ).toBe("invited");
+    ).toMatchObject({ outcome: "invited" });
   });
 
   it("a malformed address folds to bad_email — the whole batch refuses, nothing written", async () => {
@@ -120,7 +120,7 @@ describe("createInvitations", () => {
         ["ok@acme.com", "bad email"],
         "members",
       ),
-    ).toBe("bad_email");
+    ).toMatchObject({ outcome: "bad_email" });
     expect(await db.q(`SELECT 1 FROM web.invitation WHERE email = 'ok@acme.com'`)).toHaveLength(0);
   });
 
@@ -137,7 +137,7 @@ describe("createInvitations", () => {
         ["new@acme.com"],
         "members",
       ),
-    ).toBe("invited");
+    ).toMatchObject({ outcome: "invited" });
     const rows = await db.q<{ invited_by: string; fresh: boolean; n: string }>(
       `SELECT invited_by, expires_at > now() + interval '6 days' AS fresh,
               (SELECT count(*)::text FROM web.invitation WHERE email = 'new@acme.com') AS n
@@ -199,7 +199,7 @@ describe("bindInvitedSeats (the verified sign-up's binding leg)", () => {
         ["late@acme.com"],
         "members",
       ),
-    ).toBe("invited");
+    ).toMatchObject({ outcome: "invited" });
     await db.q(
       `UPDATE web.invitation SET expires_at = now() - interval '1 minute' WHERE email = 'late@acme.com'`,
     );

--- a/web/tests/unit/verify-loader.test.ts
+++ b/web/tests/unit/verify-loader.test.ts
@@ -3,11 +3,14 @@ import { installTestEnv } from "./helpers/test-env";
 
 /**
  * The /verify loader's ROUTING decisions, with the composition + data layer mocked: the
- * signed-out bounce keeps the code in `next`, and — MULTI tenancy only — a signed-in person
- * with ZERO seats anywhere is woven through workspace creation (`/new`) carrying this page as
- * `next` and, when a pending flow resolved, its requested slug as a `name` prefill hint. The
- * `/new` target is a sibling route's contract; this suite pins the decision, not the page.
- * Single tenancy never consults memberships — the zero-seat behavior is unchanged there.
+ * signed-out bounce carries the page (validated pass-through params only — the CODE never
+ * rides a URL, so there is nothing secret to preserve) as the login `next`; a `device`
+ * challenge in the URL resolves the card with zero typing; and — MULTI tenancy only — a
+ * signed-in person with ZERO seats anywhere is woven through workspace creation (`/new`)
+ * carrying this page as `next` and, when a flow resolved, its requested slug as a `name`
+ * prefill hint — UNLESS the flow carries an invitation, whose accept will seat them right
+ * here. The `/new` target is a sibling route's contract; this suite pins the decision, not
+ * the page.
  */
 
 let tenancy: "single" | "multi" = "single";
@@ -25,14 +28,22 @@ vi.mock("@/lib/auth/server", () => ({
   getAuth: () => ({ api: { getSession: async () => session } }),
 }));
 
-const pendingDeviceAuth =
-  vi.fn<(code: string) => Promise<{ requestedName: string; requestedWorkspace: string } | null>>();
+interface PendingView {
+  requestedName: string;
+  requestedWorkspace: string;
+  userCode: string;
+  inviteWorkspace: { name: string; displayName: string } | null;
+}
+
+const pendingDeviceAuthByChallenge = vi.fn<(hex: string) => Promise<PendingView | null>>();
 vi.mock("@/lib/db/identity.server", () => ({
-  pendingDeviceAuth: (code: string) => pendingDeviceAuth(code),
+  pendingDeviceAuth: vi.fn(),
+  pendingDeviceAuthByChallenge: (hex: string) => pendingDeviceAuthByChallenge(hex),
   approveDeviceAuth: vi.fn(),
   denyDeviceAuth: vi.fn(),
   // guards.server's imports (unused by the loader under test, present so the mock resolves).
   deviceActor: vi.fn(),
+  devicePerson: vi.fn(),
   seatOf: vi.fn(),
   theWorkspace: vi.fn(),
   workspaceByName: vi.fn(),
@@ -45,6 +56,14 @@ vi.mock("@/lib/db/queries.server", () => ({
 
 let loader: typeof import("@/routes/verify").loader;
 
+const CHALLENGE = "a".repeat(64);
+const FLOW: PendingView = {
+  requestedName: "box",
+  requestedWorkspace: "acme",
+  userCode: "AB12-CD34",
+  inviteWorkspace: null,
+};
+
 beforeAll(async () => {
   installTestEnv();
   ({ loader } = await import("@/routes/verify"));
@@ -53,7 +72,7 @@ beforeAll(async () => {
 beforeEach(() => {
   tenancy = "single";
   session = { user: { id: "u_1", name: "Person", email: "person@example.com" } };
-  pendingDeviceAuth.mockReset().mockResolvedValue(null);
+  pendingDeviceAuthByChallenge.mockReset().mockResolvedValue(null);
   membershipsFor.mockReset().mockResolvedValue([]);
 });
 
@@ -78,20 +97,55 @@ function expectRedirect(result: unknown, location: string): void {
 }
 
 describe("the signed-out bounce", () => {
-  it("carries the page — code included — as the login next path", async () => {
+  it("carries the page — validated loopback params included — as the login next path", async () => {
     session = null;
     expectRedirect(
-      await call("http://x/verify?code=AB12-CD34"),
-      "/login?next=%2Fverify%3Fcode%3DAB12-CD34",
+      await call(`http://x/verify?device=${CHALLENGE}&port=4321&state=abcdefgh`),
+      `/login?next=${encodeURIComponent(`/verify?device=${CHALLENGE}&port=4321&state=abcdefgh`)}`,
+    );
+  });
+
+  it("drops malformed pass-through params from the next path", async () => {
+    session = null;
+    expectRedirect(
+      await call("http://x/verify?device=nonsense&port=80&state=!!"),
+      "/login?next=%2Fverify",
     );
   });
 });
 
-describe("single tenancy (unchanged)", () => {
-  it("a zero-seat person still gets the page — memberships are never consulted", async () => {
+describe("the challenge resolution (zero typing)", () => {
+  it("a valid device challenge resolves the card, reach included", async () => {
+    membershipsFor.mockResolvedValue([{ displayName: "Acme", address: "acme" }]);
+    pendingDeviceAuthByChallenge.mockResolvedValue(FLOW);
+    const result = (await call(`http://x/verify?device=${CHALLENGE}`)) as {
+      resolved: { userCode: string; reach: { label: string; joining: boolean }[] } | null;
+    };
+    expect(pendingDeviceAuthByChallenge).toHaveBeenCalledWith(CHALLENGE);
+    expect(result.resolved?.userCode).toBe("AB12-CD34");
+    expect(result.resolved?.reach).toEqual([{ label: "Acme", joining: false }]);
+  });
+
+  it("an invite-carrying flow adds the joining workspace to the reach", async () => {
+    membershipsFor.mockResolvedValue([{ displayName: "Home", address: "home" }]);
+    pendingDeviceAuthByChallenge.mockResolvedValue({
+      ...FLOW,
+      inviteWorkspace: { name: "acme", displayName: "Acme Platform" },
+    });
+    const result = (await call(`http://x/verify?device=${CHALLENGE}`)) as {
+      resolved: { reach: { label: string; joining: boolean }[] } | null;
+    };
+    expect(result.resolved?.reach).toEqual([
+      { label: "Home", joining: false },
+      { label: "Acme Platform", joining: true },
+    ]);
+  });
+});
+
+describe("single tenancy", () => {
+  it("a zero-seat person still gets the page (the entry form)", async () => {
     const result = await call("http://x/verify");
-    expect(result).toEqual({ code: "", pending: null, multi: false });
-    expect(membershipsFor).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ multi: false, device: null, loopback: null, resolved: null });
   });
 });
 
@@ -101,32 +155,38 @@ describe("multi tenancy: the workspace-creation weave", () => {
   });
 
   it("a seated person gets the page", async () => {
-    membershipsFor.mockResolvedValue([{ id: "w_1" }]);
-    pendingDeviceAuth.mockResolvedValue({ requestedName: "box", requestedWorkspace: "acme" });
-    const result = await call("http://x/verify?code=AB12-CD34");
-    expect(result).toEqual({
-      code: "AB12-CD34",
-      pending: { requestedName: "box", requestedWorkspace: "acme" },
-      multi: true,
-    });
+    membershipsFor.mockResolvedValue([{ displayName: "W One", address: "w-one" }]);
+    pendingDeviceAuthByChallenge.mockResolvedValue(FLOW);
+    const result = await call(`http://x/verify?device=${CHALLENGE}`);
+    expect(result).toMatchObject({ multi: true, device: CHALLENGE });
   });
 
-  it("zero seats, no code → /new carrying this page as next", async () => {
+  it("zero seats, no flow → /new carrying this page as next", async () => {
     expectRedirect(await call("http://x/verify"), "/new?next=%2Fverify");
   });
 
-  it("zero seats + a RESOLVED pending flow → /new with next AND the slug as a name prefill", async () => {
-    pendingDeviceAuth.mockResolvedValue({ requestedName: "box", requestedWorkspace: "acme" });
+  it("zero seats + a RESOLVED flow → /new with next AND the slug as a name prefill", async () => {
+    pendingDeviceAuthByChallenge.mockResolvedValue(FLOW);
     expectRedirect(
-      await call("http://x/verify?code=AB12-CD34"),
-      "/new?next=%2Fverify%3Fcode%3DAB12-CD34&name=acme",
+      await call(`http://x/verify?device=${CHALLENGE}`),
+      `/new?next=${encodeURIComponent(`/verify?device=${CHALLENGE}`)}&name=acme`,
     );
   });
 
-  it("zero seats + an unresolved code → /new with next only (no prefill from a dead code)", async () => {
+  it("zero seats + an INVITE-carrying flow stays here — the accept will seat them", async () => {
+    pendingDeviceAuthByChallenge.mockResolvedValue({
+      ...FLOW,
+      inviteWorkspace: { name: "acme", displayName: "Acme" },
+    });
+    const result = await call(`http://x/verify?device=${CHALLENGE}`);
+    expect(result).toMatchObject({ multi: true });
+    expect(result).not.toBeInstanceOf(Response);
+  });
+
+  it("zero seats + an unresolved challenge → /new with next only (no prefill)", async () => {
     expectRedirect(
-      await call("http://x/verify?code=ZZZZ-9999"),
-      "/new?next=%2Fverify%3Fcode%3DZZZZ-9999",
+      await call(`http://x/verify?device=${CHALLENGE}`),
+      `/new?next=${encodeURIComponent(`/verify?device=${CHALLENGE}`)}`,
     );
   });
 });

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -190,6 +190,18 @@ fn schemas() -> Vec<(&'static str, String)> {
             "invitation-data",
             emit(schemars::schema_for!(topos_types::requests::InvitationData)),
         ),
+        (
+            "invite-accept-request",
+            emit(schemars::schema_for!(
+                topos_types::requests::InviteAcceptRequest
+            )),
+        ),
+        (
+            "invite-accept-data",
+            emit(schemars::schema_for!(
+                topos_types::requests::InviteAcceptData
+            )),
+        ),
         // The adopted verb describe/apply `data` payloads (the two-phase surface: a bare mutating verb
         // returns the describe, `--yes` returns it applied).
         (
@@ -744,7 +756,8 @@ fn fixtures() -> Vec<(&'static str, String)> {
             workspace_display_name: None,
             plane_base_url: Some("https://topos.sh/api".to_owned()),
             pending: Some(EnrollmentPending {
-                verification_uri_complete: "https://topos.sh/verify?code=WXYZ-1234".to_owned(),
+                // The bare approval page + the code on its own field — the code never rides a URL.
+                verification_uri: "https://topos.sh/verify".to_owned(),
                 user_code: "WXYZ-1234".to_owned(),
                 expires_at: Some("2026-06-25T00:15:00Z".to_owned()),
                 interval_secs: Some(5),


### PR DESCRIPTION
Invitations become redeemable by everyone — not just brand-new sign-ups — through a mailed single-use invite link, with the device-approval page reworked around it.

## What's here

**The invite link.** Inviting mints a long random single-use token (hash-stored, 7-day expiry, dead on revoke; a re-invite supersedes it). The mail now carries three CTAs — the browser link first, the agent paste-block, and the terminal line. The invitation page is viewable by anyone holding the link (viewing never consumes it); accepting and declining are explicit POSTs.

**Email-bound acceptance.** An invitation is redeemable only by the account holding the invited email: signed in with it — one click; no such account — the link creates it (passwordless where a mail sign-in rung exists, born verified: the token's delivery is the mailbox proof); signed in as someone else — a switch page, never a cross-account accept. An unverified pre-existing account must complete a mailbox round-trip first. Declines are recorded and visible to the inviter; used/expired/unknown tokens render one constant page.

**First-destination hints.** An invitation may carry one skill or channel reference (`topos invite --skill <name>` / `--channel`, or the skill page's invite affordance). The mail and the page lead with it; accepting also writes the direct follow (or channel membership) in the same transaction; the landing is the hinted page. Hints subscribe — bytes still land only through the device-side describe/consent.

**The reworked /verify.** The CLI prints a bare verification URL and the short code on separate lines — the code never enters a URL — and the lookup form posts. The resolved card enumerates every workspace the credential will reach. The device flow can carry an invite token, weaving sign-in → accept → approve into one browser visit; an already-enrolled device consumes an invite URL directly over the device lane.

**Loopback approval.** With a local browser, enrollment auto-opens the approval page and completes via a state-bound single-use 127.0.0.1 redirect — no typing. The typed-code flow stays as the headless fallback.

**Agent-safe polling.** A piped run without `--wait` prints the instructions, polls once, and exits (with a resume next-action in `--json`); only a watched terminal or an explicit `--wait` blocks.

## Testing

Full gate run green: `cargo xtask ci` (7/7), the workspace Rust suites incl. a new composed e2e (the terminal-first invited person, end to end) and piped-enrollment integration tests; web `bun run check`, vitest (524), Playwright (103) with new invitation/verify/skill-invite specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)