### PR TITLE
Adopt identical occupants, auto-namespace collisions, honest follow receipts

### DIFF
--- a/bins/topos/CLAUDE.md
+++ b/bins/topos/CLAUDE.md
@@ -151,9 +151,11 @@ renderer over the SAME typed outcomes (one value, two presentations).
   The SUBSCRIBE is two-phase: bare = a DESCRIBE (`GET /me` + `/channels` + the catalog + `/delivery`
   → workspace/role/invited-by, the install list — SCOPED to the named targets: a WORKSPACE target
   lists the whole delivered set, a channel/skill target only what it entitles — with digests +
-  `via` attribution, the all-devices +
-  fleet-reporting disclosures, pre-placed channels, dirname collisions with the `--prefix-dirname`
-  `<ws>.<name>` choice, freed-name new-identity notes, the direct-follow explanation) + `next_actions`
+  `via` attribution, the all-devices disclosure (skills you follow arrive on every device you've
+  linked to this workspace), pre-placed channels, adopt-in-place notes (a byte-identical occupant of
+  the planned dir is adopted where it sits, never a second copy) and auto-namespaced dirname
+  collisions (a different skill already holds the name → installs as `<skill>-<workspace>`),
+  freed-name new-identity notes, the direct-follow explanation) + `next_actions`
   carrying the paste-ready `--yes` argv (NOTHING mutates before `--yes` except the enrollment itself
   — identity, reversible, disclosed as `enrolled_now`); `--yes` = the row ops (`channel_join` /
   `follow_skill`) then the delivery-driven reconcile landing the DESCRIBED set THIS invocation
@@ -161,8 +163,8 @@ renderer over the SAME typed outcomes (one value, two presentations).
   restricts INSTALLATION to exactly the ids the describe disclosed, so a waiting arrival outside
   the named targets is never swept in under an unrelated `--yes` — it stays an individually
   consentable offer, while already-followed skills still UPDATE under their standing follow mode,
