### PR TITLE
Make the skill lifecycle surfaces discoverable

### DIFF
--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -207,7 +207,10 @@ module is the ONE sanctioned digest computation in this tier (carved out by name
 **The signed-in surface:** a workspace dashboard, the skill browser, the rendered review UI (unified diff +
 Approve/Reject + comments + one-click revert), the verification page, the create/join flows, and the ADMIN
 surfaces — the roster page in full (invite / role change / remove / self-serve leave, sole-owner-fenced),
-the skill lifecycle ceremonies (archive / unarchive / delete / purge / rename-with-redirect), the
+the skill lifecycle ceremonies (archive / unarchive / delete / purge / rename-with-redirect —
+discoverable: the skill pages share one tab row, Current · Proposals · History plus an OWNER-ONLY
+**Settings** tab rendered from each loader's own owner fact, while the settings route re-guards
+regardless), the
 channel pages — TABBED into **Skills** (the face, hosting in-app curation: whoever may curate — any
 member of an open channel, reviewer+ of a curated one — adds/removes the channel's skill references
 through the same core the device lane runs) · **Members** · **History** · **Settings** (the owner
@@ -217,8 +220,10 @@ default · invite policy · staleness window · the `registration` knob · an OW
 **export** — a `settings/export` resource route streaming a zip of every skill at its current version
 plus a `manifest.json`, one object at a time through the custody transport's verified reads) and
 **Devices** (the workspace fleet
-view: staleness + the named blind spots — detached copies, removed-upstream rows, stale devices), both under
-one shared tab header (`app/components/settings-tabs.tsx`) at `settings` / `settings/devices`), the "your
+view: staleness + the named blind spots — detached copies, removed-upstream rows, stale devices) and
+**Archive** (the archived-skills list with the unarchive/delete ceremonies), all under
+one shared tab header (`app/components/settings-tabs.tsx`) at `settings` / `settings/devices` /
+`settings/archive`), the "your
 devices" self-service list, and the first-run claim. It renders state read from its own `web` schema and,
 read-only, from the vault's `plane` schema; it holds no signing key, computes no digest, and initiates no
 device-signed write — publishing stays on the enrolled device.

--- a/web/app/components/settings-tabs.tsx
+++ b/web/app/components/settings-tabs.tsx
@@ -3,17 +3,19 @@ import { cn } from "@/lib/utils";
 import { useWsPath } from "@/lib/ws-path";
 
 /**
- * The Settings section's tab header, shared VERBATIM by both settings route modules so the two
- * can't drift: General (the workspace policy page) and Devices (the read-only workspace fleet).
- * The URLs stay exactly as they are — `settings` and `settings/devices` — built through the tenancy
- * hook, so the tabs are origin-rooted in single and `/:ws`-nested in multi with no per-page
- * branching. The active tab carries `aria-current="page"`.
+ * The Settings section's tab header, shared VERBATIM by the settings route modules so they
+ * can't drift: General (the workspace policy page), Devices (the read-only workspace fleet), and
+ * Archive (the archived-skills list with the delete ceremony). The URLs — `settings`,
+ * `settings/devices`, `settings/archive` — are built through the tenancy hook, so the tabs are
+ * origin-rooted in single and `/:ws`-nested in multi with no per-page branching. The active tab
+ * carries `aria-current="page"`.
  */
