### PR TITLE
Handle SIGTERM in the vault so it can actually be stopped

### DIFF
--- a/bins/topos-plane/src/main.rs
+++ b/bins/topos-plane/src/main.rs
@@ -93,7 +93,44 @@ async fn main() -> Result<()> {
         .with_context(|| format!("binding {}", cfg.bind))?;
     tracing::info!(addr = %cfg.bind, "topos-plane listening");
     axum::serve(listener, router(state))
+        .with_graceful_shutdown(shutdown_signal())
         .await
         .context("serving the vault")?;
+    tracing::info!("topos-plane stopped");
     Ok(())
+}
+
+/// Resolves when the process is asked to stop, so `axum` can finish in-flight requests and return
+/// instead of being killed mid-response.
+///
+/// This matters more than it looks: a container runtime stops a container by sending SIGTERM and
+/// then waiting out a timeout before SIGKILL. The default disposition of SIGTERM terminates a
+/// process — but only for a process that is NOT PID 1, and this binary IS PID 1 in its image
+/// (`ENTRYPOINT ["topos-plane"]`, no init shim). PID 1 ignores every signal it has no handler
+/// for, so without this function the vault sits deaf through the entire stop timeout and is
+/// SIGKILLed — a fixed, pointless stall on every single restart, and an in-flight request dies
+/// with it. Installing the handler is what makes the process actually stoppable.
+async fn shutdown_signal() {
+    // Ctrl-C for an operator running this in a terminal; SIGTERM for every orchestrator.
+    let interrupt = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("installing the Ctrl-C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("installing the SIGTERM handler")
+            .recv()
+            .await;
+    };
+    // Non-unix hosts have no SIGTERM; Ctrl-C alone decides there.
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = interrupt => tracing::info!("interrupt received; draining in-flight requests"),
+        () = terminate => tracing::info!("SIGTERM received; draining in-flight requests"),
+    }
 }


### PR DESCRIPTION
`axum::serve` was awaited with no shutdown future, and the image's entrypoint is the binary itself — so the vault runs as **PID 1**.

PID 1 does not get the default signal dispositions: it ignores every signal it has installed no handler for. A container runtime stops a container by sending SIGTERM and waiting out a grace period before SIGKILL, so the vault sat deaf for the whole period and was killed — **every single restart**.

Measured against a real deploy: a fixed **30.3s** stall, about two thirds of the redeploy downtime, with any in-flight request dying at the end of it rather than being answered.

## The change

It now serves `with_graceful_shutdown`, waiting on SIGTERM (and Ctrl-C for an operator at a terminal), which lets axum stop accepting, finish what is in flight, and return.

- `tokio`'s `signal` feature was already enabled — no dependency change.
- Ctrl-C is the whole trigger on non-unix, where there is no SIGTERM.

The stall was never the vault being slow: it opens its listener **0.15s** after start. It was a process that could not hear the request to stop.

## Verified

`cargo fmt --check` clean · `cargo clippy -p topos-plane --all-targets -- -D warnings` clean · `cargo xtask ci` all 7 gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)