-  as on any sweep; collisions decline
-  by default or install prefixed), then the fleet report. The transports are built per-base-URL
+  as on any sweep; a dirname collision auto-namespaces to `<skill>-<workspace>` and a byte-identical
+  occupant is adopted in place), then the fleet report. The transports are built per-base-URL
   behind injectable factories, so the whole flow is tested over fakes with no HTTP.
 - **The `invite` verb** (`ops/invite`, `plane_http::UreqDeviceClient`) — the two-phase roster write
   (`POST /v1/workspaces/{ws}/invitations` under the ONE device Bearer credential; the server resolves
@@ -180,8 +182,8 @@ renderer over the SAME typed outcomes (one value, two presentations).
   least one detected harness is covered by it (coverage carries provenance — live-probed vs
   vendor-docs vs unknown-treated-as-false), plus a native user-dir copy per detected-but-uncovered
   harness (the active adapter keeps its richer `placement_for`; the rest resolve through the
-  registry's user skills root with the ONE shared naming discipline — sanitize → workspace-prefix on
-  collision → the id; never a foreign dir). A SCOPED skill (`--agent` include-list and/or per-agent
+  registry's user skills root with the ONE shared naming discipline — sanitize → workspace-suffix on
+  collision (`<skill>-<workspace>`) → the id; never a foreign dir). A SCOPED skill (`--agent` include-list and/or per-agent
   exclusions) places into exactly the scoped-and-not-excluded detected harnesses' native dirs —
   never the shared dir. No detection at all (or no `$HOME`) keeps the classic active-adapter single
   placement; an adopted agent-less dir (the author's working copy) is ALWAYS managed. Targets are
@@ -407,7 +409,7 @@ are asserted byte-equal in tests.
   hook never fails a session start for a network blip; it still stamps, so a dead plane is not
   re-dialed every session event) while a genuinely local failure still exits nonzero. `follow
   --yes` reuses the same reconcile with explicit `ReconcileOpts` (batch-accepted first receives
-  restricted to the describe's disclosed ids, declined/renamed collisions, one workspace, no ack)
+  restricted to the describe's disclosed ids, one workspace, no ack)
   and no gate.
 
 - **The BUILT-IN `topos` skill** (`ops/builtin`, `cli_ref`, the repo-top-level `skills/topos/`

--- a/bins/topos/src/app.rs
+++ b/bins/topos/src/app.rs
@@ -396,7 +396,6 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
             skill,
             agent,
             yes,
-            prefix_dirname,
             manual,
             wait,
         } => {
@@ -438,7 +437,6 @@ fn run_command(json: bool, workspace: Option<String>, command: Command, bare: bo
                 // workspaces this install follows on one plane (the enrollment motions ignore it).
                 workspace: workspace.clone(),
                 yes,
-                prefix_dirname,
                 channels: channel.clone(),
                 skills: skill.clone(),
                 agents: agent.clone(),

--- a/bins/topos/src/cli.rs
+++ b/bins/topos/src/cli.rs
@@ -85,9 +85,6 @@ pub(crate) enum Command {
         /// Apply the described subscription (the one-shot consent). Bare = describe only.
         #[arg(long)]
         yes: bool,
-        /// Install a dirname-colliding skill under `<workspace>.<name>` instead of declining it.
-        #[arg(long)]
-        prefix_dirname: bool,
         /// Adopt followed skills in confirm-each mode (a one-tap accept per new version) instead of auto.
         #[arg(long)]
         manual: bool,
@@ -608,23 +605,16 @@ mod tests {
     }
 
     #[test]
-    fn follow_takes_the_two_phase_and_collision_flags() {
-        let out = Cli::try_parse_from([
-            "topos",
-            "follow",
-            "acme/channels/eng",
-            "--prefix-dirname",
-            "--yes",
-        ])
-        .unwrap();
+    fn follow_takes_the_two_phase_flag_and_the_collision_flag_is_retired() {
+        let out = Cli::try_parse_from(["topos", "follow", "acme/channels/eng", "--yes"]).unwrap();
         assert!(matches!(
             out.command,
-            Some(Command::Follow {
-                yes: true,
-                prefix_dirname: true,
-                ..
-            })
+            Some(Command::Follow { yes: true, .. })
         ));
+        // Colliding dirnames auto-namespace now — the old opt-in flag is gone.
+        let removed = Cli::try_parse_from(["topos", "follow", "acme", "--prefix-dirname", "--yes"])
+            .unwrap_err();
+        assert_eq!(removed.kind(), ErrorKind::UnknownArgument);
     }
 
     #[test]

--- a/bins/topos/src/materialize.rs
+++ b/bins/topos/src/materialize.rs
@@ -49,6 +49,9 @@ use crate::sidecar::SkillPaths;
 /// The pre-overwrite snapshot seam's shape (see [`MaterializeReq::snapshot`]).
 pub(crate) type SnapshotFn<'a> = &'a dyn Fn(&ScannedBundle) -> Result<(), ClientError>;
 
+/// The consented-takeover revalidation's shape (see [`MaterializeReq::takeover`]).
+pub(crate) type TakeoverFn<'a> = &'a dyn Fn(&Path) -> bool;
+
 /// Everything the materializer needs for one apply. The engine has already fetched + `render_verified`'d
 /// `bundle` (so the bytes are authenticated), reconciled `next_map`'s placement set, and computed the
 /// complete `next_lock` + `next_sync` target.
@@ -75,6 +78,15 @@ pub(crate) struct MaterializeReq<'a> {
     /// the never-a-lost-byte rail. `None` only where the caller has already snapshotted every copy
     /// (reset / go-back / the merge, whose snapshot-on-touch runs first).
     pub snapshot: Option<SnapshotFn<'a>>,
+    /// Consent to OVERWRITE an occupied target the record never materialized (snapshot-first) —
+    /// the one disclosed takeover path: the built-in's consented `follow topos --yes` adoption of a
+    /// marked downloaded copy. The predicate RE-PROVES the consent against the LIVE dir immediately
+    /// before the overwrite (the built-in re-checks the downloaded-copy marker), so a dir that
+    /// changed since the describe fails closed. Everywhere else `None`: a first install into an
+    /// occupied dir whose bytes differ from the target REFUSES (the never-clobber backstop) —
+    /// including an adopted dir whose occupant raced to change (the consent was for an IDENTICAL
+    /// copy).
+    pub takeover: Option<TakeoverFn<'a>>,
 }
 
 /// What the materializer actually did (so the engine can log / record the effective capability).
@@ -145,10 +157,12 @@ pub(crate) fn mirror_first_placement(map: &mut PlacementMap) {
 ///
 /// # Errors
 /// [`ClientError::PlacementUnsupported`] if a placement is a non-directory, an unresolvable symlink,
-/// an unscannable occupied dir, or on a filesystem with no safe swap; otherwise the underlying
-/// [`FsOps`] failure (which the crash gate injects). On any error `applied` has NOT advanced (the
-/// sync write is the last, all-or-nothing step); already-landed placements are recorded in the map,
-/// so a re-run converges without a second swap of those dirs.
+/// an unscannable occupied dir, an occupied FIRST-install target holding non-target bytes (the
+/// never-clobber backstop, unless [`MaterializeReq::takeover`] re-proves consent), or on a filesystem with
+/// no safe swap; otherwise the underlying [`FsOps`] failure (which the crash gate injects). On any
+/// error `applied` has NOT advanced (the sync write is the last, all-or-nothing step);
+/// already-landed placements are recorded in the map, so a re-run converges without a second swap
+/// of those dirs.
 pub(crate) fn materialize(
     fs: &dyn FsOps,
     req: &MaterializeReq<'_>,
@@ -184,7 +198,22 @@ pub(crate) fn materialize(
                         doc::write_map(fs, &sp_map(req), &map)?;
                         continue;
                     }
+                    // The never-clobber backstop: a target the record NEVER materialized is not
+                    // ours to replace — a first install must never overwrite an occupant (the
+                    // naming discipline avoids occupied dirs, and an adopted dir whose bytes raced
+                    // to change since the describe fails closed here: the consent was for an
+                    // IDENTICAL copy; the next describe re-probes and re-namespaces). The one
+                    // exception is the caller's disclosed takeover, re-proven against the LIVE dir.
                     let recorded = map.placement_state[i].materialized_sha.as_deref();
+                    if recorded.is_none() && !req.takeover.is_some_and(|t| t(&target.dir)) {
+                        return Err(ClientError::PlacementUnsupported {
+                            reason: format!(
+                                "the placement {} is occupied by content topos never placed; \
+                                 refusing to overwrite it",
+                                target.dir.display()
+                            ),
+                        });
+                    }
                     if recorded != Some(on_disk.as_str())
                         && let Some(snapshot) = req.snapshot
                     {
@@ -700,6 +729,7 @@ mod tests {
             next_sync,
             sp,
             snapshot: None,
+            takeover: None,
         }
     }
 
@@ -781,6 +811,98 @@ mod tests {
         );
         // No old-bytes staging litter left behind.
         assert!(!staging_path(&parent.0, "topos_upd").exists());
+    }
+
+    #[test]
+    fn a_first_install_into_an_occupied_dir_refuses_and_writes_nothing() {
+        let parent = Scratch::new("occ");
+        let home = Scratch::new("occ-home");
+        let placement = parent.0.join("demo");
+        install_old(&placement); // an occupant topos never placed
+        let bundle = rendered(NEW);
+        let lock = lock_of("topos_occ", NEW, &"1".repeat(64));
+        let sync = sync_at(1, 1, &"1".repeat(64), &digest_hex(NEW));
+        let mut prior = prior_map(&[&placement], &"0".repeat(64), SwapCapability::Unsupported);
+        prior.placement_state[0].materialized_sha = None; // this apply would be the FIRST install
+        let d = docs_under(&home.0, "topos_occ");
+
+        let err = materialize(
+            &RealFs,
+            &req("topos_occ", &[0], &bundle, &prior, &lock, &sync, &d.sp),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ClientError::PlacementUnsupported { .. }));
+        assert!(
+            err.to_string().contains(&placement.display().to_string()),
+            "the refusal names the dir: {err}"
+        );
+        // The occupant is byte-untouched and no doc advanced (`sync.json` was never written).
+        assert_eq!(dir_snapshot(&placement), Some(expected(OLD)));
+        assert!(!d.sp.sync.exists(), "nothing committed");
+    }
+
+    #[test]
+    fn a_takeover_predicate_that_answers_false_still_refuses() {
+        // The takeover is a per-target REVALIDATION against the live dir, not a blanket consent:
+        // a predicate that cannot re-prove the disclosed condition (e.g. the built-in's downloaded
+        // -copy marker vanished since the describe) fails closed exactly like no takeover at all.
+        let parent = Scratch::new("occ-tk");
+        let home = Scratch::new("occ-tk-home");
+        let placement = parent.0.join("demo");
+        install_old(&placement);
+        let bundle = rendered(NEW);
+        let lock = lock_of("topos_occt", NEW, &"1".repeat(64));
+        let sync = sync_at(1, 1, &"1".repeat(64), &digest_hex(NEW));
+        let mut prior = prior_map(&[&placement], &"0".repeat(64), SwapCapability::Unsupported);
+        prior.placement_state[0].materialized_sha = None;
+        let d = docs_under(&home.0, "topos_occt");
+
+        let deny: &dyn Fn(&Path) -> bool = &|_| false;
+        let req = MaterializeReq {
+            takeover: Some(deny),
+            ..req("topos_occt", &[0], &bundle, &prior, &lock, &sync, &d.sp)
+        };
+        let err = materialize(&RealFs, &req).unwrap_err();
+        assert!(matches!(err, ClientError::PlacementUnsupported { .. }));
+        assert_eq!(dir_snapshot(&placement), Some(expected(OLD)));
+    }
+
+    #[test]
+    fn a_first_install_over_target_equal_bytes_still_heals_in_place() {
+        let parent = Scratch::new("occ-heal");
+        let home = Scratch::new("occ-heal-home");
+        let placement = parent.0.join("demo");
+        // The occupant already IS the target (an adopted identical copy): heal, never refuse.
+        std::fs::create_dir_all(&placement).unwrap();
+        for (p, m, b) in NEW {
+            let dest = placement.join(p);
+            std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+            std::fs::write(&dest, b).unwrap();
+            if *m == FileMode::Executable {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+        let bundle = rendered(NEW);
+        let lock = lock_of("topos_occh", NEW, &"1".repeat(64));
+        let g = 1;
+        let sync = sync_at(g, g, &"1".repeat(64), &digest_hex(NEW));
+        let mut prior = prior_map(&[&placement], &"0".repeat(64), SwapCapability::Unsupported);
+        prior.placement_state[0].materialized_sha = None;
+        let d = docs_under(&home.0, "topos_occh");
+
+        materialize(
+            &RealFs,
+            &req("topos_occh", &[0], &bundle, &prior, &lock, &sync, &d.sp),
+        )
+        .unwrap();
+        assert_eq!(dir_snapshot(&placement), Some(expected(NEW)));
+        let m = crate::doc::read_map(&RealFs, &d.sp.map).unwrap().unwrap();
+        assert_eq!(
+            m.placement_state[0].materialized_sha.as_deref(),
+            Some(digest_hex(NEW).as_str()),
+            "the heal advanced the record with no swap"
+        );
     }
 
     #[test]

--- a/bins/topos/src/ops/agent_scope.rs
+++ b/bins/topos/src/ops/agent_scope.rs
@@ -382,6 +382,7 @@ fn plan_item(
         },
         scope,
         Some(map),
+        adopt_digest_for(lock),
     );
     let (cleaned_idx, _) = partition_leaving(ctx, map, &plan, scope);
     let cleaned: Vec<String> = cleaned_idx
@@ -485,6 +486,9 @@ pub(crate) fn apply_scope_change(
     let map = sync_engine::read_map_required(ctx, &sp)?;
     let ws = super::followed_workspace(ctx, sid.as_str());
     let slug = placement::workspace_slug(ctx, ws.as_deref());
+    // A scoped re-plan runs AFTER the first receive landed, so a native dir already holding a
+    // byte-identical copy of the placed version is ADOPTED, never duplicated under a namespaced
+    // sibling.
     let plan = placement::plan_targets(
         ctx,
         sid.as_str(),
@@ -494,6 +498,7 @@ pub(crate) fn apply_scope_change(
         },
         scope,
         Some(&map),
+        adopt_digest_for(lock),
     );
     let (cleaned_idx, _) = partition_leaving(ctx, &map, &plan, scope);
 
@@ -530,8 +535,24 @@ pub(crate) fn apply_scope_change(
         }
     }
     let mut next = placement::reconcile_map(&next, &plan);
+    // The durable adoption record for any occupied-but-identical target the plan just chose: the
+    // digest lands in `pre_existing_sha` (later plans reuse the reservation; the sticky prior-bytes
+    // record rides it), and the materialize below HEALS the dir to a materialized placement.
+    if let Some(digest) = super::parse_hex32(&lock.bundle_digest)
+        .ok()
+        .filter(|d| *d != [0u8; 32])
+    {
+        placement::record_adoptions(ctx, &mut next, sid.as_str(), &lock.name, &digest);
+    }
     materialize_missing(ctx, &sp, lock, &mut next, &plan)?;
     Ok(())
+}
+
+/// The adopt-in-place digest for a skill's LANDED current (`None` on a never-received baseline —
+/// its all-zero digest names no bytes, so there is nothing an occupant could equal).
+fn adopt_digest_for(lock: &Lock) -> Option<[u8; 32]> {
+    let digest = super::parse_hex32(&lock.bundle_digest).ok()?;
+    (digest != [0u8; 32]).then_some(digest)
 }
 
 /// Land the placed version's bytes into every planned-but-empty target from the LOCAL store, and
@@ -553,7 +574,18 @@ fn materialize_missing(
     let scans = placement::scan_placements(ctx, next)?;
     let missing: Vec<usize> = managed
         .into_iter()
-        .filter(|&i| matches!(scans[i].status, ScanStatus::Absent))
+        .filter(|&i| match &scans[i].status {
+            ScanStatus::Absent => true,
+            // An ADOPTED occupied dir — recorded never-materialized with the placed version's
+            // digest as its adoption record — rides the same call: the materializer's pre-swap
+            // scan proves the bytes equal the target and HEALS it in place (no swap), advancing
+            // the record to materialized. A raced occupant fails closed there instead.
+            ScanStatus::Foreign => {
+                next.placement_state[i].pre_existing_sha.as_deref()
+                    == Some(lock.bundle_digest.as_str())
+            }
+            _ => false,
+        })
         .collect();
     if missing.is_empty() {
         return doc::write_map(ctx.fs, &sp.map, next);
@@ -582,6 +614,7 @@ fn materialize_missing(
             snapshot: Some(&|s: &crate::scan::ScannedBundle| {
                 sync_engine::snapshot_draft(ctx, sp, lock, s).map(|_| ())
             }),
+            takeover: None,
         },
     )?;
     Ok(())

--- a/bins/topos/src/ops/builtin.rs
+++ b/bins/topos/src/ops/builtin.rs
@@ -360,6 +360,7 @@ fn ensure_inner(
             excluded: &state.excluded_agents,
         },
         Some(&map),
+        None,
     );
     let next = placement::reconcile_map(&map, &plan);
     let managed = placement::managed_indices(&next, &plan);
@@ -425,6 +426,13 @@ fn ensure_inner(
             snapshot: Some(&|s: &crate::scan::ScannedBundle| {
                 sync_engine::snapshot_draft(ctx, &sp, lock_ref, s).map(|_| ())
             }),
+            // The consented `follow topos --yes` restore takes over the marked downloaded copy —
+            // an occupied, never-materialized dir the target filter admitted only under
+            // AdoptMarked. The predicate re-proves the marker against the LIVE dir immediately
+            // before the overwrite, so a copy that lost it since the describe fails closed. The
+            // silent sweep (Freeze) never targets such a dir and passes no takeover.
+            takeover: (posture == ForeignPosture::AdoptMarked)
+                .then_some(&is_downloaded_copy as &dyn Fn(&std::path::Path) -> bool),
         },
     )?;
     Ok(BuiltinSync { changed: true })
@@ -565,6 +573,7 @@ pub(crate) fn follow_builtin(
             excluded: &scope_excluded,
         },
         prior.as_ref(),
+        None,
     );
     // The planned dirs a consented `--yes` will ADOPT: occupied, never materialized by the
     // built-in (the record's Foreign posture), and carrying the downloaded copy's marker.

--- a/bins/topos/src/ops/follow.rs
+++ b/bins/topos/src/ops/follow.rs
@@ -65,9 +65,6 @@ pub(crate) struct FollowOpts {
     pub workspace: Option<String>,
     /// `--yes` — apply the described subscription (the one-shot consent). Bare = describe only.
     pub yes: bool,
-    /// `--prefix-dirname` — install a dirname-colliding skill under `<workspace>.<name>` instead of
-    /// declining it (the collision choice the describe offers).
-    pub prefix_dirname: bool,
     /// `--channel` selectors — kind-forced channel targets (join).
     pub channels: Vec<String>,
     /// `--skill` selectors — kind-forced skill targets (direct follow).
@@ -133,8 +130,8 @@ pub(crate) enum FollowOutcome {
         resumed: Vec<String>,
     },
     /// The two-phase DESCRIBE (a bare subscribe) — nothing mutated beyond the enrollment itself;
-    /// `next_argvs` carry the ready-to-exec apply commands (`--yes`, and the `--prefix-dirname`
-    /// variant when collisions exist).
+    /// `next_argvs` carry the ready-to-exec apply command (`--yes`; empty when the follow is
+    /// already standing and nothing would change — the describe's `standing_note` says so).
     Described {
         describe: Box<FollowDescribe>,
         next_argvs: Vec<Vec<String>>,
@@ -180,10 +177,8 @@ pub(crate) struct LinkDescribe {
     /// What the link would be born as — `active`, or `pending` under the workspace's
     /// device-approval knob (an owner then approves it in the web app).
     pub born: String,
-    /// Following is person-scoped: every linked device of this person receives the same set.
+    /// Following is person-scoped: skills arrive on every device linked to the workspace.
     pub all_devices_note: String,
-    /// This device reports its applied versions to the workspace's fleet view after each update.
-    pub reporting_note: String,
 }
 
 impl FollowOutcome {
@@ -229,16 +224,31 @@ pub(crate) struct DescribedInstall {
     pub via_direct: bool,
 }
 
-/// One dirname collision: an incoming install whose name a DIFFERENT local skill already holds. The
-/// default `--yes` DECLINES it; `--prefix-dirname` installs it under the prefixed dirname instead.
+/// One dirname collision: an incoming install whose by-name dir a DIFFERENT occupant already holds
+/// (different bytes — an identical occupant is an adoption instead). `--yes` installs it under the
+/// auto-namespaced dirname, disclosed here before consent; the occupant is never touched. One entry
+/// per distinct planned outcome — a multi-root plan may collide in several roots.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct DescribedCollision {
     pub skill_id: String,
     pub name: String,
-    /// Where the existing same-named copy lives (its placement dir, or its tracked identity).
+    /// Where the occupying same-named copy lives (the by-name dir under the planned root).
     pub existing: String,
-    /// The `--prefix-dirname` alternative (`<workspace>.<name>`).
-    pub prefixed_dirname: String,
+    /// The auto-namespaced dirname `<skill>-<workspace>` the install lands under (last resort the
+    /// validated skill id), disclosed before `--yes`.
+    pub installs_as: String,
+}
+
+/// One in-place ADOPTION: the planned by-name dir is already occupied by a byte-identical copy of
+/// the incoming version, so `--yes` adopts THAT dir as the placement — never a second copy. The
+/// describe discloses it before consent; one entry per adopted dir (a multi-root plan may adopt
+/// in several roots).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DescribedAdoption {
+    pub skill_id: String,
+    pub name: String,
+    /// The adopted dir (display path).
+    pub path: String,
 }
 
 /// The two-phase DESCRIBE a bare subscribe answers — everything `--yes` would change, and nothing
@@ -249,6 +259,8 @@ pub(crate) struct FollowDescribe {
     pub workspace: DescribedWorkspace,
     /// The caller's role on the roster.
     pub role: String,
+    /// The signed-in principal this describe acts as (the enrolled-receipt disclosure).
+    pub principal: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invited_by: Option<String>,
     /// Whether THIS invocation enrolled the device (the identity step already happened; the
@@ -262,9 +274,14 @@ pub(crate) struct FollowDescribe {
     pub installs: Vec<DescribedInstall>,
     /// Channels the person is already placed into (an inviter's pre-placement; `everyone` excluded).
     pub preplaced_channels: Vec<String>,
-    /// Dirname collisions — declined by default; `--prefix-dirname` opts into the prefixed paths.
+    /// Dirname collisions — auto-namespaced: `--yes` installs each under its disclosed
+    /// `installs_as` dirname, the occupant untouched.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub collisions: Vec<DescribedCollision>,
+    /// In-place adoptions — the planned by-name dir already holds a byte-identical copy, which
+    /// `--yes` adopts as the placement (never a second copy).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub adoptions: Vec<DescribedAdoption>,
     /// A colliding name in THIS workspace whose skill id changed — a freed name reassigned to a NEW
     /// skill (the old copy stays retained locally).
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -273,17 +290,19 @@ pub(crate) struct FollowDescribe {
     /// it even if the channel drops it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub direct_follow_note: Option<String>,
-    /// Following is person-scoped: every enrolled device of this person receives the same set.
+    /// Following is person-scoped: skills arrive on every device linked to the workspace.
     pub all_devices_note: String,
-    /// This device reports its applied versions to the workspace's fleet view after each update.
-    pub reporting_note: String,
+    /// Present when the follow is ALREADY standing and `--yes` would change nothing (no installs,
+    /// no new subscription rows) — the honest "nothing new" fact; no apply argv is offered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub standing_note: Option<String>,
     /// The `--agent` placement plan for the described installs (which dirs land where), when the
     /// invocation carried an include-list. Empty otherwise.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub agent_notes: Vec<String>,
 }
 
-/// The `--yes` apply report: the rows written, the installs landed, the collisions declined.
+/// The `--yes` apply report: the rows written and the installs landed.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct FollowApplied {
     pub workspace_id: String,
@@ -295,9 +314,6 @@ pub(crate) struct FollowApplied {
     pub subscribed: Vec<DescribedTarget>,
     /// The installs the reconcile landed (batch-accepted first receives + refreshed knowns).
     pub installed: Vec<DescribedInstall>,
-    /// The dirname collisions the apply DECLINED (absent under `--prefix-dirname`).
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub declined: Vec<DescribedCollision>,
     /// The reconcile's isolated warnings (ride the envelope's `warnings` too).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
@@ -971,11 +987,8 @@ fn link_workspace(
             role: d.role,
             link_status: d.link_status,
             born: d.born,
-            all_devices_note: "following is person-scoped: every linked device of this person \
-                               receives the same set"
-                .to_owned(),
-            reporting_note: "this device reports its applied versions to the workspace's fleet \
-                             view after each update"
+            all_devices_note: "skills you follow arrive on every device you've linked to this \
+                               workspace"
                 .to_owned(),
         };
         return Ok(FollowOutcome::LinkDescribed {
@@ -1436,7 +1449,8 @@ fn continue_into_target(
 
 /// The two-phase subscribe over ONE workspace's resolved targets: assemble the describe from the
 /// member-scoped reads; bare = return it (nothing mutated); `--yes` = the row ops, the reconcile
-/// (batch-accepted first receives, collisions declined or prefixed), and the report.
+/// (batch-accepted first receives; colliding dirnames auto-namespace, identical occupants adopt in
+/// place), and the report.
 fn subscribe(
     ctx: &Ctx<'_>,
     connectors: &FollowConnectors<'_>,
@@ -1470,33 +1484,60 @@ fn subscribe(
     }
 
     if !opts.yes {
-        // The paste-ready apply argvs: the canonical qualified paths + `--yes` (and the
-        // `--prefix-dirname` variant when collisions exist).
-        let mut base_argv = vec!["topos".to_owned(), "follow".to_owned()];
-        for r in resolutions {
-            base_argv.push(match r {
-                Resolution::Workspace { workspace_name, .. } => workspace_name.clone(),
-                Resolution::Resource {
-                    workspace_name,
-                    kind,
-                    name,
-                    ..
-                } => format!("{workspace_name}/{}/{name}", kind.segment()),
-            });
-        }
-        // `--manual` must ride the apply argv: without it the suggested next action installs in the
-        // default AUTO mode, so later updates auto-land despite the confirm-each consent the user chose.
-        if opts.manual {
-            base_argv.push("--manual".to_owned());
-        }
-        let mut yes = base_argv.clone();
-        yes.push("--yes".to_owned());
-        let mut next_argvs = vec![yes];
-        if !describe.collisions.is_empty() {
-            let mut prefixed = base_argv;
-            prefixed.push("--prefix-dirname".to_owned());
-            prefixed.push("--yes".to_owned());
-            next_argvs.push(prefixed);
+        // Would `--yes` write any NEW subscription row? A workspace target writes none (membership
+        // itself entitles `everyone`); a channel join is new only when the caller is not yet a
+        // member (a missing index entry counts as new — the safe side); a direct follow only when
+        // the delivery does not already carry the skill direct.
+        let new_rows = resolutions.iter().any(|r| match r {
+            Resolution::Workspace { .. } => false,
+            Resolution::Resource {
+                kind,
+                name,
+                skill_id,
+                ..
+            } => match kind {
+                ResourceKind::Channel => channels
+                    .channels
+                    .iter()
+                    .find(|c| &c.name == name)
+                    .is_none_or(|c| !c.member),
+                ResourceKind::Skill => !snapshot
+                    .skills
+                    .iter()
+                    .any(|s| Some(s.skill_id.as_str()) == skill_id.as_deref() && s.via_direct),
+            },
+        });
+        let mut next_argvs = Vec::new();
+        if describe.installs.is_empty() && !new_rows {
+            // The follow is ALREADY standing and nothing would install — an honest no-op: no
+            // `--yes` to offer, just the standing fact.
+            describe.standing_note = Some(
+                "nothing new to install; new team skills arrive automatically on every device \
+                 you've linked to this workspace"
+                    .to_owned(),
+            );
+        } else {
+            // The paste-ready apply argv: the canonical qualified paths + `--yes`.
+            let mut base_argv = vec!["topos".to_owned(), "follow".to_owned()];
+            for r in resolutions {
+                base_argv.push(match r {
+                    Resolution::Workspace { workspace_name, .. } => workspace_name.clone(),
+                    Resolution::Resource {
+                        workspace_name,
+                        kind,
+                        name,
+                        ..
+                    } => format!("{workspace_name}/{}/{name}", kind.segment()),
+                });
+            }
+            // `--manual` must ride the apply argv: without it the suggested next action installs in
+            // the default AUTO mode, so later updates auto-land despite the confirm-each consent
+            // the user chose.
+            if opts.manual {
+                base_argv.push("--manual".to_owned());
+            }
+            base_argv.push("--yes".to_owned());
+            next_argvs.push(base_argv);
         }
         return Ok(FollowOutcome::Described {
             describe: Box::new(describe),
@@ -1541,15 +1582,16 @@ fn subscribe(
         }
     }
 
-    // 2) The reconcile lands the set THIS invocation — batch-accepting first receives, declining
-    //    or prefixing the collisions, one workspace only. INSTALLATION is RESTRICTED to exactly
-    //    the ids THIS invocation's describe disclosed (`install_only`): a `--yes` is consent for
-    //    its own describe, so a waiting arrival outside the named targets is never swept in — it
-    //    stays an offer for the sweep / its own describe. Already-followed, already-received
-    //    skills still UPDATE under their standing follow mode, exactly as on any sweep — that
-    //    consent was given at follow time, not here. The notices stay unacked (they belong
-    //    to `update`'s narration).
-    let mut rec_opts = ReconcileOpts {
+    // 2) The reconcile lands the set THIS invocation — batch-accepting first receives, one
+    //    workspace only. INSTALLATION is RESTRICTED to exactly the ids THIS invocation's describe
+    //    disclosed (`install_only`): a `--yes` is consent for its own describe, so a waiting
+    //    arrival outside the named targets is never swept in — it stays an offer for the sweep /
+    //    its own describe. Already-followed, already-received skills still UPDATE under their
+    //    standing follow mode, exactly as on any sweep — that consent was given at follow time,
+    //    not here. The notices stay unacked (they belong to `update`'s narration). Dirname
+    //    collisions need no steering here: the baseline's naming discipline auto-namespaces a
+    //    genuine conflict and adopts a byte-identical occupant, exactly as disclosed.
+    let rec_opts = ReconcileOpts {
         accept_first_receive: true,
         only_workspace: Some(ws_id.to_owned()),
         install_only: Some(
@@ -1562,17 +1604,7 @@ fn subscribe(
         ack_notices: false,
         // `--manual` threads through to the adopted entries: every later update is an offer.
         confirm_each: opts.manual,
-        ..ReconcileOpts::default()
     };
-    for c in &describe.collisions {
-        if opts.prefix_dirname {
-            rec_opts
-                .rename
-                .insert(c.skill_id.clone(), c.prefixed_dirname.clone());
-        } else {
-            rec_opts.decline.insert(c.skill_id.clone());
-        }
-    }
     // The reconcile's byte fetches ride the SAME transport as the delivery (the engine ctx's plane
     // is swapped onto it) — a mid-invocation enrollment's ctx still carries the inert startup
     // plane, and `bind_skill` must land on the object the fetches use.
@@ -1583,8 +1615,8 @@ fn subscribe(
 
     // 3) The apply report: which of the described installs actually landed (an isolated per-skill
     //    failure stays a warning — the reconcile's isolation semantics hold here too). The rows key
-    //    by the skill's local NAME (its dirname), so a `--prefix-dirname` install matches under the
-    //    prefixed spelling.
+    //    by the skill's CATALOG name (its lock name — an auto-namespaced install keeps it; only the
+    //    dirname carries the workspace suffix).
     let landed: HashMap<&str, PullAction> = out
         .data
         .skills
@@ -1595,22 +1627,13 @@ fn subscribe(
         .installs
         .iter()
         .filter(|i| {
-            let prefixed = format!("{}.{}", me.name, i.name);
-            let action = landed
-                .get(i.name.as_str())
-                .or_else(|| landed.get(prefixed.as_str()));
             matches!(
-                action,
+                landed.get(i.name.as_str()),
                 Some(PullAction::FastForwarded | PullAction::UpToDate | PullAction::Merged)
             )
         })
         .cloned()
         .collect();
-    let declined = if opts.prefix_dirname {
-        Vec::new()
-    } else {
-        describe.collisions.clone()
-    };
     // The `--agent` include-list rides the apply: record it on each directly-followed skill and
     // reconcile its placements (clean what the scope removes, land the native dirs from the local
     // store). Runs AFTER the reconcile so the first receive has already laid bytes to re-scope.
@@ -1633,8 +1656,8 @@ fn subscribe(
             let Ok(sid) = crate::id::SkillId::parse(id) else {
                 continue;
             };
-            // A declined collision (or a still-pending offer) laid no lock — nothing to re-scope yet;
-            // the recorded include-list engages when the bytes land.
+            // A still-pending offer laid no lock — nothing to re-scope yet; the recorded
+            // include-list engages when the bytes land.
             if let Some(lock) = doc::read_doc::<Lock>(ctx.fs, &ctx.layout.published(&sid).lock)? {
                 super::agent_scope::apply_scope_change(
                     ctx,
@@ -1654,7 +1677,6 @@ fn subscribe(
         enrolled_now,
         subscribed,
         installed,
-        declined,
         warnings: out.warnings,
     })))
 }
@@ -1665,7 +1687,7 @@ fn subscribe(
 /// channel/skill subscribe lists ONLY what its own targets entitle — any other waiting arrival
 /// stays an undisclosed offer for the sweep / a later describe of its own, never listed under (or
 /// landed by) an unrelated `--yes`. Plus: who you are here, the pre-placements, the dirname
-/// collisions with the prefixed choice, and the standing disclosures.
+/// outcomes (in-place adoptions; auto-namespaced collisions), and the standing disclosures.
 fn build_describe(
     ctx: &Ctx<'_>,
     me: &WireMe,
@@ -1809,32 +1831,92 @@ fn build_describe(
         }
     }
 
-    // Dirname collisions + the freed-name notes, over the would-land set.
+    // The dirname outcomes, over the ACTUAL placement plan per install: the by-name dir may be
+    // occupied by a byte-identical copy (ADOPTED in place) or by a different occupant (the plan
+    // auto-namespaces `<skill>-<workspace>`) — the describe scans exactly what the apply's
+    // baseline will choose. The freed-name notes stay a tracked-names read.
     let tracked = tracked_names(ctx)?;
-    let mut collisions = Vec::new();
+    let mut collisions: Vec<DescribedCollision> = Vec::new();
+    let mut adoptions: Vec<DescribedAdoption> = Vec::new();
     let mut freed_name_notes = Vec::new();
     for inst in &installs {
-        let Some(existing) = tracked
+        if let Some(existing) = tracked
             .iter()
             .find(|t| t.name == inst.name && t.skill_id != inst.skill_id)
-        else {
-            continue;
-        };
-        collisions.push(DescribedCollision {
-            skill_id: inst.skill_id.clone(),
-            name: inst.name.clone(),
-            existing: existing
-                .placement
-                .clone()
-                .unwrap_or_else(|| format!("tracked skill {}", existing.skill_id)),
-            prefixed_dirname: format!("{}.{}", me.name, inst.name),
-        });
-        if existing.workspace_id.as_deref() == Some(me.workspace_id.as_str()) {
+            && existing.workspace_id.as_deref() == Some(me.workspace_id.as_str())
+        {
             freed_name_notes.push(format!(
                 "'{}' is a NEW skill under a previously-used name in this workspace — your \
                  existing copy ({}) stays retained and is NOT this skill's history",
                 inst.name, existing.skill_id
             ));
+        }
+        let Ok(sid) = crate::id::SkillId::parse(&inst.skill_id) else {
+            continue;
+        };
+        // A sweep-laid baseline's record steers the plan exactly as the apply's will.
+        let prior = if ctx.fs.exists(&ctx.layout.skill_dir(&sid)) {
+            doc::read_map(ctx.fs, &ctx.layout.published(&sid).map)?
+        } else {
+            None
+        };
+        let digest = inst
+            .bundle_digest
+            .as_deref()
+            .and_then(|hex| super::parse_hex32(hex).ok());
+        let plan = crate::placement::plan_targets(
+            ctx,
+            &inst.skill_id,
+            topos_harness::PlacementNaming {
+                name: Some(&inst.name),
+                workspace_slug: Some(&me.name),
+            },
+            crate::placement::AgentScope::default(),
+            prior.as_ref(),
+            digest,
+        );
+        let Some(n) = topos_harness::sanitize_skill_dir(&inst.name) else {
+            continue;
+        };
+        // Per PLACEMENT, not per skill: a multi-root plan can adopt in one root and namespace in
+        // another — every distinct outcome gets its own entry (the dedupe keys carry the path).
+        for target in &plan.targets {
+            let Some(leaf) = target.dir.file_name().and_then(|l| l.to_str()) else {
+                continue;
+            };
+            if leaf == n {
+                // The by-name dir with an occupant is an adoption (the plan chooses an occupied
+                // by-name dir only when the probe answered, or a still-valid adoption reservation
+                // holds it); a free by-name dir is the plain uncontested install.
+                let path = target.dir.display().to_string();
+                if target.dir.exists()
+                    && !adoptions
+                        .iter()
+                        .any(|a| a.skill_id == inst.skill_id && a.path == path)
+                {
+                    adoptions.push(DescribedAdoption {
+                        skill_id: inst.skill_id.clone(),
+                        name: inst.name.clone(),
+                        path,
+                    });
+                }
+            } else {
+                let existing = target
+                    .dir
+                    .parent()
+                    .map(|p| p.join(&n).display().to_string())
+                    .unwrap_or_else(|| n.clone());
+                if !collisions.iter().any(|c| {
+                    c.skill_id == inst.skill_id && c.installs_as == leaf && c.existing == existing
+                }) {
+                    collisions.push(DescribedCollision {
+                        skill_id: inst.skill_id.clone(),
+                        name: inst.name.clone(),
+                        existing,
+                        installs_as: leaf.to_owned(),
+                    });
+                }
+            }
         }
     }
 
@@ -1866,21 +1948,20 @@ fn build_describe(
             address: me.address.clone(),
         },
         role: me.role.clone(),
+        principal: me.principal.clone(),
         invited_by: me.invited_by.clone(),
         enrolled_now,
         targets,
         installs,
         preplaced_channels,
         collisions,
+        adoptions,
         freed_name_notes,
         direct_follow_note,
-        all_devices_note: format!(
-            "following is person-scoped: every device enrolled as {} receives this set",
-            me.principal
-        ),
-        reporting_note: "this device reports its applied versions to the workspace's fleet view \
-                         after each update"
+        all_devices_note: "skills you follow arrive on every device you've linked to this \
+                           workspace"
             .to_owned(),
+        standing_note: None,
         agent_notes: Vec::new(),
     })
 }
@@ -1903,6 +1984,12 @@ fn agent_plan_notes(
     let undetected = crate::placement::validate_agent_slugs(ctx, &scope).unwrap_or_default();
     let mut notes = Vec::new();
     for inst in installs {
+        // The install's digest arms the same adopt-in-place choice the apply's plan makes, so the
+        // disclosed dirs never differ from what `--yes` lands.
+        let digest = inst
+            .bundle_digest
+            .as_deref()
+            .and_then(|hex| super::parse_hex32(hex).ok());
         let plan = crate::placement::plan_targets(
             ctx,
             &inst.skill_id,
@@ -1915,6 +2002,7 @@ fn agent_plan_notes(
                 excluded: &[],
             },
             None,
+            digest,
         );
         for target in &plan.targets {
             let where_ = match (&target.kind, &target.agent) {
@@ -1963,18 +2051,16 @@ fn locally_received(ctx: &Ctx<'_>, skill_id: &str) -> Result<bool, ClientError> 
         .is_some_and(|s| !sync_engine::is_never_received(s)))
 }
 
-/// One locally-tracked skill's naming facts — the collision detector's input.
+/// One locally-tracked skill's naming facts — the freed-name detector's input.
 struct TrackedName {
     name: String,
     skill_id: String,
-    /// Its first placement dir, when the map records one.
-    placement: Option<String>,
     /// The workspace its follow entry names, when followed.
     workspace_id: Option<String>,
 }
 
-/// Every tracked skill's `(name, id, placement, workspace)` — read from the sidecar walk + the
-/// follow-state (directly from `follows.json`, so it is correct even under an inert `ctx.follow`).
+/// Every tracked skill's `(name, id, workspace)` — read from the sidecar walk + the follow-state
+/// (directly from `follows.json`, so it is correct even under an inert `ctx.follow`).
 fn tracked_names(ctx: &Ctx<'_>) -> Result<Vec<TrackedName>, ClientError> {
     let followed: HashMap<String, String> = enroll::read_follows(ctx.fs, &ctx.layout)?
         .map(|f| {
@@ -2001,13 +2087,10 @@ fn tracked_names(ctx: &Ctx<'_>) -> Result<Vec<TrackedName>, ClientError> {
         let Some(lock) = doc::read_doc::<Lock>(ctx.fs, &ctx.layout.published(&sid).lock)? else {
             continue;
         };
-        let placement = doc::read_map(ctx.fs, &ctx.layout.published(&sid).map)?
-            .and_then(|m| m.placements.first().cloned());
         out.push(TrackedName {
             name: lock.name,
             workspace_id: followed.get(sid.as_str()).cloned(),
             skill_id: sid.into_string(),
-            placement,
         });
     }
     Ok(out)
@@ -2020,13 +2103,19 @@ fn tracked_names(ctx: &Ctx<'_>) -> Result<Vec<TrackedName>, ClientError> {
 /// Lay the NEVER-RECEIVED sidecar baseline for `skill_id` (mirrors `ops::add`'s staged-then-renamed,
 /// all-or-nothing publish). A fresh `sync` (`observed = applied = 0`, empty `recorded`), an empty
 /// `lock` (the name + zero base/digest, no files), and a `map` carrying the harness placement target (so
-/// the existing apply path can first-install there) but no applied content. Idempotent: a skill dir that
-/// already exists (already baselined, or received) is left untouched — `follow` never clobbers bytes.
+/// the existing apply path can first-install there) but no applied content. `workspace_slug` is the
+/// ADDRESS slug the naming discipline suffixes onto a colliding dirname (`None` = no namespace
+/// attempt — the fallback is the validated id); `incoming_digest` arms the adopt-in-place probe: a
+/// by-name occupant whose bytes digest-equal the incoming version becomes the placement, recorded
+/// as an ADOPTION RESERVATION (`pre_existing_sha`, no bytes moved here). Idempotent: a skill dir
+/// that already exists (already baselined, or received) is left untouched — `follow` never clobbers
+/// bytes.
 pub(crate) fn lay_first_receive_baseline(
     ctx: &Ctx<'_>,
     skill_id: &crate::id::SkillId,
     name: String,
-    workspace_slug: &str,
+    workspace_slug: Option<&str>,
+    incoming_digest: Option<&[u8; 32]>,
 ) -> Result<(), ClientError> {
     let _guard = sidecar::lock_skill(ctx.fs, &ctx.layout, skill_id)?;
     if ctx.fs.exists(&ctx.layout.skill_dir(skill_id)) {
@@ -2050,16 +2139,18 @@ pub(crate) fn lay_first_receive_baseline(
     // the adapter/registry "callers pass an already-validated id" contract; the display name +
     // workspace slug are UNTRUSTED advisory hints — the naming discipline sanitizes them and falls
     // back to the id, so they can never redirect a placement. A brand-new arrival is UNSCOPED (no
-    // follow entry exists yet; a later `--agent` scope narrows through the scope verbs).
+    // follow entry exists yet; a later `--agent` scope narrows through the scope verbs). The adopt
+    // digest lets a byte-identical by-name occupant BE the placement instead of a namespaced sibling.
     let plan = crate::placement::plan_targets(
         ctx,
         skill_id.as_str(),
         topos_harness::PlacementNaming {
             name: Some(&name),
-            workspace_slug: Some(workspace_slug),
+            workspace_slug,
         },
         crate::placement::AgentScope::default(),
         None,
+        incoming_digest.copied(),
     );
     doc::write_doc(
         ctx.fs,
@@ -2086,11 +2177,15 @@ pub(crate) fn lay_first_receive_baseline(
         harness_layer: None,
         harness_slug: Some(ctx.harness.id().slug().to_owned()),
     };
-    doc::write_map(
-        ctx.fs,
-        &sp.map,
-        &crate::placement::reconcile_map(&baseline, &plan),
-    )?;
+    let mut map = crate::placement::reconcile_map(&baseline, &plan);
+    // Record the ADOPTIONS durably: a planned dir that already exists under the display name with
+    // byte-identical content gets its digest into `pre_existing_sha` — the reservation later plans
+    // reuse (and the sticky prior-bytes record uninstall restores). `materialized_sha` stays None:
+    // no bytes move at baseline time; the consented accept heals the dir in place.
+    if let Some(digest) = incoming_digest {
+        crate::placement::record_adoptions(ctx, &mut map, skill_id.as_str(), &name, digest);
+    }
+    doc::write_map(ctx.fs, &sp.map, &map)?;
     // lock LAST — the commit marker (recovery keeps a dir only when lock.json is present).
     doc::write_doc(
         ctx.fs,

--- a/bins/topos/src/ops/merge_resolve.rs
+++ b/bins/topos/src/ops/merge_resolve.rs
@@ -783,6 +783,7 @@ fn place_draft_on_current(
             next_sync: &next_sync,
             sp,
             snapshot: Some(&|s: &ScannedBundle| snapshot_draft(ctx, sp, lock, s).map(|_| ())),
+            takeover: None,
         },
     )?;
     Ok(())

--- a/bins/topos/src/ops/pull.rs
+++ b/bins/topos/src/ops/pull.rs
@@ -18,7 +18,7 @@
 //! hang the harness.
 
 use std::cell::Cell;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
 use topos_core::digest::to_hex;
@@ -104,8 +104,8 @@ impl PullOutcome {
 }
 
 /// How a delivery-driven reconcile behaves — the `follow --yes` apply and the hook differ only here.
-/// The default (the bare enrolled sweep) accepts nothing silently, declines nothing, renames nothing,
-/// reconciles every enrolled workspace, and fetches notices WITHOUT acking.
+/// The default (the bare enrolled sweep) accepts nothing silently, reconciles every enrolled
+/// workspace, and fetches notices WITHOUT acking.
 #[derive(Default)]
 pub(crate) struct ReconcileOpts {
     /// Accept first-receive offers THIS invocation (the `follow --yes` batch consent: the describe
@@ -113,12 +113,6 @@ pub(crate) struct ReconcileOpts {
     /// Already-received skills keep their normal consent path — this never releases a hold or
     /// auto-applies a confirm-each update.
     pub accept_first_receive: bool,
-    /// Skill ids NOT to install (declined dirname collisions): a declined NEW arrival is skipped
-    /// wholesale — no follow entry, no baseline, no bytes.
-    pub decline: HashSet<String>,
-    /// skill_id → the dirname to install a NEW arrival under (the `--prefix-dirname` `<ws>.<name>`
-    /// choice for a colliding name). Only a fresh install consults it.
-    pub rename: HashMap<String, String>,
     /// Reconcile only this workspace (a `follow --yes` targets one); `None` = every enrolled one.
     pub only_workspace: Option<String>,
     /// When `Some`, RESTRICT first-receive acceptance AND new-arrival installation to these skill ids —
@@ -348,8 +342,8 @@ pub(crate) enum ResetOutcome {
 }
 
 /// The reconcile with explicit [`ReconcileOpts`] — the `follow --yes` apply (one workspace,
-/// batch-accepted first receives, declined/renamed collisions) and the interactive `update` (acked
-/// notices) drive the non-default forms; `&ReconcileOpts::default()` is the bare sweep.
+/// batch-accepted first receives) and the interactive `update` (acked notices) drive the
+/// non-default forms; `&ReconcileOpts::default()` is the bare sweep.
 pub(crate) fn pull_reconcile_with(
     ctx: &Ctx<'_>,
     delivery: &dyn DeliverySource,
@@ -464,13 +458,6 @@ pub(crate) fn pull_reconcile_with(
         let mut delivered_cache: BTreeMap<String, DeliveredSkill> = BTreeMap::new();
         let mut delivered_ids: HashSet<&str> = HashSet::with_capacity(snapshot.skills.len());
         for ds in &snapshot.skills {
-            // A DECLINED new arrival (a dirname collision the follow describe listed and `--yes`
-            // did not opt into) is skipped WHOLESALE — no follow entry, no baseline, no bytes, and
-            // no delivered-id mark (the undelivered classifier below must not treat it as detached:
-            // it is not followed, so the filter never selects it anyway).
-            if opts.decline.contains(&ds.skill_id) {
-                continue;
-            }
             delivered_ids.insert(ds.skill_id.as_str());
             delivered_cache.insert(
                 ds.skill_id.clone(),
@@ -497,8 +484,7 @@ pub(crate) fn pull_reconcile_with(
                 Some((_, f)) => sync_delivered(ctx, &ws, ds, f, accept_for(ctx, ds, opts)),
                 // A brand-new arrival OUTSIDE a targeted install (a re-attach / a targeted
                 // `follow --yes`) stays undisclosed — no follow entry, no baseline, no bytes.
-                // Skipped wholesale (like a declined collision) so the next full describe is the
-                // first to disclose it.
+                // Skipped wholesale so the next full describe is the first to disclose it.
                 None if opts
                     .install_only
                     .as_ref()
@@ -933,10 +919,11 @@ fn sync_delivered(
 
 /// A brand-new delivered skill this device has never held: record the follow entry (person-scoped
 /// truth lives on the plane; the local entry is install-state), lay the first-receive baseline
-/// under the skill's CATALOG name (or the caller's `--prefix-dirname` rename), and run the engine —
-/// whose kernel consent OFFERS the first bytes (I-TOFU) on a bare sweep, and PLACES them under the
-/// `follow --yes` batch consent ([`ReconcileOpts::accept_first_receive`], where the describe already
-/// disclosed the install set).
+/// under the skill's CATALOG name (a colliding dirname auto-namespaces by the workspace's ADDRESS
+/// slug; a byte-identical occupant is adopted in place), and run the engine — whose kernel consent
+/// OFFERS the first bytes (I-TOFU) on a bare sweep, and PLACES them under the `follow --yes` batch
+/// consent ([`ReconcileOpts::accept_first_receive`], where the describe already disclosed the
+/// install set).
 fn install_new_arrival(
     ctx: &Ctx<'_>,
     ws: &str,
@@ -944,17 +931,22 @@ fn install_new_arrival(
     opts: &ReconcileOpts,
 ) -> Result<PullSkill, ClientError> {
     let sid = SkillId::parse(&ds.skill_id)?;
-    let dirname = opts
-        .rename
-        .get(&ds.skill_id)
-        .cloned()
-        .unwrap_or_else(|| ds.name.clone());
+    // The collision namespace is the workspace's ADDRESS slug from the enrolled membership — a raw
+    // `w_…` id must never reach a dir name; with no membership record the naming discipline skips
+    // the namespace attempt and falls back to the validated skill id.
+    let slug = crate::placement::workspace_slug(ctx, Some(ws));
     // The BASELINE FIRST, the follow entry second — the same ordering `follow`'s promote uses. A
     // crash between them leaves a baseline with no entry, which the NEXT reconcile treats as a
     // fresh arrival again (the baseline layer is idempotent: it returns early if the skill dir
     // exists). The reverse order would leave an entry whose sidecar docs do not exist, and every
     // later sweep would fail that skill on a missing-doc read — a permanent wedge.
-    super::follow::lay_first_receive_baseline(ctx, &sid, dirname, ws)?;
+    super::follow::lay_first_receive_baseline(
+        ctx,
+        &sid,
+        ds.name.clone(),
+        slug.as_deref(),
+        Some(&ds.bundle_digest),
+    )?;
     enroll::write_follows_merged(
         ctx.fs,
         &ctx.layout,

--- a/bins/topos/src/ops/sync_engine.rs
+++ b/bins/topos/src/ops/sync_engine.rs
@@ -251,6 +251,42 @@ pub(crate) fn sync_one_with(
     // story) — corruption evidence, never a transient skip.
     let bundle = store.render_verified(target_commit, target_digest)?;
     let target_digest_hex = to_hex(&target_digest);
+    // A first-receive ADOPTION recorded for an EARLIER served version LAPSES here — the plan runs
+    // before the fetch, so only now can the reservation's digest be checked against the resolved
+    // target. The offer's consent was "adopt the byte-identical occupant"; a target that resolved
+    // to DIFFERENT bytes no longer describes it, and proceeding would wedge the apply on the
+    // materializer's never-clobber refusal. Clear the stale record and re-plan: the re-choose
+    // suffixes past the occupied dir, the reservation swap puts the record right, and the apply
+    // proceeds with the fresh state (the correction only touches never-materialized reservations,
+    // which scan Foreign/Absent either way — the base classification above is unchanged).
+    let (map, managed, work) = if first_receive
+        && managed.iter().any(|&i| {
+            map.placement_state[i].materialized_sha.is_none()
+                && map.placement_state[i]
+                    .pre_existing_sha
+                    .as_deref()
+                    .is_some_and(|sha| sha != target_digest_hex)
+        }) {
+        let mut corrected = map.clone();
+        for &i in &managed {
+            let st = &mut corrected.placement_state[i];
+            if st.materialized_sha.is_none()
+                && st
+                    .pre_existing_sha
+                    .as_deref()
+                    .is_some_and(|sha| sha != target_digest_hex)
+            {
+                st.pre_existing_sha = None;
+            }
+        }
+        let plan = placement::plan_for_skill(ctx, skill_id, &lock, &corrected);
+        let map = placement::reconcile_map(&corrected, &plan);
+        let managed = placement::managed_indices(&map, &plan);
+        let work = compute_work(ctx, &map, &lock, &name)?;
+        (map, managed, work)
+    } else {
+        (map, managed, work)
+    };
     // "At target" is now an EVERYWHERE fact: every managed placement must already hold the target's
     // bytes for the no-swap heal — a partial landing (a crash mid-loop, a newly added dir) stays a
     // CleanForward, whose apply loop skips the landed dirs and swaps only the rest.
@@ -437,6 +473,7 @@ pub(crate) fn go_back(
             snapshot: Some(&|scanned: &ScannedBundle| {
                 snapshot_draft(ctx, &sp, &lock, scanned).map(|_| ())
             }),
+            takeover: None,
         },
     )?;
     log_apply(ctx, skill_id, "pull-goback", target, &report);
@@ -517,6 +554,7 @@ pub(crate) fn reset_to_base(
             snapshot: Some(&|scanned: &ScannedBundle| {
                 snapshot_draft(ctx, &sp, &lock, scanned).map(|_| ())
             }),
+            takeover: None,
         },
     )?;
     // A recorded merge conflict describes the divergence this reset just DISCARDED — clear the
@@ -626,6 +664,7 @@ fn apply_forward(
             snapshot: Some(&|scanned: &ScannedBundle| {
                 snapshot_draft(ctx, sp, lock, scanned).map(|_| ())
             }),
+            takeover: None,
         },
     )?;
     log_apply(ctx, skill_id, "pull", t.commit, &report);
@@ -693,6 +732,7 @@ fn converge_placements(
             snapshot: Some(&|scanned: &ScannedBundle| {
                 snapshot_draft(ctx, sp, lock, scanned).map(|_| ())
             }),
+            takeover: None,
         },
     )?;
     log_apply(ctx, skill_id, "converge", base, &report);

--- a/bins/topos/src/placement.rs
+++ b/bins/topos/src/placement.rs
@@ -24,10 +24,13 @@
 //! ## Naming + never-clobber
 //!
 //! Every new target dir is named by the ONE discipline the reference adapter uses
-//! ([`topos_harness::choose_skill_dir`]): the sanitized display name, workspace-prefixed on a
-//! collision, the validated id as the last resort — and only a FREE dir or one this skill's own
-//! placement record already owns is ever chosen. An already-recorded (kind, agent) target keeps its
-//! dir verbatim (stability comes from the record, not from re-derivation).
+//! ([`topos_harness::choose_skill_dir`]): the sanitized display name, workspace-suffixed on a
+//! collision (`<name>-<ws>`), the validated id as the last resort — and only a FREE dir or one this
+//! skill's own placement record already owns is ever chosen. An already-recorded (kind, agent)
+//! target keeps its dir verbatim (stability comes from the record, not from re-derivation). One
+//! CLI-side refinement on top: an occupant that is a byte-identical copy of the incoming version —
+//! and that no OTHER tracked skill's record owns — is ADOPTED in place (the caller arms the choice
+//! with the incoming bundle digest), never duplicated under a namespaced sibling.
 
 use std::path::{Path, PathBuf};
 
@@ -94,22 +97,26 @@ pub(crate) fn scope_of(ctx: &Ctx<'_>, skill_id: &str) -> (Vec<String>, Vec<Strin
 
 /// Compute the placement plan for one skill. `naming` carries the untrusted display name + workspace
 /// slug (the collision namespace); `prior` is the durable record whose dirs are kept verbatim for
-/// already-recorded targets. With no roots (no `$HOME`, or a test that does not exercise detection)
-/// or no detected harness, the plan is the CLASSIC single placement — the prior record as-is, else
-/// the active adapter's placement.
+/// already-recorded targets; `adopt` is the INCOMING version's bundle digest, arming adopt-in-place
+/// (a first receive passes it so a byte-identical occupant becomes the placement instead of a
+/// namespaced sibling — and a recorded adoption reservation is reusable only for THAT digest).
+/// With no roots (no `$HOME`, or a test that does not exercise detection) or no detected harness,
+/// the plan is the CLASSIC single placement — the prior record as-is, else the active adapter's
+/// placement.
 pub(crate) fn plan_targets(
     ctx: &Ctx<'_>,
     skill_id: &str,
     naming: PlacementNaming<'_>,
     scope: AgentScope<'_>,
     prior: Option<&PlacementMap>,
+    adopt: Option<[u8; 32]>,
 ) -> PlacementPlan {
     let detected: Vec<&'static registry::KnownHarness> = match &ctx.roots {
         Some(roots) => registry::detected_harnesses(&roots.home, roots.cwd.as_deref()),
         None => Vec::new(),
     };
     if detected.is_empty() {
-        return classic_plan(ctx, skill_id, naming, prior);
+        return classic_plan(ctx, skill_id, naming, prior, adopt);
     }
     let home = &ctx
         .roots
@@ -128,6 +135,12 @@ pub(crate) fn plan_targets(
         .collect();
 
     let owned = owned_predicate(prior);
+    // The CLI's taken-probe: a path is unavailable when a filesystem entry holds it (lstat, so a
+    // dangling symlink counts) OR when ANOTHER tracked skill's record names it — an absent-on-disk
+    // recorded path stays reserved for its owner, so the ladder suffixes past it exactly like an
+    // occupied dir.
+    let taken =
+        |p: &Path| topos_harness::dir_taken(p) || recorded_by_another_skill(ctx, skill_id, p);
     let mut plan = PlacementPlan::default();
 
     // Shared-dir-first — but ONLY for an unscoped skill: a shared dir cannot express narrowing, so
@@ -148,12 +161,19 @@ pub(crate) fn plan_targets(
             }
         }
         if !plan.shared_covers.is_empty() {
-            let dir = prior_dir(prior, PlacementKind::Shared, None).unwrap_or_else(|| {
-                topos_harness::choose_skill_dir(
-                    &coverage::shared_skills_dir(home),
+            let dir = prior_dir(prior, PlacementKind::Shared, None, adopt).unwrap_or_else(|| {
+                adopt_override(
+                    ctx,
+                    topos_harness::choose_skill_dir(
+                        &coverage::shared_skills_dir(home),
+                        skill_id,
+                        naming,
+                        &taken,
+                        &owned,
+                    ),
                     skill_id,
                     naming,
-                    &owned,
+                    adopt,
                 )
             });
             plan.targets.push(PlannedTarget {
@@ -166,20 +186,28 @@ pub(crate) fn plan_targets(
 
     let active_slug = ctx.harness.id().slug();
     for h in native {
-        let dir = match prior_dir(prior, PlacementKind::Native, Some(h.slug)) {
+        let dir = match prior_dir(prior, PlacementKind::Native, Some(h.slug), adopt) {
             Some(dir) => dir,
             // The active adapter keeps its own richer `placement_for` for its native dir; every
             // other detected harness resolves through the registry's canonical user skills root
             // (v0's composition root constructs one adapter — the registry root is the same dir the
             // sibling adapters' no-discovery default names) with the shared naming discipline.
-            None if h.slug == active_slug => ctx.harness.placement_for(skill_id, naming, None).dir,
+            None if h.slug == active_slug => {
+                adapter_choice(ctx, skill_id, naming, &taken, &owned, adopt)
+            }
             None => {
                 let Some(root) =
                     registry::skills_root(h.slug, registry::SkillScope::User, home, cwd)
                 else {
                     continue; // a cwd-only harness has no user-scope dir — nothing to place
                 };
-                topos_harness::choose_skill_dir(&root, skill_id, naming, &owned)
+                adopt_override(
+                    ctx,
+                    topos_harness::choose_skill_dir(&root, skill_id, naming, &taken, &owned),
+                    skill_id,
+                    naming,
+                    adopt,
+                )
             }
         };
         // A native dir may coincide with an already-planned target (a harness whose native user dir
@@ -218,40 +246,63 @@ pub(crate) fn plan_targets(
         // fallback deliberately does NOT engage here: an explicit scope that excludes everything
         // must not resurrect the active adapter's copy.
         if !scope.narrows() {
-            return classic_plan(ctx, skill_id, naming, prior);
+            return classic_plan(ctx, skill_id, naming, prior, adopt);
         }
     }
     plan
 }
 
-/// The classic single-placement plan (no detection): the prior record's targets as-is, else the
-/// active adapter's placement — today's behavior, byte-identical.
+/// The classic single-placement plan (no detection): the prior record's targets as-is — except a
+/// STALE adoption reservation (never materialized, dir occupied, the occupant no longer matching
+/// its recorded digest), which is re-chosen fresh so [`reconcile_map`] can replace it (mirroring
+/// [`prior_dir`]'s validation on the detection path; returned verbatim it would wedge every apply
+/// on the never-clobber refusal) — else the active adapter's placement.
 fn classic_plan(
     ctx: &Ctx<'_>,
     skill_id: &str,
     naming: PlacementNaming<'_>,
     prior: Option<&PlacementMap>,
+    adopt: Option<[u8; 32]>,
 ) -> PlacementPlan {
+    let owned = owned_predicate(prior);
+    let taken =
+        |p: &Path| topos_harness::dir_taken(p) || recorded_by_another_skill(ctx, skill_id, p);
     if let Some(map) = prior
         && !map.placements.is_empty()
     {
-        return PlacementPlan {
-            targets: map
-                .placements
-                .iter()
-                .zip(&map.placement_state)
-                .map(|(dir, st)| PlannedTarget {
+        let mut targets: Vec<PlannedTarget> = Vec::new();
+        let mut invalid: Vec<(PlacementKind, Option<String>)> = Vec::new();
+        for (dir, st) in map.placements.iter().zip(&map.placement_state) {
+            let reusable = st.materialized_sha.is_some()
+                || !topos_harness::dir_taken(Path::new(dir))
+                || adoption_reservation_holds(dir, st, adopt);
+            if reusable {
+                targets.push(PlannedTarget {
                     dir: PathBuf::from(dir),
                     kind: st.kind,
                     agent: st.agent.clone(),
-                })
-                .collect(),
+                });
+            } else {
+                invalid.push((st.kind, st.agent.clone()));
+            }
+        }
+        // Each invalidated key re-chooses through the active adapter (+ the caller's adopt digest);
+        // an equal dir already planned collapses to one target.
+        for (kind, agent) in invalid {
+            let dir = adapter_choice(ctx, skill_id, naming, &taken, &owned, adopt);
+            if targets.iter().any(|t| t.dir == dir) {
+                continue;
+            }
+            targets.push(PlannedTarget { dir, kind, agent });
+        }
+        return PlacementPlan {
+            targets,
             shared_covers: Vec::new(),
         };
     }
     PlacementPlan {
         targets: vec![PlannedTarget {
-            dir: ctx.harness.placement_for(skill_id, naming, None).dir,
+            dir: adapter_choice(ctx, skill_id, naming, &taken, &owned, adopt),
             kind: PlacementKind::Native,
             agent: Some(ctx.harness.id().slug().to_owned()),
         }],
@@ -259,14 +310,79 @@ fn classic_plan(
     }
 }
 
+/// The active adapter's placement, hardened against paths ANOTHER tracked skill's record owns: the
+/// adapter's own ladder probes only the filesystem (it is content-blind and cannot see the sidecar),
+/// so when its answer lands on a recorded-elsewhere path — occupied or deleted — the ONE ladder
+/// re-runs directly over the same root with the CLI's full taken-probe (no duplicate naming logic;
+/// the adapter told us the root). The adopt override then applies as usual.
+fn adapter_choice(
+    ctx: &Ctx<'_>,
+    skill_id: &str,
+    naming: PlacementNaming<'_>,
+    taken: &dyn Fn(&Path) -> bool,
+    owned: &dyn Fn(&Path) -> bool,
+    adopt: Option<[u8; 32]>,
+) -> PathBuf {
+    let mut dir = ctx.harness.placement_for(skill_id, naming, None).dir;
+    if recorded_by_another_skill(ctx, skill_id, &dir)
+        && let Some(root) = dir.parent().map(Path::to_path_buf)
+    {
+        dir = topos_harness::choose_skill_dir(&root, skill_id, naming, taken, owned);
+    }
+    adopt_override(ctx, dir, skill_id, naming, adopt)
+}
+
+/// Adopt-in-place override on a chosen placement dir: when the by-name candidate under the same
+/// root is OCCUPIED by a byte-identical copy of the incoming version — and no OTHER tracked
+/// skill's record already owns that dir — that dir IS the placement, never a second namespaced/id
+/// copy. The reserved built-in dir name is never overridden. When the naming discipline already
+/// chose the by-name dir (free, or owned), the candidate equals the choice and nothing changes.
+fn adopt_override(
+    ctx: &Ctx<'_>,
+    dir: PathBuf,
+    skill_id: &str,
+    naming: PlacementNaming<'_>,
+    adopt: Option<[u8; 32]>,
+) -> PathBuf {
+    let Some(digest) = adopt else {
+        return dir;
+    };
+    let Some(name) = naming.name.and_then(topos_harness::sanitize_skill_dir) else {
+        return dir;
+    };
+    if name == topos_harness::RESERVED_SKILL_DIR && skill_id != topos_harness::RESERVED_SKILL_DIR {
+        return dir;
+    }
+    let Some(parent) = dir.parent() else {
+        return dir;
+    };
+    let candidate = parent.join(&name);
+    if candidate != dir
+        && topos_harness::dir_taken(&candidate)
+        && !recorded_by_another_skill(ctx, skill_id, &candidate)
+        && digest_probe(digest)(&candidate)
+    {
+        candidate
+    } else {
+        dir
+    }
+}
+
 /// The dir the prior record holds for a (kind, agent) key — target stability comes from the record.
 /// A record that was NEVER materialized and whose dir has since been occupied by someone else is not
 /// reusable (never clobber a foreign dir): the key re-chooses, and [`reconcile_map`] replaces the
-/// stale reservation.
+/// stale reservation. ONE occupied-but-reusable exception: an ADOPTION RESERVATION — a
+/// never-materialized placement whose `pre_existing_sha` records the occupant's digest, laid at
+/// first-receive baseline time for a byte-identical occupant — stays reusable while the occupant is
+/// unchanged (a fresh scan reproduces the recorded sha) AND, when the caller supplied the incoming
+/// version's digest, that version is still the recorded one (an adoption recorded for version A is
+/// never reused for an apply of version B). A failed scan or any mismatch means the reservation
+/// lapsed: NOT reusable, and it is replaced like any other stale reservation.
 fn prior_dir(
     prior: Option<&PlacementMap>,
     kind: PlacementKind,
     agent: Option<&str>,
+    adopt: Option<[u8; 32]>,
 ) -> Option<PathBuf> {
     let map = prior?;
     map.placements
@@ -275,9 +391,117 @@ fn prior_dir(
         .find(|(dir, st)| {
             st.kind == kind
                 && st.agent.as_deref() == agent
-                && (st.materialized_sha.is_some() || !Path::new(dir).exists())
+                && (st.materialized_sha.is_some()
+                    || !topos_harness::dir_taken(Path::new(dir))
+                    || adoption_reservation_holds(dir, st, adopt))
         })
         .map(|(dir, _)| PathBuf::from(dir))
+}
+
+/// Whether a never-materialized-but-occupied placement is a still-valid ADOPTION reservation: its
+/// recorded `pre_existing_sha` (the adopted occupant's digest) still matches a fresh scan of the
+/// dir, and — when the caller supplied the incoming version's digest — that digest too. Fails
+/// closed — an unscannable or changed occupant, or a version the adoption was not recorded for, is
+/// not ours to reuse.
+fn adoption_reservation_holds(dir: &str, st: &PlacementState, adopt: Option<[u8; 32]>) -> bool {
+    st.pre_existing_sha.as_deref().is_some_and(|sha| {
+        adopt.is_none_or(|d| topos_core::digest::to_hex(&d) == sha)
+            && scan::scan(Path::new(dir))
+                .is_ok_and(|s| topos_core::digest::to_hex(&s.bundle_digest) == sha)
+    })
+}
+
+/// The standard adopt-in-place content probe over an incoming/current bundle digest: an occupant
+/// whose scanned bytes digest-equal it is adoptable.
+fn digest_probe(digest: [u8; 32]) -> impl Fn(&Path) -> bool {
+    move |p: &Path| scan::scan(p).is_ok_and(|s| s.bundle_digest == digest)
+}
+
+/// A path's canonical form for record comparison, resolvable even when the LEAF is absent: a
+/// deleted placement dir still compares by canonicalizing its (real) parent and re-joining the
+/// leaf — records store canonicalized paths, and a deleted dir must stay comparable or its
+/// reservation would silently stop matching.
+fn canonical_or_parent(p: &Path) -> Option<PathBuf> {
+    std::fs::canonicalize(p).ok().or_else(|| {
+        let parent = p.parent()?;
+        let leaf = p.file_name()?;
+        std::fs::canonicalize(parent).ok().map(|c| c.join(leaf))
+    })
+}
+
+/// Whether ANOTHER tracked skill's placement map records `dir` (materialized or reserved,
+/// PRESENT on disk or deleted — an absent recorded path stays reserved for its owner) — a
+/// candidate some other skill's record names must never be claimed or adopted, or two records
+/// would own one path. Best-effort over the sidecar walk (naming-choice moments are rare, so the
+/// cost is fine): an absent sidecar records nothing; an unreadable entry is skipped — the
+/// materializer's never-clobber backstop stays the hard rail behind this planning-time hygiene.
+fn recorded_by_another_skill(ctx: &Ctx<'_>, skill_id: &str, dir: &Path) -> bool {
+    if !ctx.fs.exists(&ctx.layout.skills_dir()) {
+        return false;
+    }
+    let Ok(entries) = ctx.fs.read_dir(&ctx.layout.skills_dir()) else {
+        return false;
+    };
+    // Records store CANONICALIZED paths (adopt-in-place canonicalizes its source); the candidate
+    // may arrive through a symlinked root — and either side may be absent on disk. Raw equality
+    // first, then the parent-resolved canonical forms.
+    let canonical = canonical_or_parent(dir);
+    for entry in entries {
+        let Some(id) = entry.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if id.starts_with('.') || !entry.is_dir() || id == skill_id {
+            continue;
+        }
+        let Ok(sid) = crate::id::SkillId::parse(id) else {
+            continue;
+        };
+        let Ok(Some(map)) = crate::doc::read_map(ctx.fs, &ctx.layout.published(&sid).map) else {
+            continue;
+        };
+        if map.placements.iter().any(|p| {
+            let recorded = Path::new(p);
+            recorded == dir
+                || canonical
+                    .as_deref()
+                    .is_some_and(|c| canonical_or_parent(recorded).is_some_and(|r| r == c))
+        }) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Record ADOPTION RESERVATIONS on a freshly reconciled map: every never-materialized placement
+/// whose dir already exists under the sanitized display `name` with content digest-equal to
+/// `digest` — and which no OTHER tracked skill's record owns (the same guard the plan's adopt
+/// choice applies) — gets that digest into `pre_existing_sha` — the durable adoption record
+/// ([`prior_dir`] and [`classic_plan`] reuse it across plans; the sticky prior-bytes semantics
+/// ride it). No bytes move here; `materialized_sha` stays untouched.
+pub(crate) fn record_adoptions(
+    ctx: &Ctx<'_>,
+    map: &mut PlacementMap,
+    skill_id: &str,
+    name: &str,
+    digest: &[u8; 32],
+) {
+    let Some(sanitized) = topos_harness::sanitize_skill_dir(name) else {
+        return;
+    };
+    let probe = digest_probe(*digest);
+    for (dir, st) in map.placements.iter().zip(map.placement_state.iter_mut()) {
+        if st.materialized_sha.is_some() {
+            continue;
+        }
+        let p = Path::new(dir);
+        if p.file_name().and_then(|l| l.to_str()) == Some(sanitized.as_str())
+            && topos_harness::dir_taken(p)
+            && !recorded_by_another_skill(ctx, skill_id, p)
+            && probe(p)
+        {
+            st.pre_existing_sha = Some(topos_core::digest::to_hex(digest));
+        }
+    }
 }
 
 /// The never-clobber ownership predicate: a dir counts as this skill's own iff the record names it
@@ -306,7 +530,9 @@ pub(crate) fn reconcile_map(prior: &PlacementMap, plan: &PlacementPlan) -> Place
         }
         // A stale RESERVATION for the same (kind, agent) key — recorded, never materialized, and
         // re-chosen because its dir got occupied — is REPLACED in place (a reservation holds no
-        // bytes, so nothing freezes); everything else appends.
+        // bytes, so nothing freezes); everything else appends. The slot's state resets with the
+        // dir: the old reservation's `pre_existing_sha` described the OLD dir's occupant and must
+        // never migrate to the new one.
         if let Some(i) = next
             .placements
             .iter()
@@ -318,6 +544,13 @@ pub(crate) fn reconcile_map(prior: &PlacementMap, plan: &PlacementPlan) -> Place
             })
         {
             next.placements[i] = dir;
+            next.placement_state[i] = PlacementState {
+                kind: t.kind,
+                agent: t.agent.clone(),
+                materialized_sha: None,
+                pre_existing_sha: None,
+                swap_capability: SwapCapability::Unsupported,
+            };
             continue;
         }
         next.placements.push(dir);
@@ -569,7 +802,7 @@ pub(crate) fn placements_diverged(skill_name: &str, scans: &[PlacementScan]) -> 
 }
 
 /// The workspace ADDRESS slug for `workspace_id` (the collision namespace `choose_skill_dir`
-/// prefixes with), from the enrolled memberships — best-effort (`None` offline / unenrolled).
+/// suffixes with), from the enrolled memberships — best-effort (`None` offline / unenrolled).
 pub(crate) fn workspace_slug(ctx: &Ctx<'_>, workspace_id: Option<&str>) -> Option<String> {
     let ws = workspace_id?;
     crate::enroll::read_user(ctx.fs, &ctx.layout)
@@ -599,10 +832,13 @@ pub(crate) fn plan_for_skill(
                 workspace_slug: None,
             },
             Some(prior),
+            None,
         );
     }
     let (agents, excluded) = scope_of(ctx, skill_id);
     let slug = workspace_slug(ctx, ws.as_deref());
+    // No adopt probe here: a tracked skill's adoption continuity rides the record — the baseline's
+    // adoption reservation (`pre_existing_sha`) keeps [`prior_dir`] answering the adopted dir.
     plan_targets(
         ctx,
         skill_id,
@@ -615,6 +851,7 @@ pub(crate) fn plan_for_skill(
             excluded: &excluded,
         },
         Some(prior),
+        None,
     )
 }
 
@@ -649,4 +886,76 @@ pub(crate) fn validate_agent_slugs(
         .filter(|s| !detected.contains(&s.as_str()))
         .cloned()
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A one-entry never-materialized map (a reservation) whose slot carries a recorded adoption.
+    fn reservation_map(dir: &str, pre_existing: Option<&str>) -> PlacementMap {
+        PlacementMap {
+            schema_version: topos_types::PLACEMENT_MAP_SCHEMA_VERSION,
+            placements: vec![dir.to_owned()],
+            applied_commit: "0".repeat(64),
+            materialized_sha: "0".repeat(64),
+            pre_existing_sha: None,
+            swap_capability: SwapCapability::Unsupported,
+            placement_state: vec![PlacementState {
+                kind: PlacementKind::Native,
+                agent: Some("claude-code".to_owned()),
+                materialized_sha: None,
+                pre_existing_sha: pre_existing.map(str::to_owned),
+                swap_capability: SwapCapability::AtomicExchange,
+            }],
+            harness: None,
+            harness_layer: None,
+            harness_slug: None,
+        }
+    }
+
+    /// Replacing a stale reservation's dir RESETS the slot's state (kind/agent kept): the old
+    /// adoption's `pre_existing_sha` described the OLD occupant and must never migrate to the new
+    /// dir, and the cached swap capability was probed against the old parent.
+    #[test]
+    fn a_replaced_stale_reservation_resets_the_slot_state() {
+        let prior = reservation_map("/skills/deploy", Some(&"a".repeat(64)));
+        let plan = PlacementPlan {
+            targets: vec![PlannedTarget {
+                dir: PathBuf::from("/skills/deploy-acme"),
+                kind: PlacementKind::Native,
+                agent: Some("claude-code".to_owned()),
+            }],
+            shared_covers: Vec::new(),
+        };
+        let next = reconcile_map(&prior, &plan);
+        assert_eq!(next.placements, vec!["/skills/deploy-acme".to_owned()]);
+        let st = &next.placement_state[0];
+        assert_eq!(st.kind, PlacementKind::Native);
+        assert_eq!(st.agent.as_deref(), Some("claude-code"));
+        assert!(st.materialized_sha.is_none());
+        assert!(st.pre_existing_sha.is_none(), "no adoption record migrates");
+        assert_eq!(st.swap_capability, SwapCapability::Unsupported);
+    }
+
+    /// The same-dir plan (a still-valid reservation) keeps the slot verbatim — the reset fires
+    /// only on an actual replacement.
+    #[test]
+    fn an_unchanged_reservation_keeps_its_recorded_state() {
+        let prior = reservation_map("/skills/deploy", Some(&"a".repeat(64)));
+        let plan = PlacementPlan {
+            targets: vec![PlannedTarget {
+                dir: PathBuf::from("/skills/deploy"),
+                kind: PlacementKind::Native,
+                agent: Some("claude-code".to_owned()),
+            }],
+            shared_covers: Vec::new(),
+        };
+        let next = reconcile_map(&prior, &plan);
+        assert_eq!(next.placements, vec!["/skills/deploy".to_owned()]);
+        assert_eq!(
+            next.placement_state[0].pre_existing_sha.as_deref(),
+            Some("a".repeat(64).as_str())
+        );
+    }
 }

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -1022,7 +1022,8 @@ pub(crate) fn follow_tty(data: &FollowData, resumed: &[String]) -> String {
 }
 
 /// The generic next-actions for a two-phase DESCRIBE: each argv is the ready-to-exec apply command
-/// (`… --yes`, plus alternatives like the `--prefix-dirname` variant).
+/// (`… --yes`). An empty argv list yields an empty next-actions list (a standing follow's
+/// nothing-to-apply describe).
 pub(crate) fn describe_next_actions(argvs: Vec<Vec<String>>) -> Vec<NextAction> {
     argvs
         .into_iter()
@@ -1060,7 +1061,10 @@ fn shell_quote(arg: &str) -> String {
 }
 
 /// The follow DESCRIBE's TTY: the workspace story, the install list with digests + via, the
-/// collision choice, the standing disclosures, and the `--yes` argvs. Nothing has changed yet.
+/// dirname outcomes (adoptions; auto-namespaced collisions), the standing disclosures, and the
+/// `--yes` argv. Nothing has changed yet — except an enrollment, which is disclosed as a fact
+/// (the credential/link persisted and the trigger armed), never papered over with "nothing has
+/// changed".
 pub(crate) fn follow_describe_tty(
     d: &crate::ops::FollowDescribe,
     next_argvs: &[Vec<String>],
@@ -1070,11 +1074,19 @@ pub(crate) fn follow_describe_tty(
         d.workspace.display_name, d.workspace.name, d.workspace.address
     );
     if d.enrolled_now {
-        s.push_str("\nEnrolled this device (identity only — nothing is installed yet).");
-    }
-    s.push_str(&format!("\nYour role: {}", d.role));
-    if let Some(by) = &d.invited_by {
-        s.push_str(&format!(" — invited by {by}"));
+        s.push_str(&format!(
+            "\nEnrolled this device as {} — role: {}",
+            d.principal, d.role
+        ));
+        if let Some(by) = &d.invited_by {
+            s.push_str(&format!(" — invited by {by}"));
+        }
+        s.push('.');
+    } else {
+        s.push_str(&format!("\nYour role: {}", d.role));
+        if let Some(by) = &d.invited_by {
+            s.push_str(&format!(" — invited by {by}"));
+        }
     }
     if !d.preplaced_channels.is_empty() {
         s.push_str(&format!(
@@ -1087,6 +1099,15 @@ pub(crate) fn follow_describe_tty(
         .iter()
         .map(|t| format!("{} {}", t.kind, t.name))
         .collect();
+    if let Some(note) = &d.standing_note {
+        // The standing no-op: one honest line carrying the whole fact (the all-devices constant
+        // is folded into the note), no install lines, no apply block.
+        s.push_str(&format!(
+            "\nFollowing: {} — {note}.",
+            target_list.join(", ")
+        ));
+        return s;
+    }
     s.push_str(&format!("\nFollowing: {}", target_list.join(", ")));
     if d.installs.is_empty() {
         s.push_str("\nNothing new would install on this device.");
@@ -1116,26 +1137,41 @@ pub(crate) fn follow_describe_tty(
     for note in &d.freed_name_notes {
         s.push_str(&format!("\nnote: {note}"));
     }
+    if !d.adoptions.is_empty() {
+        s.push_str("\nAdopts in place:");
+        for a in &d.adoptions {
+            s.push_str(&format!(
+                "\n  {} — adopts your existing identical copy at {}",
+                a.name, a.path
+            ));
+        }
+    }
     if !d.collisions.is_empty() {
-        s.push_str("\nName collisions (declined by default):");
+        s.push_str("\nName collisions:");
         for c in &d.collisions {
             s.push_str(&format!(
-                "\n  {} — a different skill already lives at {}; `--prefix-dirname` installs it \
-                 as {}",
-                c.name, c.existing, c.prefixed_dirname
+                "\n  {} — a different skill already lives at {}; installs as {}",
+                c.name, c.existing, c.installs_as
             ));
         }
     }
     s.push_str(&format!("\n{}", d.all_devices_note));
-    s.push_str(&format!("\n{}", d.reporting_note));
-    s.push_str("\nNothing has changed yet — apply with:");
-    for argv in next_argvs {
-        s.push_str(&format!("\n  {}", argv_line(argv)));
+    if !next_argvs.is_empty() {
+        if d.enrolled_now {
+            // The enrollment DID persist (credential/link + the armed trigger) — never claim
+            // nothing has changed.
+            s.push_str("\nApply the follow with:");
+        } else {
+            s.push_str("\nNothing has changed yet — apply with:");
+        }
+        for argv in next_argvs {
+            s.push_str(&format!("\n  {}", argv_line(argv)));
+        }
     }
     s
 }
 
-/// The follow APPLY's TTY: what was subscribed, what landed, what was declined.
+/// The follow APPLY's TTY: what was subscribed and what landed.
 pub(crate) fn follow_applied_tty(a: &crate::ops::FollowApplied) -> String {
     let mut s = format!("Following in {} ({}).", a.workspace_name, a.workspace_id);
     if a.enrolled_now {
@@ -1155,13 +1191,6 @@ pub(crate) fn follow_applied_tty(a: &crate::ops::FollowApplied) -> String {
             let digest = i.bundle_digest.as_deref().map(short).unwrap_or("?");
             s.push_str(&format!("\n  {}  @{digest}", i.name));
         }
-    }
-    for c in &a.declined {
-        s.push_str(&format!(
-            "\nDeclined {} (name collision with {}); re-run with `--prefix-dirname` to install it \
-             as {}",
-            c.name, c.existing, c.prefixed_dirname
-        ));
     }
     for w in &a.warnings {
         s.push_str(&format!("\nwarning: {w}"));
@@ -1230,7 +1259,6 @@ pub(crate) fn link_describe_tty(d: &crate::ops::LinkDescribe, yes_argv: &[String
         },
     }
     s.push_str(&format!("\n{}", d.all_devices_note));
-    s.push_str(&format!("\n{}", d.reporting_note));
     s.push_str(&format!(
         "\nNothing has changed yet — apply with:\n  {}",
         argv_line(yes_argv)

--- a/bins/topos/src/test_support.rs
+++ b/bins/topos/src/test_support.rs
@@ -118,6 +118,8 @@ pub struct FollowDescribeView {
     pub address: String,
     /// The caller's role on the roster.
     pub role: String,
+    /// The signed-in principal the describe acts as (the enrolled-receipt disclosure).
+    pub principal: String,
     /// Who invited the caller (present for an invited member).
     pub invited_by: Option<String>,
     /// Whether THIS invocation enrolled the device.
@@ -128,10 +130,15 @@ pub struct FollowDescribeView {
     pub installs: Vec<InstallView>,
     /// Channels the person is already placed into (an inviter's pre-placement; `everyone` excluded).
     pub preplaced_channels: Vec<String>,
-    /// Following is person-scoped: every enrolled device receives the same set.
+    /// The in-place adoptions the describe disclosed (`(skill name, adopted path)`).
+    pub adoptions: Vec<(String, String)>,
+    /// The auto-namespaced dirname collisions (`(skill name, the dirname it installs as)`).
+    pub collisions: Vec<(String, String)>,
+    /// Following is person-scoped: skills arrive on every device linked to the workspace.
     pub all_devices_note: String,
-    /// This device reports its applied versions to the workspace's fleet view.
-    pub reporting_note: String,
+    /// Present when the follow is already standing and `--yes` would change nothing (no apply
+    /// argv offered).
+    pub standing_note: Option<String>,
 }
 
 /// The `--yes` APPLY report — the public face of `FollowApplied`: the subscription rows written and the
@@ -958,7 +965,6 @@ impl FollowHarness {
             manual,
             workspace: None,
             yes: false,
-            prefix_dirname: false,
             channels: Vec::new(),
             skills: Vec::new(),
             agents: Vec::new(),
@@ -979,7 +985,6 @@ impl FollowHarness {
             manual: false,
             workspace: None,
             yes: false,
-            prefix_dirname: false,
             channels: Vec::new(),
             skills: Vec::new(),
             agents: Vec::new(),
@@ -1002,7 +1007,6 @@ impl FollowHarness {
             manual: false,
             workspace: None,
             yes: false,
-            prefix_dirname: false,
             channels: Vec::new(),
             skills: Vec::new(),
             agents: Vec::new(),
@@ -1054,7 +1058,6 @@ impl FollowHarness {
             manual: false,
             workspace: None,
             yes: false,
-            prefix_dirname: false,
             channels: Vec::new(),
             skills: Vec::new(),
             agents: Vec::new(),
@@ -1500,7 +1503,6 @@ impl FollowHarness {
             manual: false,
             workspace: None,
             yes: true,
-            prefix_dirname: false,
             channels: Vec::new(),
             skills: skills.iter().map(|s| (*s).to_owned()).collect(),
             agents: Vec::new(),
@@ -3108,14 +3110,13 @@ impl ReconcileHarness {
     }
 }
 
-/// `follow`'s flags for the address-flow methods: the classic auto adoption, no workspace filter, no
-/// prefixing, no kind-forced selectors — just the `--yes` toggle the describe/apply split turns on.
+/// `follow`'s flags for the address-flow methods: the classic auto adoption, no workspace filter,
+/// no kind-forced selectors — just the `--yes` toggle the describe/apply split turns on.
 fn follow_opts(yes: bool) -> ops::FollowOpts {
     ops::FollowOpts {
         manual: false,
         workspace: None,
         yes,
-        prefix_dirname: false,
         channels: Vec::new(),
         skills: Vec::new(),
         agents: Vec::new(),
@@ -3129,6 +3130,7 @@ fn describe_view(d: &crate::ops::FollowDescribe) -> FollowDescribeView {
         workspace_name: d.workspace.name.clone(),
         address: d.workspace.address.clone(),
         role: d.role.clone(),
+        principal: d.principal.clone(),
         invited_by: d.invited_by.clone(),
         enrolled_now: d.enrolled_now,
         targets: d
@@ -3149,8 +3151,18 @@ fn describe_view(d: &crate::ops::FollowDescribe) -> FollowDescribeView {
             })
             .collect(),
         preplaced_channels: d.preplaced_channels.clone(),
+        adoptions: d
+            .adoptions
+            .iter()
+            .map(|a| (a.name.clone(), a.path.clone()))
+            .collect(),
+        collisions: d
+            .collisions
+            .iter()
+            .map(|c| (c.name.clone(), c.installs_as.clone()))
+            .collect(),
         all_devices_note: d.all_devices_note.clone(),
-        reporting_note: d.reporting_note.clone(),
+        standing_note: d.standing_note.clone(),
     }
 }
 

--- a/bins/topos/src/tests/builtin_skill.rs
+++ b/bins/topos/src/tests/builtin_skill.rs
@@ -59,7 +59,13 @@ impl HarnessAdapter for StubClaude {
         _d: Option<&DiscoveredPlacement>,
     ) -> PlacementTarget {
         PlacementTarget {
-            dir: topos_harness::choose_skill_dir(&self.skills, skill_id, naming, &|_| false),
+            dir: topos_harness::choose_skill_dir(
+                &self.skills,
+                skill_id,
+                naming,
+                &topos_harness::dir_taken,
+                &|_| false,
+            ),
         }
     }
     fn currency_kind(&self) -> CurrencyKind {
@@ -657,11 +663,12 @@ fn the_name_is_reserved_end_to_end_client_side() {
             name: Some("topos"),
             workspace_slug: Some("acme"),
         },
+        &topos_harness::dir_taken,
         &|_| false,
     );
     assert_eq!(
         chosen,
-        root.join("acme-topos"),
+        root.join("topos-acme"),
         "a foreign skill named `topos` disambiguates like a collision"
     );
     // The built-in itself (skill id == the reserved name) keeps the plain dir.
@@ -672,6 +679,7 @@ fn the_name_is_reserved_end_to_end_client_side() {
             name: Some("topos"),
             workspace_slug: None,
         },
+        &topos_harness::dir_taken,
         &|_| false,
     );
     assert_eq!(own, root.join("topos"));

--- a/bins/topos/src/tests/follow.rs
+++ b/bins/topos/src/tests/follow.rs
@@ -480,7 +480,6 @@ fn opts(yes: bool) -> ops::FollowOpts {
         manual: false,
         workspace: None,
         yes,
-        prefix_dirname: false,
         channels: Vec::new(),
         skills: Vec::new(),
         agents: Vec::new(),

--- a/bins/topos/src/tests/placement_breadth.rs
+++ b/bins/topos/src/tests/placement_breadth.rs
@@ -62,7 +62,13 @@ impl HarnessAdapter for StubClaude {
         _d: Option<&DiscoveredPlacement>,
     ) -> PlacementTarget {
         PlacementTarget {
-            dir: topos_harness::choose_skill_dir(&self.skills, skill_id, naming, &|_| false),
+            dir: topos_harness::choose_skill_dir(
+                &self.skills,
+                skill_id,
+                naming,
+                &topos_harness::dir_taken,
+                &|_| false,
+            ),
         }
     }
     fn currency_kind(&self) -> CurrencyKind {
@@ -215,6 +221,7 @@ fn unscoped_plan_is_shared_dir_first_plus_uncovered_natives() {
         },
         AgentScope::default(),
         None,
+        None,
     );
 
     // ONE shared copy (cline + openclaw are covered) + native copies for cursor and codex (probed
@@ -276,6 +283,7 @@ fn scoped_plan_is_native_only_never_the_shared_dir() {
         },
         scoped(&include, &[]),
         None,
+        None,
     );
     assert!(plan.targets.iter().all(|t| t.kind == PlacementKind::Native));
     assert_eq!(plan.targets.len(), 1);
@@ -301,6 +309,7 @@ fn scoped_plan_is_native_only_never_the_shared_dir() {
         },
         scoped(&[], &excluded),
         None,
+        None,
     );
     assert!(plan.targets.iter().all(|t| t.kind == PlacementKind::Native));
     assert_eq!(
@@ -324,8 +333,148 @@ fn scoped_plan_is_native_only_never_the_shared_dir() {
         },
         scoped(&include, &[]),
         None,
+        None,
     );
     assert!(plan.targets.is_empty(), "{:?}", plan.targets);
+}
+
+#[test]
+fn a_stale_classic_adoption_reservation_rechooses_a_fresh_dir() {
+    // The no-detection path validates adoption reservations exactly like the detection path: a
+    // recorded never-materialized placement whose occupant CHANGED since the adoption is dropped
+    // from the plan and its key re-chooses fresh — returned verbatim it would wedge every apply on
+    // the never-clobber refusal.
+    let rig = Rig::new("classic-stale");
+    let occupied = rig
+        .agent_home
+        .0
+        .join(".claude")
+        .join("skills")
+        .join("deploy");
+    std::fs::create_dir_all(&occupied).unwrap();
+    std::fs::write(occupied.join("SKILL.md"), "# someone else's deploy\n").unwrap();
+    let mk_prior = |pre_existing: &str| topos_types::persisted::PlacementMap {
+        schema_version: topos_types::PLACEMENT_MAP_SCHEMA_VERSION,
+        placements: vec![occupied.to_string_lossy().into_owned()],
+        applied_commit: "0".repeat(64),
+        materialized_sha: "0".repeat(64),
+        pre_existing_sha: None,
+        swap_capability: topos_types::persisted::SwapCapability::Unsupported,
+        placement_state: vec![topos_types::persisted::PlacementState {
+            kind: PlacementKind::Native,
+            agent: Some("claude-code".to_owned()),
+            materialized_sha: None,
+            pre_existing_sha: Some(pre_existing.to_owned()),
+            swap_capability: topos_types::persisted::SwapCapability::Unsupported,
+        }],
+        harness: None,
+        harness_layer: None,
+        harness_slug: None,
+    };
+    let inert_f = InertFollow;
+    let inert_p = InertPlane;
+    let ctx = rig.ctx_no_roots(&inert_f, &inert_p);
+    let naming = topos_harness::PlacementNaming {
+        name: Some("deploy"),
+        workspace_slug: Some("acme"),
+    };
+
+    // STALE: the recorded adoption digest no longer matches the occupant → re-choose (the by-name
+    // dir is occupied, so the fresh choice is the workspace-suffixed sibling).
+    let stale = mk_prior(&"a".repeat(64));
+    let plan = placement::plan_targets(
+        &ctx,
+        "topos_stale",
+        naming,
+        AgentScope::default(),
+        Some(&stale),
+        None,
+    );
+    assert_eq!(plan.targets.len(), 1);
+    assert_eq!(
+        plan.targets[0].dir,
+        rig.agent_home
+            .0
+            .join(".claude")
+            .join("skills")
+            .join("deploy-acme"),
+        "the stale reservation is not reused"
+    );
+
+    // VALID: a reservation whose occupant still matches its recorded digest is kept verbatim.
+    let digest = crate::scan::scan(&occupied).unwrap().bundle_digest;
+    let valid = mk_prior(&topos_core::digest::to_hex(&digest));
+    let plan = placement::plan_targets(
+        &ctx,
+        "topos_stale",
+        naming,
+        AgentScope::default(),
+        Some(&valid),
+        None,
+    );
+    assert_eq!(plan.targets.len(), 1);
+    assert_eq!(plan.targets[0].dir, occupied);
+}
+
+#[test]
+fn a_scope_replan_adopts_a_byte_identical_native_occupant() {
+    // FIX territory: scoping to an agent whose native dir ALREADY holds a byte-identical copy of
+    // the landed version adopts that dir — never a namespaced (or id-named) duplicate — and the
+    // adoption heals to a materialized placement so later updates ride the normal rail.
+    let rig = Rig::new("scope-adopt");
+    let sid = rig.adopt_followed("deploy");
+    rig.detect(".cursor");
+    let cursor = rig
+        .agent_home
+        .0
+        .join(".cursor")
+        .join("skills")
+        .join("deploy");
+    std::fs::create_dir_all(&cursor).unwrap();
+    std::fs::write(cursor.join("SKILL.md"), "# deploy\nbody\n").unwrap(); // byte-identical
+
+    let follow = rig.follow_seam();
+    let inert_p = InertPlane;
+    let ctx = rig.ctx(&follow, &inert_p);
+    let out = ops::set_scope(
+        &ctx,
+        &["deploy".to_owned()],
+        &["cursor".to_owned()],
+        None,
+        true,
+    )
+    .unwrap();
+    assert!(matches!(out, ops::AgentScopeOutcome::Applied(_)));
+
+    let map = rig.read_map(&sid);
+    let i = map
+        .placements
+        .iter()
+        .position(|p| Path::new(p) == cursor)
+        .expect("the identical occupant IS the placement");
+    let skills_root = rig.agent_home.0.join(".cursor").join("skills");
+    let entries: Vec<String> = std::fs::read_dir(&skills_root)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        entries,
+        vec!["deploy".to_owned()],
+        "no namespaced or id-named duplicate lands beside the adopted copy"
+    );
+    // Healed to materialized: the record advanced with no swap, the occupant byte-untouched.
+    let lock: topos_types::persisted::Lock =
+        doc::read_doc(&rig.fs, &rig.layout().published(&sid).lock)
+            .unwrap()
+            .unwrap();
+    assert_eq!(
+        map.placement_state[i].materialized_sha.as_deref(),
+        Some(lock.bundle_digest.as_str())
+    );
+    assert_eq!(
+        std::fs::read_to_string(cursor.join("SKILL.md")).unwrap(),
+        "# deploy\nbody\n"
+    );
 }
 
 #[test]
@@ -346,6 +495,7 @@ fn no_detection_keeps_the_classic_single_placement() {
                 workspace_slug: None,
             },
             AgentScope::default(),
+            None,
             None,
         );
         assert_eq!(plan.targets.len(), 1);

--- a/bins/topos/src/tests/subscribe.rs
+++ b/bins/topos/src/tests/subscribe.rs
@@ -1,9 +1,10 @@
 //! The two-phase SUBSCRIBE surface over fakes (no HTTP): the `follow <address>` enroll flow
 //! (card → authorize(workspace) → redeem → the describe gate), the wrong-server `TOPOS_HOME`
-//! refusal, the describe fields (installs + collision choice + direct-follow note), the `--yes`
-//! apply (row ops + the batch-accepted reconcile), the dual-kind `unfollow` (workspace/`everyone`
-//! refusals; the skill detach row + the local pause), and the hook posture (the staleness warning
-//! line; notices fetched-without-ack vs narrated-then-acked).
+//! refusal, the describe fields (installs + the dirname outcomes — in-place adoptions and
+//! auto-namespaced collisions — + direct-follow note), the `--yes` apply (row ops + the
+//! batch-accepted reconcile), the dual-kind `unfollow` (workspace/`everyone` refusals; the skill
+//! detach row + the local pause), and the hook posture (the staleness warning line; notices
+//! fetched-without-ack vs narrated-then-acked).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -73,11 +74,17 @@ impl HarnessAdapter for TmpHarness {
         naming: topos_harness::PlacementNaming<'_>,
         _d: Option<&DiscoveredPlacement>,
     ) -> PlacementTarget {
-        // Mirror the real adapters: the DIRNAME is the (sanitized) display name — the collision
-        // machinery's whole subject — falling back to the id.
-        let dir = naming.name.unwrap_or(skill_id);
+        // Mirror the real adapters: the ONE naming discipline — the (sanitized) display name,
+        // workspace-suffixed on a collision, the id as the last resort. The collision machinery
+        // is this suite's whole subject.
         PlacementTarget {
-            dir: self.skills_root.join(dir),
+            dir: topos_harness::choose_skill_dir(
+                &self.skills_root,
+                skill_id,
+                naming,
+                &topos_harness::dir_taken,
+                &|_| false,
+            ),
         }
     }
     fn currency_kind(&self) -> CurrencyKind {
@@ -528,7 +535,6 @@ fn opts(yes: bool) -> ops::FollowOpts {
         manual: false,
         workspace: None,
         yes,
-        prefix_dirname: false,
         channels: Vec::new(),
         skills: Vec::new(),
         agents: Vec::new(),
@@ -599,17 +605,15 @@ fn an_address_follow_enrolls_then_lands_on_the_describe_never_the_apply() {
     assert!(describe.enrolled_now, "this invocation enrolled");
     assert_eq!(describe.workspace.name, "acme");
     assert_eq!(describe.role, "member");
+    assert_eq!(describe.principal, "alice@acme.com");
     assert_eq!(describe.invited_by.as_deref(), Some("robert@acme.com"));
     // The inviter's pre-placement is disclosed; the structural everyone is not.
     assert_eq!(describe.preplaced_channels, vec!["design".to_owned()]);
-    // The paste-ready apply argv ends in --yes.
-    assert_eq!(
-        next_argvs[0],
-        vec!["topos", "follow", "acme", "--yes"]
-            .into_iter()
-            .map(str::to_owned)
-            .collect::<Vec<_>>()
-    );
+    // Nothing is delivered and a workspace target writes no row — the honest standing receipt: no
+    // `--yes` to offer, the standing note carries the fact instead.
+    assert!(next_argvs.is_empty(), "{next_argvs:?}");
+    let note = describe.standing_note.as_deref().expect("standing note");
+    assert!(note.starts_with("nothing new to install"), "{note}");
     // The grant was polled for (the credential rides the granted poll — no redeem round-trip).
     assert!(log.lock().unwrap().iter().any(|e| e == "poll"));
     // The enrollment itself promoted (identity, reversible): the credential + membership are on
@@ -663,7 +667,7 @@ fn the_wrong_server_refusal_names_the_topos_home_hatch() {
 // ---------------------------------------------------------------------------------------------
 
 #[test]
-fn the_channel_describe_lists_installs_with_digests_and_the_collision_choice() {
+fn the_channel_describe_lists_installs_with_digests_and_the_auto_namespaced_collision() {
     let rig = Rig::new("describe");
     rig.seed_enrolled();
     let log: CallLog = Arc::default();
@@ -674,9 +678,9 @@ fn the_channel_describe_lists_installs_with_digests_and_the_collision_choice() {
     let directory = FakeDirectory::acme(log.clone());
     let transport = FakeTransport::empty(log.clone());
 
-    // A LOCAL tracked skill already holds the name "deploy" (a different identity) — the incoming
-    // channel skill collides on the dirname.
-    let local = rig.work.0.join("local-deploy");
+    // A LOCAL tracked skill (a different identity, DIFFERENT bytes) already occupies the by-name
+    // dir under the harness skills root — the incoming channel skill collides on the dirname.
+    let local = rig.work.0.join("skills").join("deploy");
     std::fs::create_dir_all(&local).unwrap();
     std::fs::write(local.join("SKILL.md"), b"# local deploy\n").unwrap();
     {
@@ -715,12 +719,22 @@ fn the_channel_describe_lists_installs_with_digests_and_the_collision_choice() {
     );
     assert_eq!(install.via_channels, vec!["eng".to_owned()]);
     assert!(!install.via_direct);
-    // The collision is listed with the prefixed-dir choice, and the alternative argv is offered.
+    // The collision is disclosed with the auto-namespaced dirname (skill first, workspace suffix);
+    // there is exactly ONE apply argv — no opt-in flag exists any more.
     assert_eq!(describe.collisions.len(), 1);
     assert_eq!(describe.collisions[0].name, "deploy");
-    assert_eq!(describe.collisions[0].prefixed_dirname, "acme.deploy");
-    assert_eq!(next_argvs.len(), 2, "the --prefix-dirname argv is offered");
-    assert!(next_argvs[1].contains(&"--prefix-dirname".to_owned()));
+    assert_eq!(describe.collisions[0].installs_as, "deploy-acme");
+    assert!(
+        describe.collisions[0].existing.ends_with("skills/deploy"),
+        "{}",
+        describe.collisions[0].existing
+    );
+    assert!(describe.adoptions.is_empty(), "different bytes never adopt");
+    assert_eq!(next_argvs.len(), 1, "one apply argv, no collision variant");
+    assert!(
+        next_argvs[0].iter().all(|a| a != "--prefix-dirname"),
+        "{next_argvs:?}"
+    );
     // Nothing was mutated by the describe.
     assert!(log.lock().unwrap().iter().all(|e| !e.starts_with("join")));
 }
@@ -764,6 +778,553 @@ fn a_direct_skill_follow_on_a_channel_delivered_skill_explains_why_it_is_not_red
     let note = describe.direct_follow_note.expect("the note is present");
     assert!(note.contains("already arrives via #eng"), "{note}");
     assert!(note.contains("keeps it"), "{note}");
+}
+
+// ---------------------------------------------------------------------------------------------
+// The dirname outcomes: a byte-identical occupant is ADOPTED in place; a genuine conflict
+// auto-namespaces `<skill>-<workspace>` (the ADDRESS slug, never the `w_…` id); an unknown slug
+// falls back to the validated skill id.
+// ---------------------------------------------------------------------------------------------
+
+/// A transport whose delivery carries `s_deploy` at a REAL version (the engine re-verifies bytes).
+fn transport_with_deploy(log: CallLog) -> (FakeTransport, Version) {
+    let v = mk_version(&[("SKILL.md", FileMode::Regular, b"# deploy\n")]);
+    let mut transport = FakeTransport::empty(log);
+    transport.snapshot.skills.push(DeliverySkill {
+        skill_id: "s_deploy".into(),
+        name: "deploy".into(),
+        review_required: false,
+        version_id: v.id,
+        generation: 1,
+        bundle_digest: v.digest,
+        via_channels: vec!["eng".into()],
+        via_direct: false,
+    });
+    transport
+        .versions
+        .insert("s_deploy".into(), v.fetched.clone());
+    (transport, v)
+}
+
+#[test]
+fn a_byte_identical_occupant_is_adopted_in_place_never_duplicated() {
+    let rig = Rig::new("adopt");
+    rig.seed_enrolled();
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeAddressEnroll {
+        api_base: API.to_owned(),
+        log: log.clone(),
+    };
+    let directory = FakeDirectory::acme(log.clone());
+    let (transport, v) = transport_with_deploy(log.clone());
+
+    // An UNTRACKED byte-identical copy already sits at the by-name dir (e.g. hand-installed from
+    // the same source) — the untracked-occupant policy is identical to a tracked one's.
+    let occupant = rig.work.0.join("skills").join("deploy");
+    std::fs::create_dir_all(&occupant).unwrap();
+    std::fs::write(occupant.join("SKILL.md"), b"# deploy\n").unwrap();
+
+    // The workspace describe discloses the ADOPTION — no collision, no namespaced sibling.
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described { describe, .. } = out else {
+        panic!("bare = describe");
+    };
+    assert_eq!(describe.adoptions.len(), 1, "{:?}", describe.adoptions);
+    assert_eq!(describe.adoptions[0].name, "deploy");
+    assert!(
+        describe.adoptions[0].path.ends_with("skills/deploy"),
+        "{}",
+        describe.adoptions[0].path
+    );
+    assert!(
+        describe.collisions.is_empty(),
+        "identical bytes are an adoption, never a collision: {:?}",
+        describe.collisions
+    );
+
+    // `--yes` manages THAT dir: no `deploy-acme` sibling, the recorded placement IS the adopted
+    // dir, and the sync landed applied over the occupant's (identical) bytes.
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(true),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Applied(applied) = out else {
+        panic!("--yes = apply");
+    };
+    assert_eq!(
+        applied
+            .installed
+            .iter()
+            .map(|i| i.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["deploy"]
+    );
+    assert!(
+        !rig.work.0.join("skills").join("deploy-acme").exists(),
+        "never a second copy beside an identical occupant"
+    );
+    assert_eq!(
+        std::fs::read(occupant.join("SKILL.md")).unwrap(),
+        b"# deploy\n"
+    );
+    let sid = crate::id::SkillId::parse("s_deploy").unwrap();
+    let map = crate::doc::read_map(&rig.fs, &rig.layout().published(&sid).map)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        map.placements,
+        vec![occupant.to_string_lossy().into_owned()],
+        "the adopted dir IS the placement"
+    );
+    assert_eq!(
+        map.placement_state[0].materialized_sha.as_deref(),
+        Some(topos_core::digest::to_hex(&v.digest).as_str()),
+        "the apply advanced over the adopted dir"
+    );
+}
+
+#[test]
+fn a_conflicting_occupant_auto_namespaces_by_the_address_slug_and_stays_untouched() {
+    let rig = Rig::new("conflict");
+    rig.seed_enrolled();
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeAddressEnroll {
+        api_base: API.to_owned(),
+        log: log.clone(),
+    };
+    let directory = FakeDirectory::acme(log.clone());
+    let (transport, v) = transport_with_deploy(log.clone());
+
+    // An UNTRACKED occupant with DIFFERENT bytes holds the by-name dir.
+    let occupant = rig.work.0.join("skills").join("deploy");
+    std::fs::create_dir_all(&occupant).unwrap();
+    std::fs::write(occupant.join("SKILL.md"), b"# mine\n").unwrap();
+
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described { describe, .. } = out else {
+        panic!("bare = describe");
+    };
+    assert_eq!(describe.collisions.len(), 1, "{:?}", describe.collisions);
+    assert_eq!(describe.collisions[0].installs_as, "deploy-acme");
+    assert!(describe.adoptions.is_empty(), "{:?}", describe.adoptions);
+
+    // `--yes`: the namespaced dir lands the incoming bytes; the occupant is byte-untouched; the
+    // suffix is the workspace's ADDRESS slug — a `w_…` id never reaches a dir name.
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(true),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Applied(applied) = out else {
+        panic!("--yes = apply");
+    };
+    assert_eq!(
+        applied
+            .installed
+            .iter()
+            .map(|i| i.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["deploy"]
+    );
+    let namespaced = rig.work.0.join("skills").join("deploy-acme");
+    assert_eq!(
+        std::fs::read(namespaced.join("SKILL.md")).unwrap(),
+        b"# deploy\n"
+    );
+    assert_eq!(
+        std::fs::read(occupant.join("SKILL.md")).unwrap(),
+        b"# mine\n",
+        "the occupant is never written"
+    );
+    for entry in std::fs::read_dir(rig.work.0.join("skills")).unwrap() {
+        let name = entry.unwrap().file_name().to_string_lossy().into_owned();
+        assert!(
+            !name.starts_with("w_"),
+            "a workspace ID must never reach a dir name: {name}"
+        );
+    }
+    let sid = crate::id::SkillId::parse("s_deploy").unwrap();
+    let map = crate::doc::read_map(&rig.fs, &rig.layout().published(&sid).map)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        map.placements,
+        vec![namespaced.to_string_lossy().into_owned()]
+    );
+    let _ = v;
+}
+
+#[test]
+fn an_unknown_membership_slug_falls_back_to_the_skill_id_never_the_workspace_id() {
+    // Enrolled shape WITHOUT a membership record (instance + credential only): the delivered
+    // workspace's ADDRESS slug is unknowable, so a colliding dirname skips the namespace attempt
+    // and lands under the validated skill id.
+    let rig = Rig::new("slug-fallback");
+    enroll::write_instance(
+        &rig.fs,
+        &rig.layout(),
+        &enroll::Instance {
+            schema_version: 1,
+            base_url: API.to_owned(),
+        },
+    )
+    .unwrap();
+    enroll::write_credentials(&rig.fs, &rig.layout(), "wsc_secret", "dev_1").unwrap();
+    crate::identity::load_or_create_device_id(&rig.fs, &rig.layout()).unwrap();
+    let log: CallLog = Arc::default();
+    let (transport, _v) = transport_with_deploy(log.clone());
+    let occupant = rig.work.0.join("skills").join("deploy");
+    std::fs::create_dir_all(&occupant).unwrap();
+    std::fs::write(occupant.join("SKILL.md"), b"# mine\n").unwrap();
+
+    let inert_f = InertFollow;
+    // The transport doubles as ctx.plane so the accepted first receive can fetch its bytes.
+    let ctx = rig.ctx(&transport, &inert_f);
+    let out = ops::pull_reconcile_with(
+        &ctx,
+        &transport,
+        &ops::ReconcileOpts {
+            accept_first_receive: true,
+            ..ops::ReconcileOpts::default()
+        },
+    )
+    .unwrap();
+    assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    let id_dir = rig.work.0.join("skills").join("s_deploy");
+    assert_eq!(
+        std::fs::read(id_dir.join("SKILL.md")).unwrap(),
+        b"# deploy\n",
+        "the fallback dirname is the validated skill id"
+    );
+    assert!(
+        !rig.work.0.join("skills").join("deploy-acme").exists()
+            && !rig.work.0.join("skills").join("w_acme-deploy").exists()
+            && !rig.work.0.join("skills").join("deploy-w_acme").exists(),
+        "no namespace attempt without a membership slug"
+    );
+    assert_eq!(
+        std::fs::read(occupant.join("SKILL.md")).unwrap(),
+        b"# mine\n"
+    );
+}
+
+#[test]
+fn a_moved_target_lapses_the_adoption_and_the_accept_lands_namespaced() {
+    // The adoption reservation was laid for version A (the sweep's offer); the served current
+    // moves to B before the accept. The A-recorded adoption must not be reused for B — the engine
+    // clears the lapsed record, re-plans, and lands B under the suffixed dir in the SAME
+    // invocation: the occupant stays byte-untouched and nothing wedges.
+    let rig = Rig::new("adopt-lapse");
+    rig.seed_enrolled();
+    crate::identity::load_or_create_device_id(&rig.fs, &rig.layout()).unwrap();
+    let log: CallLog = Arc::default();
+    let v_a = mk_version(&[("SKILL.md", FileMode::Regular, b"# deploy v1\n")]);
+    let v_b = mk_version(&[("SKILL.md", FileMode::Regular, b"# deploy v2\n")]);
+    let mut transport = FakeTransport::empty(log.clone());
+    transport.snapshot.skills.push(DeliverySkill {
+        skill_id: "s_deploy".into(),
+        name: "deploy".into(),
+        review_required: false,
+        version_id: v_a.id,
+        generation: 1,
+        bundle_digest: v_a.digest,
+        via_channels: vec!["eng".into()],
+        via_direct: false,
+    });
+    transport
+        .versions
+        .insert("s_deploy".into(), v_a.fetched.clone());
+
+    // An UNTRACKED occupant byte-identical to VERSION A sits at the by-name dir.
+    let occupant = rig.work.0.join("skills").join("deploy");
+    std::fs::create_dir_all(&occupant).unwrap();
+    std::fs::write(occupant.join("SKILL.md"), b"# deploy v1\n").unwrap();
+
+    // The bare sweep lays the baseline + the A-adoption and OFFERS (no bytes move).
+    let inert_f = InertFollow;
+    {
+        let ctx = rig.ctx(&transport, &inert_f);
+        ops::pull_reconcile_with(&ctx, &transport, &ops::ReconcileOpts::default()).unwrap();
+    }
+    let sid = crate::id::SkillId::parse("s_deploy").unwrap();
+    let map = crate::doc::read_map(&rig.fs, &rig.layout().published(&sid).map)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        map.placement_state[0].pre_existing_sha.as_deref(),
+        Some(topos_core::digest::to_hex(&v_a.digest).as_str()),
+        "the sweep recorded the A-adoption"
+    );
+
+    // The served current MOVES to B before any accept.
+    let mut transport_b = transport.clone();
+    transport_b.snapshot.skills[0].version_id = v_b.id;
+    transport_b.snapshot.skills[0].bundle_digest = v_b.digest;
+    transport_b.snapshot.skills[0].generation = 2;
+    transport_b
+        .versions
+        .insert("s_deploy".into(), v_b.fetched.clone());
+
+    // ONE accept: B lands under the suffixed dir; the occupant untouched; no wedge, no retry.
+    let follows = enroll::read_follows(&rig.fs, &rig.layout())
+        .unwrap()
+        .unwrap();
+    let seam = crate::plane_http::FileFollow::new(enroll::follow_contexts(&follows));
+    let ctx = rig.ctx(&transport_b, &seam);
+    let out = ops::pull_reconcile_with(
+        &ctx,
+        &transport_b,
+        &ops::ReconcileOpts {
+            accept_first_receive: true,
+            ..ops::ReconcileOpts::default()
+        },
+    )
+    .unwrap();
+    assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    assert!(
+        matches!(out.data.skills[0].action, PullAction::FastForwarded),
+        "{:?}",
+        out.data.skills[0].action
+    );
+    assert_eq!(
+        std::fs::read(occupant.join("SKILL.md")).unwrap(),
+        b"# deploy v1\n",
+        "the raced occupant is never written"
+    );
+    let namespaced = rig.work.0.join("skills").join("deploy-acme");
+    assert_eq!(
+        std::fs::read(namespaced.join("SKILL.md")).unwrap(),
+        b"# deploy v2\n"
+    );
+    let map = crate::doc::read_map(&rig.fs, &rig.layout().published(&sid).map)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        map.placements,
+        vec![namespaced.to_string_lossy().into_owned()],
+        "the lapsed reservation was swapped for the suffixed dir"
+    );
+}
+
+#[test]
+fn a_dir_recorded_by_another_skill_is_never_adopted_even_when_identical() {
+    // The strongest confusion case: ANOTHER tracked skill already owns the by-name dir with bytes
+    // IDENTICAL to the incoming version. Adoption must refuse (two records must never own one
+    // dir) — the plan suffixes instead, and each record keeps exactly its own dir.
+    let rig = Rig::new("adopt-owned");
+    rig.seed_enrolled();
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeAddressEnroll {
+        api_base: API.to_owned(),
+        log: log.clone(),
+    };
+    let directory = FakeDirectory::acme(log.clone());
+    let (transport, _v) = transport_with_deploy(log.clone());
+
+    let owned = rig.work.0.join("skills").join("deploy");
+    std::fs::create_dir_all(&owned).unwrap();
+    std::fs::write(owned.join("SKILL.md"), b"# deploy\n").unwrap(); // identical to the incoming
+    let other_id = {
+        let inert_p = InertPlane;
+        let inert_f = InertFollow;
+        let ctx = rig.ctx(&inert_p, &inert_f);
+        ops::add_with_name(&ctx, &owned, Some("deploy"))
+            .unwrap()
+            .skill_id
+    };
+
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described { describe, .. } = out else {
+        panic!("bare = describe");
+    };
+    assert!(
+        describe.adoptions.is_empty(),
+        "another record's dir is never adopted: {:?}",
+        describe.adoptions
+    );
+    assert_eq!(describe.collisions.len(), 1);
+    assert_eq!(describe.collisions[0].installs_as, "deploy-acme");
+
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(true),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Applied(applied) = out else {
+        panic!("--yes = apply");
+    };
+    assert_eq!(
+        applied
+            .installed
+            .iter()
+            .map(|i| i.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["deploy"]
+    );
+    let namespaced = rig.work.0.join("skills").join("deploy-acme");
+    assert_eq!(
+        std::fs::read(namespaced.join("SKILL.md")).unwrap(),
+        b"# deploy\n"
+    );
+    // Each record owns exactly its own dir.
+    let sid = crate::id::SkillId::parse("s_deploy").unwrap();
+    let map = crate::doc::read_map(&rig.fs, &rig.layout().published(&sid).map)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        map.placements,
+        vec![namespaced.to_string_lossy().into_owned()]
+    );
+    let other_sid = crate::id::SkillId::parse(&other_id).unwrap();
+    let other_map = crate::doc::read_map(&rig.fs, &rig.layout().published(&other_sid).map)
+        .unwrap()
+        .unwrap();
+    // The record stores the CANONICALIZED adopt source (macOS temp roots are symlinked).
+    assert_eq!(
+        other_map.placements,
+        vec![owned.canonicalize().unwrap().to_string_lossy().into_owned()],
+        "the other skill's record is untouched"
+    );
+}
+
+#[test]
+fn a_deleted_dir_recorded_by_another_skill_stays_reserved() {
+    // Skill A's record owns the by-name dir but the dir was manually DELETED: the free-LOOKING
+    // path must stay A's — a same-named arrival lands suffixed (never claims it), and A's later
+    // converge re-lands A's bytes there without touching the arrival's dir.
+    let rig = Rig::new("recorded-free");
+    rig.seed_enrolled();
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeAddressEnroll {
+        api_base: API.to_owned(),
+        log: log.clone(),
+    };
+    let directory = FakeDirectory::acme(log.clone());
+    let (transport, _v) = transport_with_deploy(log.clone());
+
+    // Skill A: tracked at the by-name dir; then its dir is deleted on disk.
+    let owned = rig.work.0.join("skills").join("deploy");
+    std::fs::create_dir_all(&owned).unwrap();
+    std::fs::write(owned.join("SKILL.md"), b"# A's deploy\n").unwrap();
+    let a_id = {
+        let inert_p = InertPlane;
+        let inert_f = InertFollow;
+        let ctx = rig.ctx(&inert_p, &inert_f);
+        ops::add_with_name(&ctx, &owned, Some("deploy"))
+            .unwrap()
+            .skill_id
+    };
+    std::fs::remove_dir_all(&owned).unwrap();
+
+    // The arrival's `--yes` lands under the suffix — the deleted dir is still A's.
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(true),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Applied(applied) = out else {
+        panic!("--yes = apply");
+    };
+    assert_eq!(
+        applied
+            .installed
+            .iter()
+            .map(|i| i.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["deploy"]
+    );
+    let namespaced = rig.work.0.join("skills").join("deploy-acme");
+    assert_eq!(
+        std::fs::read(namespaced.join("SKILL.md")).unwrap(),
+        b"# deploy\n"
+    );
+    assert!(!owned.exists(), "the reserved path is never claimed");
+    let sid = crate::id::SkillId::parse("s_deploy").unwrap();
+    let map = crate::doc::read_map(&rig.fs, &rig.layout().published(&sid).map)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        map.placements,
+        vec![namespaced.to_string_lossy().into_owned()]
+    );
+
+    // A's record is untouched; its converge re-lands A's bytes at the reserved path without
+    // touching the arrival's dir.
+    let a_sid = crate::id::SkillId::parse(&a_id).unwrap();
+    let a_lock: topos_types::persisted::Lock =
+        crate::doc::read_doc(&rig.fs, &rig.layout().published(&a_sid).lock)
+            .unwrap()
+            .unwrap();
+    {
+        let inert_p = InertPlane;
+        let inert_f = InertFollow;
+        let ctx = rig.ctx(&inert_p, &inert_f);
+        ops::apply_scope_change(
+            &ctx,
+            &a_sid,
+            &a_lock,
+            crate::placement::AgentScope::default(),
+        )
+        .unwrap();
+    }
+    assert_eq!(
+        std::fs::read(owned.join("SKILL.md")).unwrap(),
+        b"# A's deploy\n",
+        "A's bytes re-land at A's recorded dir"
+    );
+    assert_eq!(
+        std::fs::read(namespaced.join("SKILL.md")).unwrap(),
+        b"# deploy\n",
+        "the arrival's dir is untouched"
+    );
+    let a_map = crate::doc::read_map(&rig.fs, &rig.layout().published(&a_sid).map)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        a_map.placements,
+        vec![owned.canonicalize().unwrap().to_string_lossy().into_owned()]
+    );
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -1115,6 +1676,203 @@ fn a_workspace_yes_still_lands_the_whole_delivered_set() {
     );
     assert!(rig.work.0.join("skills").join("deploy").exists());
     assert!(rig.work.0.join("skills").join("extra").exists());
+}
+
+// ---------------------------------------------------------------------------------------------
+// The standing no-op receipt + the enrolled receipt: a describe that would change nothing offers
+// no apply argv (the standing note carries the fact); an enrolling describe names the principal
+// and never claims "nothing has changed".
+// ---------------------------------------------------------------------------------------------
+
+#[test]
+fn a_standing_follow_with_nothing_new_offers_no_apply_argv() {
+    let rig = Rig::new("standing");
+    rig.seed_enrolled();
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeAddressEnroll {
+        api_base: API.to_owned(),
+        log: log.clone(),
+    };
+    // An extra channel with NO skills: `design` is already a member (no new row), `ops` is not
+    // (a join row would be new even with nothing to install).
+    let mut directory = FakeDirectory::acme(log.clone());
+    directory
+        .channels
+        .push(channel_entry("ops", false, false, &[]));
+    let transport = FakeTransport::empty(log.clone());
+
+    // The workspace target: no installs, no new rows → the standing note, no `--yes` offered.
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described {
+        describe,
+        next_argvs,
+    } = out
+    else {
+        panic!("bare = describe");
+    };
+    assert!(next_argvs.is_empty(), "{next_argvs:?}");
+    let note = describe.standing_note.as_deref().expect("standing note");
+    assert!(note.starts_with("nothing new to install"), "{note}");
+    assert!(
+        note.contains("every device you've linked to this workspace"),
+        "{note}"
+    );
+    // The TTY carries the standing fact and neither the classic no-change line nor an argv.
+    let text = crate::render::follow_describe_tty(&describe, &next_argvs);
+    assert!(text.contains("nothing new to install"), "{text}");
+    assert!(!text.contains("Nothing has changed yet"), "{text}");
+    assert!(!text.contains("--yes"), "{text}");
+    assert!(
+        crate::render::describe_next_actions(Vec::new()).is_empty(),
+        "an empty argv list yields no next actions"
+    );
+
+    // An ALREADY-MEMBER channel target with nothing to install: same suppression.
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme/channels/design".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described {
+        describe,
+        next_argvs,
+    } = out
+    else {
+        panic!("bare = describe");
+    };
+    assert!(next_argvs.is_empty(), "{next_argvs:?}");
+    assert!(describe.standing_note.is_some());
+
+    // A NOT-YET-JOINED channel writes a row even with nothing to install → the argv is offered.
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme/channels/ops".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described {
+        describe,
+        next_argvs,
+    } = out
+    else {
+        panic!("bare = describe");
+    };
+    assert_eq!(next_argvs.len(), 1, "{next_argvs:?}");
+    assert!(describe.standing_note.is_none());
+}
+
+#[test]
+fn the_enrolled_receipt_names_the_principal_and_never_claims_nothing_changed() {
+    // The two-call enroll against an EMPTY delivery: the receipt leads with WHO this device now
+    // acts as, and folds the standing fact into the Following line.
+    let rig = Rig::new("enroll-receipt");
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeAddressEnroll {
+        api_base: API.to_owned(),
+        log: log.clone(),
+    };
+    let directory = FakeDirectory::acme(log.clone());
+    let transport = FakeTransport::empty(log.clone());
+    run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        Vec::new(),
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described {
+        describe,
+        next_argvs,
+    } = out
+    else {
+        panic!("resume lands on the describe");
+    };
+    assert!(describe.enrolled_now);
+    let text = crate::render::follow_describe_tty(&describe, &next_argvs);
+    assert!(
+        text.contains(
+            "Enrolled this device as alice@acme.com — role: member — invited by robert@acme.com."
+        ),
+        "{text}"
+    );
+    assert!(
+        text.contains(
+            "Following: workspace acme — nothing new to install; new team skills arrive \
+             automatically on every device you've linked to this workspace."
+        ),
+        "{text}"
+    );
+    assert!(!text.contains("Your role:"), "{text}");
+    assert!(
+        !text.contains("Nothing has changed yet"),
+        "the enrollment persisted a credential and armed the trigger: {text}"
+    );
+
+    // With an install waiting, the enrolled describe offers the apply under the honest heading.
+    let rig = Rig::new("enroll-receipt-installs");
+    let log: CallLog = Arc::default();
+    let enroll_fake = FakeAddressEnroll {
+        api_base: API.to_owned(),
+        log: log.clone(),
+    };
+    let directory = FakeDirectory::acme(log.clone());
+    let (transport, _v) = transport_with_deploy(log.clone());
+    run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        vec!["acme".to_owned()],
+        opts(false),
+    )
+    .unwrap();
+    let out = run_follow(
+        &rig,
+        &enroll_fake,
+        &directory,
+        &transport,
+        Vec::new(),
+        opts(false),
+    )
+    .unwrap();
+    let ops::FollowOutcome::Described {
+        describe,
+        next_argvs,
+    } = out
+    else {
+        panic!("resume lands on the describe");
+    };
+    assert!(describe.enrolled_now && describe.standing_note.is_none());
+    assert_eq!(next_argvs.len(), 1);
+    let text = crate::render::follow_describe_tty(&describe, &next_argvs);
+    assert!(text.contains("Apply the follow with:"), "{text}");
+    assert!(!text.contains("Nothing has changed yet"), "{text}");
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/bins/topos/src/tests/verbs.rs
+++ b/bins/topos/src/tests/verbs.rs
@@ -1428,7 +1428,6 @@ fn follow_approve_resumes_an_unfollowed_skill() {
             manual: false,
             workspace: None,
             yes: false,
-            prefix_dirname: false,
             channels: Vec::new(),
             skills: Vec::new(),
             agents: Vec::new(),

--- a/crates/topos-harness/CLAUDE.md
+++ b/crates/topos-harness/CLAUDE.md
@@ -12,7 +12,7 @@ scheduler probe — health is never claimed on faith, and the footprint stays a 
 **Implemented:** the **Claude Code** reference adapter (`claude_code`) — `discover` (probe
 `~/.claude/skills/*/SKILL.md`, confirm by existence, never parse frontmatter), `placement_for` (a pure
 follower's first receive names the folder by the skill's **sanitized display name** — Claude Code invokes a
-skill by its folder name — namespacing by workspace on a name collision and falling back to the validated
+skill by its folder name — namespacing by the workspace slug on a name collision (`<skill>-<workspace>`) and falling back to the validated
 id; the display name + workspace slug are UNTRUSTED and routed through `sanitize_skill_dir` to one safe path
 component, so they can never redirect the placement), `currency_kind` = `SessionStart`, and the idempotent,
 content-blind `install_currency_trigger` /
@@ -88,7 +88,7 @@ github-copilot / goose / opencode `Docs(true)` from vendor docs) over the automa
 registry row whose USER dir is the literal home `.agents/skills` ⇒ `Docs(true)`, staying in sync
 with registry re-syncs). The registry additionally exposes `detected_harnesses(home, cwd)` (the rows
 whose detect dirs exist) and the crate exports `choose_skill_dir` — the ONE placement-naming
-discipline (sanitized display name → workspace-prefixed on collision → the validated id; only a FREE
+discipline (sanitized display name → workspace-suffixed on collision (`<skill>-<workspace>`) → the validated id; only a FREE
 dir or one the caller's own record owns), factored out of the Claude Code adapter so registry-target
 dirs name identically. The dir name `topos` (`RESERVED_SKILL_DIR`) is reserved for the CLI's
 BUILT-IN skill (the one skill whose id equals it): any other skill folding to that name

--- a/crates/topos-harness/src/claude_code.rs
+++ b/crates/topos-harness/src/claude_code.rs
@@ -107,7 +107,13 @@ impl<'a> ClaudeCode<'a> {
     /// [`crate::choose_skill_dir`] (this adapter is the reference; other placement targets name
     /// identically); with no placement record to consult here, only a FREE dir counts as available.
     fn follower_placement_dir(&self, skill_id: &str, naming: PlacementNaming<'_>) -> PathBuf {
-        crate::choose_skill_dir(&self.skills_dir(), skill_id, naming, &|_| false)
+        crate::choose_skill_dir(
+            &self.skills_dir(),
+            skill_id,
+            naming,
+            &crate::dir_taken,
+            &|_| false,
+        )
     }
 
     fn settings_path(&self) -> PathBuf {
@@ -1102,7 +1108,8 @@ mod tests {
         let cfg = MemConfig::default();
         let a = adapter(&home.0, &cfg);
 
-        // Collision on the plain name → namespaced by the (sanitized) workspace slug, never clobbering.
+        // Collision on the plain name → suffixed by the (sanitized) workspace slug — skill first, so
+        // the folder stays recognizable — never clobbering.
         let naming = PlacementNaming {
             name: Some("deploy-helper"),
             workspace_slug: Some("robert's workspace"),
@@ -1111,15 +1118,65 @@ mod tests {
             a.placement_for("topos_abc", naming, None).dir,
             home.0
                 .join("skills")
-                .join("robert-s-workspace-deploy-helper"),
+                .join("deploy-helper-robert-s-workspace"),
         );
 
         // Now the namespaced form is taken too → the globally-unique id is the ultimate safe fallback.
-        home.skill("robert-s-workspace-deploy-helper");
+        home.skill("deploy-helper-robert-s-workspace");
         assert_eq!(
             a.placement_for("topos_abc", naming, None).dir,
             home.0.join("skills").join("topos_abc"),
             "when every named candidate is taken, the unique id never collides",
+        );
+    }
+
+    #[test]
+    fn an_occupied_id_dir_namespaces_by_workspace_before_the_bare_id_residual() {
+        let home = TempHome::new();
+        home.skill("deploy-helper"); // the plain name is taken…
+        home.skill("deploy-helper-acme"); // …and its workspace form…
+        home.skill("topos_abc"); // …and even the id dir.
+        let cfg = MemConfig::default();
+        let a = adapter(&home.0, &cfg);
+        let naming = PlacementNaming {
+            name: Some("deploy-helper"),
+            workspace_slug: Some("acme"),
+        };
+        assert_eq!(
+            a.placement_for("topos_abc", naming, None).dir,
+            home.0.join("skills").join("topos_abc-acme"),
+            "an occupied id dir disambiguates by the workspace before giving up"
+        );
+
+        // Every rung occupied → the bare id is returned; the CLI's materializer refuses to
+        // overwrite an occupied dir it never placed, so this names but never clobbers.
+        home.skill("topos_abc-acme");
+        assert_eq!(
+            a.placement_for("topos_abc", naming, None).dir,
+            home.0.join("skills").join("topos_abc"),
+        );
+    }
+
+    #[test]
+    fn a_dangling_symlink_counts_as_occupied_and_the_ladder_moves_on() {
+        // `Path::exists()` traverses symlinks, so a DANGLING link would read as "free" and the
+        // materializer would then refuse the unresolvable entry — occupancy is lstat-based, and
+        // the ladder namespaces past it instead.
+        let home = TempHome::new();
+        let skills = home.0.join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        std::os::unix::fs::symlink(skills.join("gone-target"), skills.join("deploy-helper"))
+            .unwrap();
+        let cfg = MemConfig::default();
+        let a = adapter(&home.0, &cfg);
+        let naming = PlacementNaming {
+            name: Some("deploy-helper"),
+            workspace_slug: Some("acme"),
+        };
+        assert_eq!(
+            a.placement_for("topos_abc", naming, None).dir,
+            home.0.join("skills").join("deploy-helper-acme"),
+            "a dangling link at the by-name rung is occupied — the ladder suffixes past it"
         );
     }
 

--- a/crates/topos-harness/src/lib.rs
+++ b/crates/topos-harness/src/lib.rs
@@ -85,46 +85,76 @@ pub fn sanitize_skill_dir(raw: &str) -> Option<String> {
 /// The dir name reserved for the CLI's BUILT-IN skill (whose skill id IS this name). No other
 /// skill may name its placement dir `topos` — even a free dir — so the built-in can never be
 /// shadowed or clobbered by a workspace skill; a colliding display name disambiguates exactly like
-/// an occupied-dir collision (workspace prefix, then the id).
+/// an occupied-dir collision (workspace suffix, then the id).
 pub const RESERVED_SKILL_DIR: &str = "topos";
+
+/// The DEFAULT taken-probe for [`choose_skill_dir`]: lstat-based occupancy. A DANGLING symlink is a
+/// real filesystem entry a placement cannot claim, but `Path::exists()` traverses it and reads
+/// "free" — the ladder must move past it. Callers with richer knowledge (the CLI knows which paths
+/// its sidecar records) compose this into their own probe.
+#[must_use]
+pub fn dir_taken(p: &Path) -> bool {
+    std::fs::symlink_metadata(p).is_ok()
+}
 
 /// Choose the directory a skill's bytes land in under `skills_root` — the ONE naming discipline every
 /// placement target follows (the reference adapter's, factored out so registry-resolved dirs name
 /// identically): prefer the skill's **sanitized display name** (agents invoke a skill by its folder
 /// name); on a collision with a dir that is neither FREE nor this skill's own recorded placement,
-/// disambiguate by the sanitized workspace slug (`<ws>-<name>`); fall back to the validated,
-/// globally-unique `skill_id`. A foreign dir is NEVER a valid target — only a free dir, or one
-/// `is_owned` answers `true` for (the caller's own placement record), is ever chosen, so a placement
-/// can never clobber another skill's (or the user's) directory. The name [`RESERVED_SKILL_DIR`] is
-/// additionally reserved for the built-in skill (the one skill whose ID equals it).
+/// disambiguate by suffixing the sanitized workspace slug (`<name>-<ws>` — the skill stays the
+/// leading, recognizable part); then the validated, globally-unique `skill_id`; then `<skill_id>-<ws>`
+/// when even the id dir is taken. What "taken" means is the CALLER'S probe (`is_taken` — the default
+/// is the lstat-based [`dir_taken`]; the CLI enriches it with its own record knowledge, so a path
+/// reserved elsewhere counts as taken even when absent on disk). A foreign dir is NEVER a valid
+/// target — only a non-taken dir, or one `is_owned` answers `true` for (the caller's own placement
+/// record), is ever chosen, so a placement can never clobber another skill's (or the user's)
+/// directory. The one residual: with EVERY rung taken (astronomically unlikely — four distinct
+/// foreign dirs shadowing one skill), the bare id is still returned; the CLI's materializer refuses
+/// to overwrite an occupied dir it never placed, so even that names but never clobbers. The name
+/// [`RESERVED_SKILL_DIR`] is additionally reserved for the built-in skill (the one skill whose ID
+/// equals it).
 ///
 /// `naming`'s strings are UNTRUSTED and are sanitized to a single safe path component before any join;
-/// `skill_id` must be an already-validated single component (the trait-wide id contract).
+/// `skill_id` must be an already-validated single component (the trait-wide id contract). The crate
+/// stays content-blind: it receives predicates, never bytes or sidecar state.
 #[must_use]
 pub fn choose_skill_dir(
     skills_root: &Path,
     skill_id: &str,
     naming: PlacementNaming<'_>,
+    is_taken: &dyn Fn(&Path) -> bool,
     is_owned: &dyn Fn(&Path) -> bool,
 ) -> PathBuf {
     if let Some(name) = naming.name.and_then(sanitize_skill_dir) {
         let reserved = name == RESERVED_SKILL_DIR && skill_id != RESERVED_SKILL_DIR;
         let by_name = skills_root.join(&name);
-        if !reserved && (!by_name.exists() || is_owned(&by_name)) {
+        if !reserved && (!is_taken(&by_name) || is_owned(&by_name)) {
             return by_name;
         }
         // Collision: a different skill (or the user's own dir) already holds this name. Namespace by
         // the workspace so the two coexist (both parts are already sanitized single components).
         if let Some(ws) = naming.workspace_slug.and_then(sanitize_skill_dir) {
-            let namespaced = skills_root.join(format!("{ws}-{name}"));
-            if !namespaced.exists() || is_owned(&namespaced) {
+            let namespaced = skills_root.join(format!("{name}-{ws}"));
+            if !is_taken(&namespaced) || is_owned(&namespaced) {
                 return namespaced;
             }
         }
     }
-    // Unnamed / unsafe name / every candidate taken → the unique id (a validated single component
-    // that can never collide with another skill).
-    skills_root.join(skill_id)
+    // Unnamed / unsafe name / every named candidate taken → the unique id (a validated single
+    // component that can never collide with another SKILL — but the dir itself may still be
+    // taken by something the record does not own, so it gets the same taken-or-owned check and
+    // one more workspace disambiguation before the bare-id residual above applies).
+    let by_id = skills_root.join(skill_id);
+    if !is_taken(&by_id) || is_owned(&by_id) {
+        return by_id;
+    }
+    if let Some(ws) = naming.workspace_slug.and_then(sanitize_skill_dir) {
+        let namespaced = skills_root.join(format!("{skill_id}-{ws}"));
+        if !is_taken(&namespaced) || is_owned(&namespaced) {
+            return namespaced;
+        }
+    }
+    by_id
 }
 
 /// The narrow filesystem port an adapter needs to read + atomically replace a harness **config** file

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,6 @@ Follow a workspace, channel, or skill — enroll if needed, then subscribe two-p
 | `--skill` | `<NAME>` |  | Follow a specific skill by name (repeatable; kind-forced) |
 | `--agent` | `<SLUG>` |  | Scope a followed skill's placement to these agents on THIS device (registry slugs; repeatable; `'*'` clears the list back to unscoped). Placement policy only — the subscription is untouched and the server is never told. Two-phase: bare describes the placement plan; `--yes` applies |
 | `--yes` |  |  | Apply the described subscription (the one-shot consent). Bare = describe only |
-| `--prefix-dirname` |  |  | Install a dirname-colliding skill under `<workspace>.<name>` instead of declining it |
 | `--manual` |  |  | Adopt followed skills in confirm-each mode (a one-tap accept per new version) instead of auto |
 | `--wait` | `<SECONDS>` |  | Block until the browser approval settles, finishing enrollment in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. Put `--wait` AFTER any positional. A TTY blocks by default; a PIPED run without `--wait` prints the approval URL and returns immediately — re-invoke `follow` to poll, or pass `--wait` to block |
 

--- a/skills/topos/reference.md
+++ b/skills/topos/reference.md
@@ -43,7 +43,6 @@ Follow a workspace, channel, or skill — enroll if needed, then subscribe two-p
 | `--skill` | `<NAME>` |  | Follow a specific skill by name (repeatable; kind-forced) |
 | `--agent` | `<SLUG>` |  | Scope a followed skill's placement to these agents on THIS device (registry slugs; repeatable; `'*'` clears the list back to unscoped). Placement policy only — the subscription is untouched and the server is never told. Two-phase: bare describes the placement plan; `--yes` applies |
 | `--yes` |  |  | Apply the described subscription (the one-shot consent). Bare = describe only |
-| `--prefix-dirname` |  |  | Install a dirname-colliding skill under `<workspace>.<name>` instead of declining it |
 | `--manual` |  |  | Adopt followed skills in confirm-each mode (a one-tap accept per new version) instead of auto |
 | `--wait` | `<SECONDS>` |  | Block until the browser approval settles, finishing enrollment in ONE command. Bare `--wait` waits until the code expires; `--wait <seconds>` caps the wait. Put `--wait` AFTER any positional. A TTY blocks by default; a PIPED run without `--wait` prints the approval URL and returns immediately — re-invoke `follow` to poll, or pass `--wait` to block |
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -73,8 +73,8 @@ in their crates; this directory is for what only a cross-crate composed run can 
   agent hand-off) and byte-identical across the address / the origin root / an unmatched path; call
   1 pends (user code + the `0600` WAL) → the signed-in member approves at `/verify` → the resumed
   follow persists the ONE `0600` bearer credential and continues into the two-phase DESCRIBE
-  (role, installs with consent digests, the `via everyone` attribution, the all-devices +
-  fleet-reporting disclosures) → `--yes` lands `everyone`'s genesis byte-exact. The TARGET-SCOPED
+  (role, installs with consent digests, the `via everyone` attribution, the all-devices
+  disclosure) → `--yes` lands `everyone`'s genesis byte-exact. The TARGET-SCOPED
   consent regression: with a waiting `everyone` arrival never received on the member's device, the
   targeted channel/skill describes list ONLY their named target's set and the targeted `--yes`
   lands exactly that (no subscription state, no bytes for the un-named arrival — no member

--- a/tests/tests/follow_e2e.rs
+++ b/tests/tests/follow_e2e.rs
@@ -168,13 +168,10 @@ fn e2e_real_follow_enrolls_describes_and_lands_the_first_skill() {
     );
     assert_eq!(install.via_channels, vec!["everyone".to_owned()]);
     assert!(!install.via_direct, "it arrives via the everyone channel");
-    assert!(
-        !describe.all_devices_note.is_empty(),
-        "the person-scoped disclosure"
-    );
-    assert!(
-        !describe.reporting_note.is_empty(),
-        "the fleet-reporting disclosure"
+    assert_eq!(
+        describe.all_devices_note,
+        "skills you follow arrive on every device you've linked to this workspace",
+        "the person-scoped disclosure is link-accurate (and the fleet-reporting line is gone)"
     );
 
     // Call 3 — `topos follow <address> --yes`: the reconcile lands `everyone`'s set this invocation.


### PR DESCRIPTION
## What

**First-receive collision policy is now one disclosed rule.** When a skill's dirname is already taken on this machine:

- a **byte-identical** occupant is **adopted in place** (snapshot-first, disclosed in the describe as "Adopts in place:", consented by the ordinary `--yes`/offer-accept) — never a duplicate copy;
- a **genuinely different** occupant **auto-namespaces to `<skill>-<workspace>`** using the workspace **address slug** (never the opaque `w_…` id), disclosed in the describe before any consent;
- tracked and untracked occupants take the same policy; `--prefix-dirname` is **retired** (its behavior is the default now); the last-resort id fallback and the reserved `topos` dir are unchanged.

**The naming ladder got safety rails** (from review rounds): every rung consults an injected "taken" probe — a path recorded by another skill counts as taken even when deleted on disk; adoption reservations are version-aware (a moved `current` lapses them instead of wedging); the materializer gains a never-clobber backstop whose takeover consent is re-proven against the live dir; occupancy is lstat-based so dangling symlinks count.

**Follow/link receipts tell the truth, shorter.** The person-scoped note reads "skills you follow arrive on every device you've linked to this workspace" (identical at both describe sites); the fleet-reporting line is gone from both the TTY and the JSON payloads; an enrolled receipt names the principal and role instead of claiming nothing changed; an apply that would change nothing offers no `--yes` argv and states the standing fact instead.

Forward-only: no migration for existing installs; recorded placements keep their dirs.

## Testing

- `cargo xtask ci` — all 7 gates green (schemas/fixtures regenerated byte-identical; `docs/cli.md` + `skills/topos/reference.md` regenerated for the flag removal)
- Full workspace suite on the pinned Postgres image: **817 passed / 0 failed**, including the composed e2e suites (follow, hero, channels, claim, contribute, cross-workspace, device-links, invite-redemption, revocation)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- Four review rounds; final round clean; new regression tests cover adopt-in-place, auto-namespacing, slug-not-id fallback, reserved-dir survival, moved-target lapse, cross-skill ownership, takeover revalidation, and dangling-symlink occupancy

🤖 Generated with [Claude Code](https://claude.com/claude-code)