-export function SettingsTabs({ active }: { active: "general" | "devices" }) {
+export function SettingsTabs({ active }: { active: "general" | "devices" | "archive" }) {
   const wsPath = useWsPath();
   const tabs = [
     { id: "general", label: "General", href: wsPath("settings") },
     { id: "devices", label: "Devices", href: wsPath("settings/devices") },
+    { id: "archive", label: "Archive", href: wsPath("settings/archive") },
   ] as const;
   return (
     <nav aria-label="Settings sections" className="flex gap-1 border-line-soft border-b">

--- a/web/app/components/shell/breadcrumbs.tsx
+++ b/web/app/components/shell/breadcrumbs.tsx
@@ -165,7 +165,7 @@ const REGISTRY: Record<string, CrumbBuilder> = {
   "routes/workspace-members": () => [{ label: "Members" }],
   "routes/workspace-settings": () => [{ label: "Settings" }],
   "routes/fleet": () => [{ label: "Settings", sub: "settings" }, { label: "Devices" }],
-  "routes/workspace-archive": () => [{ label: "Archived skills" }],
+  "routes/workspace-archive": () => [{ label: "Settings", sub: "settings" }, { label: "Archive" }],
 
   // Account-scoped (top-level in both tenancies) — mirrors the page's own title.
   "routes/your-devices": () => [{ label: "Your devices" }],

--- a/web/app/components/skill/skill-tabs.tsx
+++ b/web/app/components/skill/skill-tabs.tsx
@@ -1,26 +1,31 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router";
 
-type ActiveTab = "current" | "proposals" | "history";
+type ActiveTab = "current" | "proposals" | "history" | "settings";
 
 /**
- * The skill's section switcher — Current / Proposals / History as PURE LINKS (no client state).
+ * The skill's section switcher — Current / Proposals / History (+ Settings for owners) as PURE
+ * LINKS (no client state).
  * Each tab is a real route, so the active tab is decided by whichever page renders this bar, every
  * tab is a shareable URL, and switching is an ordinary navigation with blocking SSR. The active tab
  * reads pressed — ink text under a 2px accent underline; the rest stay quiet (dim) until hovered.
  * Both variants carry a `border-b-2` (accent vs transparent) so the row height never shifts as
  * the active tab moves. `openProposals` decorates the Proposals label with a small count.
  * `basePath` is the catalog-name-keyed skill URL the caller built through `useWsPath` (origin-rooted
- * in single tenancy, `/<slug>`-nested in multi).
+ * in single tenancy, `/<slug>`-nested in multi). `showSettings` renders the owner-only Settings
+ * tab — the caller passes its loader's own owner fact; the settings ROUTE re-guards regardless
+ * (the tab is discoverability, never the gate).
  */
 export function SkillTabs({
   basePath,
   active,
   openProposals = 0,
+  showSettings = false,
 }: {
   basePath: string;
   active: ActiveTab;
   openProposals?: number;
+  showSettings?: boolean;
 }) {
   return (
     <nav aria-label="Skill sections" className="flex border-line-soft border-b">
@@ -38,6 +43,11 @@ export function SkillTabs({
       <Tab to={`${basePath}/history`} isActive={active === "history"}>
         History
       </Tab>
+      {showSettings && (
+        <Tab to={`${basePath}/settings`} isActive={active === "settings"}>
+          Settings
+        </Tab>
+      )}
     </nav>
   );
 }

--- a/web/app/routes/skill-current.tsx
+++ b/web/app/routes/skill-current.tsx
@@ -204,6 +204,7 @@ function SkillCurrentContent({
         basePath={wsPath(`skills/${skill}`)}
         active="current"
         openProposals={openProposals}
+        showSettings={isOwner}
       />
       {versionId !== null && versionFiles !== null ? (
         <VersionFiles skill={skill} versionId={versionId} currentChip {...versionFiles} />

--- a/web/app/routes/skill-history.tsx
+++ b/web/app/routes/skill-history.tsx
@@ -115,6 +115,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   }
 
   return {
+    isOwner: actor.role === "owner",
     wsName: workspace.name,
     skill,
     currentShort: row.versionId !== null ? row.versionId.slice(0, 12) : "—",
@@ -315,6 +316,7 @@ export default function SkillHistoryPage() {
     currentShort,
     displayName,
     kind,
+    isOwner,
     openProposals,
     history,
     canPurge,
@@ -335,6 +337,7 @@ export default function SkillHistoryPage() {
           basePath={wsPath(`skills/${skill}`)}
           active="history"
           openProposals={openProposals}
+          showSettings={isOwner}
         />
         <HistorySection skill={skill} data={history} />
         <PurgeSection skill={skill} data={history} canPurge={canPurge} />

--- a/web/app/routes/skill-proposals.tsx
+++ b/web/app/routes/skill-proposals.tsx
@@ -49,6 +49,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   }));
 
   return {
+    isOwner: actor.role === "owner",
     wsName: workspace.name,
     skill,
     currentShort: row.versionId !== null ? row.versionId.slice(0, 12) : "—",
@@ -60,7 +61,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 export default function SkillProposalsPage() {
-  const { wsName, skill, currentShort, displayName, kind, openProposals, proposals } =
+  const { isOwner, wsName, skill, currentShort, displayName, kind, openProposals, proposals } =
     useLoaderData<typeof loader>();
   const wsPath = useWsPath();
   return (
@@ -76,6 +77,7 @@ export default function SkillProposalsPage() {
         basePath={wsPath(`skills/${skill}`)}
         active="proposals"
         openProposals={openProposals}
+        showSettings={isOwner}
       />
       <ProposalsSection skill={skill} proposals={proposals} />
     </div>

--- a/web/app/routes/skill-settings.tsx
+++ b/web/app/routes/skill-settings.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, redirect, useFetcher, useLoaderData } from "react-router";
+import { SkillHeader } from "@/components/skill/skill-header";
+import { SkillTabs } from "@/components/skill/skill-tabs";
 import { StepUpFields, StepUpMethodProvider } from "@/components/step-up";
-import { buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
+import { buttonClasses, Card, SectionHeading } from "@/components/ui";
 import {
   notFound,
   requireMemberInScope,
@@ -20,6 +22,7 @@ import { workspacePolicyOf } from "@/lib/db/queries.policy.server";
 import { bundleById, skillIndexRow } from "@/lib/db/queries.server";
 import { resolveSkillName } from "@/lib/db/resolve.server";
 import { isValidSkillName, renameDeniedCopy, SKILL_NAME_MAX } from "@/lib/plane/lifecycle-copy";
+import { useWsPath } from "@/lib/ws-path";
 import { wsPathServer } from "@/lib/ws-url.server";
 
 /** The verbatim boundary the archive ceremony must state — what archiving costs and what it keeps. */
@@ -64,6 +67,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return {
     wsName: workspace.name,
     skill: row.name,
+    currentShort: row.versionId !== null ? row.versionId.slice(0, 12) : "—",
+    displayName: row.displayName,
+    kind: row.kind,
+    openProposals: row.openProposals,
     protection: (pinned ?? "inherit") as ProtectionChoice,
     protectionDefault: policy.protectionDefault,
     stepUpMethod: await stepUpMethod(owner.userId),
@@ -203,7 +210,7 @@ async function archiveIntent(
     });
   }
   if (outcome.outcome === "archived") {
-    throw redirect(wsPathServer(wsName, "archive"));
+    throw redirect(wsPathServer(wsName, "settings/archive"));
   }
   await recordAdminEvent(owner, {
     kind: "skill_archived",
@@ -263,14 +270,33 @@ async function protectionIntent(request: Request, ws: string, skill: string, for
 }
 
 export default function SkillSettings() {
-  const { wsName, skill, protection, protectionDefault, stepUpMethod } =
-    useLoaderData<typeof loader>();
+  const {
+    wsName,
+    skill,
+    currentShort,
+    displayName,
+    kind,
+    openProposals,
+    protection,
+    protectionDefault,
+    stepUpMethod,
+  } = useLoaderData<typeof loader>();
+  const wsPath = useWsPath();
   return (
     <StepUpMethodProvider method={stepUpMethod}>
       <div className="space-y-8">
-        <PageHeader
-          title={`${skill} settings`}
-          meta={<code className="font-mono">{wsName}</code>}
+        <SkillHeader
+          ws={wsName}
+          skill={skill}
+          currentShort={currentShort}
+          displayName={displayName}
+          kind={kind}
+        />
+        <SkillTabs
+          basePath={wsPath(`skills/${skill}`)}
+          active="settings"
+          openProposals={openProposals}
+          showSettings
         />
         <ProtectionCeremony
           skill={skill}

--- a/web/app/routes/workspace-archive.tsx
+++ b/web/app/routes/workspace-archive.tsx
@@ -1,5 +1,6 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Form, useActionData, useFetcher, useLoaderData, useNavigation } from "react-router";
+import { SettingsTabs } from "@/components/settings-tabs";
 import { StepUpFields, StepUpMethodProvider } from "@/components/step-up";
 import { buttonClasses, Card, PageHeader } from "@/components/ui";
 import { requireMemberInScope, requireWorkspaceOwner } from "@/lib/auth/guards.server";
@@ -211,7 +212,8 @@ export default function WorkspaceArchive() {
   return (
     <StepUpMethodProvider method={stepUpMethod}>
       <div className="space-y-6">
-        <PageHeader title="Archived skills" meta={<code className="font-mono">{wsName}</code>} />
+        <PageHeader title="Archive" meta={<code className="font-mono">{wsName}</code>} />
+        <SettingsTabs active="archive" />
         {deleted !== null && (
           <Card className="px-4 py-3">
             <p className="text-dim text-sm" role="status">

--- a/web/app/topos-web/routes.ts
+++ b/web/app/topos-web/routes.ts
@@ -157,7 +157,7 @@ function memberWorkspaceChildren(
 ): RouteConfigEntry[] {
   const children: RouteConfigEntry[] = [
     route("members", file("workspace-members.tsx")),
-    route("archive", file("workspace-archive.tsx")),
+    route("settings/archive", file("workspace-archive.tsx")),
     route("settings", file("workspace-settings.tsx")),
     // The workspace's device view (staleness + blind spots) — a tab of the Settings page.
     route("settings/devices", file("fleet.tsx")),

--- a/web/tests/e2e/lifecycle.spec.ts
+++ b/web/tests/e2e/lifecycle.spec.ts
@@ -144,7 +144,7 @@ test("archive retires the skill: the base name frees, the catalog drops it, the 
 
 test("unarchive restores the base name exactly", async ({ page }) => {
   await theWorkspace();
-  await gotoSettled(page, `/archive`);
+  await gotoSettled(page, `/settings/archive`);
 
   await page.getByText("Unarchive…", { exact: true }).click();
   await page.locator(`#unarchive-${SKILL.id}-password`).fill(E2E_PASSWORD);

--- a/web/tests/e2e/skill-tabs.spec.ts
+++ b/web/tests/e2e/skill-tabs.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+import { adminQuery, ensureBundle, ensureSeatedUser } from "./seed";
+import { gotoSettled, signIn } from "./sign-in";
+
+/**
+ * The lifecycle surfaces' DISCOVERABILITY: the skill page's owner-only Settings tab and the
+ * workspace Settings section's Archive tab. The tab is a link, never the gate — the routes
+ * re-guard — so the member case asserts both halves: no tab rendered, and the direct URL still
+ * answers the uniform 404. The suite's default identity is the claimed OWNER (storage state);
+ * the member drives a fresh context.
+ */
+
+const SKILL = { id: "s_e2e_tabs", name: "tabs-notes" };
+const MEMBER_EMAIL = "tabs-member@e2e.test";
+
+test.beforeAll(async () => {
+  await adminQuery(`delete from web.bundle where id = $1`, [SKILL.id]);
+  await ensureBundle(SKILL);
+  await ensureSeatedUser(MEMBER_EMAIL, "member");
+});
+
+test("the owner sees the Settings tab on the skill page and the Archive tab under settings", async ({
+  page,
+}) => {
+  await gotoSettled(page, `/skills/${SKILL.name}`);
+  const tabs = page.getByRole("navigation", { name: "Skill sections" });
+  await expect(tabs.getByRole("link", { name: "Settings" })).toBeVisible();
+
+  // The tab is a real route link: clicking lands on the settings page, tab row intact + pressed.
+  await tabs.getByRole("link", { name: "Settings" }).click();
+  await page.waitForURL(`**/skills/${SKILL.name}/settings`);
+  await expect(
+    page
+      .getByRole("navigation", { name: "Skill sections" })
+      .getByRole("link", { name: "Settings" }),
+  ).toHaveAttribute("aria-current", "page");
+
+  // The workspace Settings section: General · Devices · Archive, and Archive is a real page.
+  await gotoSettled(page, "/settings");
+  const settingsTabs = page.getByRole("navigation", { name: "Settings sections" });
+  await expect(settingsTabs.getByRole("link", { name: "Archive" })).toBeVisible();
+  await settingsTabs.getByRole("link", { name: "Archive" }).click();
+  await page.waitForURL("**/settings/archive");
+  await expect(page.getByRole("heading", { name: "Archive", exact: true })).toBeVisible();
+});
+
+test("a member gets no Settings tab, and the settings route stays the uniform 404", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const p = await context.newPage();
+  try {
+    await signIn(p, MEMBER_EMAIL);
+    await gotoSettled(p, `/skills/${SKILL.name}`);
+    const tabs = p.getByRole("navigation", { name: "Skill sections" });
+    await expect(tabs.getByRole("link", { name: "Current" })).toBeVisible();
+    await expect(tabs.getByRole("link", { name: "Settings" })).toHaveCount(0);
+
+    // The tab was discoverability, not the gate: the direct URL answers the house 404.
+    await p.goto(`/skills/${SKILL.name}/settings`);
+    await expect(p.getByRole("heading", { name: "Not found" })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});


### PR DESCRIPTION
The skill lifecycle ceremonies (rename / protection / archive, then unarchive / delete) existed only as unlinked URLs — an owner could not reach them by clicking. Two small changes:

- **Skill pages gain an owner-only Settings tab.** The shared tab row (Current · Proposals · History) renders a fourth tab for workspace owners; each page's loader passes its own owner fact, and the settings route re-guards regardless — the tab is discoverability, never the gate. The skill settings page now renders the shared skill header + tab row instead of a bespoke title.
- **The archived-skills page becomes the Settings section's third tab** — General · Devices · Archive at `settings` / `settings/devices` / `settings/archive` (route moved from the unlinked `/archive`). The archive ceremony's redirect follows; breadcrumbs updated.

## Testing

- New Playwright spec (`skill-tabs.spec.ts`): owner sees the Settings tab and reaches settings + archive by click; a member sees no tab AND the direct settings URL still answers the uniform 404.
- Full web suite green: `bun run check`, vitest, Playwright 105/105 (lifecycle spec updated for the moved path).
- Codex review: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)