### PR TITLE
Never let a form look idle while it waits

### DIFF
--- a/web/app/app.css
+++ b/web/app/app.css
@@ -171,6 +171,18 @@ body {
   }
 }
 
+/* The in-flight look for a <BusyFields> group (components/ui.tsx). A Klein input paints its own
+   background and border, so the browser's default disabled rendering barely shows through — this
+   makes "on the wire, don't type here" legible. Scoped to fieldset:disabled so it can only ever
+   fire inside that wrapper, and deliberately NOT applied to buttons: the submit inside carries the
+   pending label, and it has to stay readable. */
+@layer base {
+  fieldset:disabled :is(input, textarea, select) {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
 /* ── Rendered markdown (server-sanitized GFM from lib/view/markdown) ──────────────────────────
    Compact README-style typography for the skill browser's doc preview + markdown file view.
    Klein tokens only — no new colors — and every rule scopes under .doc-prose so nothing leaks

--- a/web/app/components/members/invite-member-form.tsx
+++ b/web/app/components/members/invite-member-form.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useFetcher } from "react-router";
-import { buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses } from "@/components/ui";
 
 /** The members route's typed reply for `intent=invite`. */
 interface InviteActionData {
@@ -54,26 +54,30 @@ export function InviteMemberForm({ mailArmed, isOwner }: { mailArmed: boolean; i
 
   return (
     <div className="space-y-3">
-      <fetcher.Form ref={formRef} method="post" className="flex flex-wrap items-end gap-2">
+      <fetcher.Form ref={formRef} method="post">
         <input type="hidden" name="intent" value="invite" />
-        <label className="block flex-1">
-          <span className="mb-1 block font-medium text-sm text-dim">Invite by email</span>
-          <input
-            type="text"
-            name="emails"
-            required
-            autoComplete="off"
-            placeholder="teammate@company.com, another@company.com"
-            // The echoed submittedEmails (keyed, so the node remounts) keeps the typed addresses
-            // through a denial/error re-render.
-            key={state?.submittedEmails ?? "initial"}
-            defaultValue={state?.submittedEmails ?? ""}
-            className="block h-11 w-full min-w-56 rounded-md border border-line px-3 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
-          />
-        </label>
-        <button type="submit" disabled={pending} className={`${buttonClasses("quiet")} min-h-11`}>
-          {pending ? "Inviting…" : "Invite"}
-        </button>
+        {/* Inviting mints tokens and sends mail — an SMTP round-trip per address, so the wait is
+            real and the field goes inert with the button. */}
+        <BusyFields busy={pending} className="flex flex-wrap items-end gap-2">
+          <label className="block flex-1">
+            <span className="mb-1 block font-medium text-sm text-dim">Invite by email</span>
+            <input
+              type="text"
+              name="emails"
+              required
+              autoComplete="off"
+              placeholder="teammate@company.com, another@company.com"
+              // The echoed submittedEmails (keyed, so the node remounts) keeps the typed addresses
+              // through a denial/error re-render.
+              key={state?.submittedEmails ?? "initial"}
+              defaultValue={state?.submittedEmails ?? ""}
+              className="block h-11 w-full min-w-56 rounded-md border border-line px-3 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
+            />
+          </label>
+          <button type="submit" className={`${buttonClasses("quiet")} min-h-11`}>
+            {pending ? "Inviting…" : "Invite"}
+          </button>
+        </BusyFields>
       </fetcher.Form>
       <p className="text-faint text-xs">
         Invitations lapse after 7 days. Inviting an address again re-sends the mail and re-arms the

--- a/web/app/components/review/CommentForm.tsx
+++ b/web/app/components/review/CommentForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useFetcher } from "react-router";
-import { buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses } from "@/components/ui";
 
 /** The review route's typed reply for `intent=comment`. */
 interface CommentActionData {
@@ -42,30 +42,32 @@ export function CommentForm({
 
   return (
     <div className="flex flex-col gap-2">
-      <fetcher.Form ref={formRef} method="post" className="flex flex-col gap-2">
+      <fetcher.Form ref={formRef} method="post">
         <input type="hidden" name="intent" value="comment" />
         <input type="hidden" name="version_id" value={versionId} />
         <input type="hidden" name="comment_id" value={commentId} />
-        <label className="block">
-          <span className="sr-only">Comment</span>
-          <textarea
-            name="body"
-            required
-            rows={2}
-            maxLength={4000}
-            placeholder="Comment on this proposal — plain text, visible to the workspace."
-            // The echoed submittedBody (keyed, so the node remounts) keeps the typed text through a
-            // non-success re-render.
-            key={state?.submittedBody ?? "initial"}
-            defaultValue={state?.submittedBody ?? ""}
-            className="block w-full rounded-md border border-line px-3 py-2 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
-          />
-        </label>
-        <div>
-          <button type="submit" disabled={pending} className={`${buttonClasses("quiet")} min-h-11`}>
-            {pending ? "Posting…" : "Comment"}
-          </button>
-        </div>
+        <BusyFields busy={pending} className="flex flex-col gap-2">
+          <label className="block">
+            <span className="sr-only">Comment</span>
+            <textarea
+              name="body"
+              required
+              rows={2}
+              maxLength={4000}
+              placeholder="Comment on this proposal — plain text, visible to the workspace."
+              // The echoed submittedBody (keyed, so the node remounts) keeps the typed text through
+              // a non-success re-render.
+              key={state?.submittedBody ?? "initial"}
+              defaultValue={state?.submittedBody ?? ""}
+              className="block w-full rounded-md border border-line px-3 py-2 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
+            />
+          </label>
+          <div>
+            <button type="submit" className={`${buttonClasses("quiet")} min-h-11`}>
+              {pending ? "Posting…" : "Comment"}
+            </button>
+          </div>
+        </BusyFields>
       </fetcher.Form>
       {state?.status === "empty" && (
         <p className="text-red-600 text-sm" role="alert">

--- a/web/app/components/review/RejectDialog.tsx
+++ b/web/app/components/review/RejectDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useFetcher } from "react-router";
-import { buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses } from "@/components/ui";
 
 /** The review route's typed reply (shared approve/reject shape; this fetcher reads the reject arm). */
 interface ReviewActionData {
@@ -74,33 +74,31 @@ export function RejectDialog({
       <summary className="cursor-pointer select-none font-mono text-[13px] text-dim hover:text-ink">
         {copy.summary}
       </summary>
-      <fetcher.Form ref={formRef} method="post" className="mt-3 flex flex-col gap-2">
+      <fetcher.Form ref={formRef} method="post" className="mt-3">
         <input type="hidden" name="intent" value={variant === "withdraw" ? "withdraw" : "reject"} />
         <input type="hidden" name="version_id" value={versionId} />
-        <label className="block">
-          <span className="mb-1 block font-medium text-sm text-dim">{copy.label}</span>
-          <textarea
-            name="reason"
-            required
-            rows={3}
-            maxLength={2000}
-            placeholder="Say why — the proposer and every reviewer will see it."
-            // The echoed submittedReason (keyed, so the node remounts) keeps the typed text through
-            // a non-success re-render.
-            key={state?.submittedReason ?? "initial"}
-            defaultValue={state?.submittedReason ?? ""}
-            className="block w-full rounded-md border border-line px-3 py-2 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
-          />
-        </label>
-        <div>
-          <button
-            type="submit"
-            disabled={pending}
-            className={`${buttonClasses("danger")} min-h-11`}
-          >
-            {pending ? copy.pending : copy.submit}
-          </button>
-        </div>
+        <BusyFields busy={pending} className="flex flex-col gap-2">
+          <label className="block">
+            <span className="mb-1 block font-medium text-sm text-dim">{copy.label}</span>
+            <textarea
+              name="reason"
+              required
+              rows={3}
+              maxLength={2000}
+              placeholder="Say why — the proposer and every reviewer will see it."
+              // The echoed submittedReason (keyed, so the node remounts) keeps the typed text
+              // through a non-success re-render.
+              key={state?.submittedReason ?? "initial"}
+              defaultValue={state?.submittedReason ?? ""}
+              className="block w-full rounded-md border border-line px-3 py-2 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
+            />
+          </label>
+          <div>
+            <button type="submit" className={`${buttonClasses("danger")} min-h-11`}>
+              {pending ? copy.pending : copy.submit}
+            </button>
+          </div>
+        </BusyFields>
       </fetcher.Form>
       {state?.status === "rejected" && (
         <p className="mt-2 text-sm text-dim" role="status">

--- a/web/app/components/skill/skill-invite.tsx
+++ b/web/app/components/skill/skill-invite.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useFetcher } from "react-router";
-import { buttonClasses, Card } from "@/components/ui";
+import { BusyFields, buttonClasses, Card } from "@/components/ui";
 
 /** The skill route's typed reply for `intent=invite` (mirrors the action's return union). */
 interface SkillInviteReply {
@@ -86,30 +86,28 @@ export function SkillInviteAffordance({
         <p className="text-dim text-sm">Only a workspace owner can invite (and revoke) members.</p>
       ) : (
         <>
-          <fetcher.Form ref={formRef} method="post" className="flex flex-wrap items-end gap-2">
+          <fetcher.Form ref={formRef} method="post">
             <input type="hidden" name="intent" value="invite" />
-            <label className="block flex-1">
-              <span className="mb-1 block font-medium text-dim text-sm">Invite by email</span>
-              <input
-                type="text"
-                name="email"
-                required
-                autoComplete="off"
-                placeholder="teammate@company.com"
-                // The echoed submittedEmail (keyed, so the node remounts) keeps the typed address
-                // through a denial/error re-render.
-                key={state?.submittedEmail ?? "initial"}
-                defaultValue={state?.submittedEmail ?? ""}
-                className="block h-11 w-full min-w-56 rounded-md border border-line px-3 text-ink text-sm placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
-              />
-            </label>
-            <button
-              type="submit"
-              disabled={pending}
-              className={`${buttonClasses("quiet")} min-h-11`}
-            >
-              {pending ? "Inviting…" : "Invite"}
-            </button>
+            <BusyFields busy={pending} className="flex flex-wrap items-end gap-2">
+              <label className="block flex-1">
+                <span className="mb-1 block font-medium text-dim text-sm">Invite by email</span>
+                <input
+                  type="text"
+                  name="email"
+                  required
+                  autoComplete="off"
+                  placeholder="teammate@company.com"
+                  // The echoed submittedEmail (keyed, so the node remounts) keeps the typed address
+                  // through a denial/error re-render.
+                  key={state?.submittedEmail ?? "initial"}
+                  defaultValue={state?.submittedEmail ?? ""}
+                  className="block h-11 w-full min-w-56 rounded-md border border-line px-3 text-ink text-sm placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
+                />
+              </label>
+              <button type="submit" className={`${buttonClasses("quiet")} min-h-11`}>
+                {pending ? "Inviting…" : "Invite"}
+              </button>
+            </BusyFields>
           </fetcher.Form>
           <p className="text-faint text-xs">
             The invitation leads with this skill — it is the first thing the invitee sees.

--- a/web/app/components/ui.tsx
+++ b/web/app/components/ui.tsx
@@ -37,6 +37,34 @@ export function Chip({
   );
 }
 
+/**
+ * The in-flight wrapper for a form's controls. A submit that crosses the network — a sign-in, a
+ * mailed link, an account ceremony — leaves a window where the page looks untouched and a second
+ * click is the obvious thing to try; this closes it. `busy` goes inert in ONE attribute (a native
+ * `<fieldset disabled>`: every control inside stops accepting input and stops submitting, no
+ * per-field bookkeeping) and announces itself to assistive tech.
+ *
+ * The VISIBLE half is the button inside, which keeps its own pending label ("Sending the link…") —
+ * fields dim, the "we're working" copy does not. The fieldset is a transparent box: Tailwind's
+ * preflight zeroes its margin/padding/border, so pass the layout classes the form would have
+ * carried.
+ */
+export function BusyFields({
+  busy,
+  className = "",
+  children,
+}: {
+  busy: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <fieldset disabled={busy} aria-busy={busy} className={className}>
+      {children}
+    </fieldset>
+  );
+}
+
 /** A short identifier (version hash, fingerprint) in mono, self-labeling as truncated. */
 export function ShortId({ value, length = 12 }: { value: string; length?: number }) {
   return (

--- a/web/app/lib/pending.ts
+++ b/web/app/lib/pending.ts
@@ -1,0 +1,24 @@
+import { useNavigation } from "react-router";
+
+/**
+ * The `intent` of a submission from THIS page currently on the wire, or null when nothing of
+ * ours is.
+ *
+ * `useNavigation()` reports EVERY navigation — a sidebar link, a breadcrumb, the redirect that
+ * lands somewhere else — so a form keyed on a bare `state !== "idle"` goes inert and announces
+ * "Creating…" while you are merely leaving the page. Scoping to `formMethod === "POST"` keeps it
+ * to real submissions. It deliberately stays non-null through the post-submit `loading` phase,
+ * because a form that lands by redirect must stay inert until the new page actually arrives.
+ *
+ * The value is the submitted `intent` field, or `""` for a form that posts none — so a route
+ * serving several arms from one action can name the wait for the arm that was clicked instead of
+ * making every arm claim it. FETCHER-driven forms need none of this: a fetcher only ever reports
+ * its own submission, so `fetcher.state` is already scoped.
+ */
+export function useSubmittingIntent(): string | null {
+  const navigation = useNavigation();
+  if (navigation.state === "idle" || navigation.formMethod !== "POST") {
+    return null;
+  }
+  return String(navigation.formData?.get("intent") ?? "");
+}

--- a/web/app/routes/channel-detail.tsx
+++ b/web/app/routes/channel-detail.tsx
@@ -293,7 +293,13 @@ function StanceSection({ detail }: { detail: ChannelDetailData }) {
         />
         <input type="hidden" name="channel_id" value={detail.channelId} />
         <button type="submit" disabled={pending} className={buttonClasses("quiet")}>
-          {detail.viewerIncluded ? "Remove from my skills" : "Add to my skills"}
+          {pending
+            ? detail.viewerIncluded
+              ? "Removing…"
+              : "Adding…"
+            : detail.viewerIncluded
+              ? "Remove from my skills"
+              : "Add to my skills"}
         </button>
       </fetcher.Form>
       {error !== undefined && (

--- a/web/app/routes/channel-new.tsx
+++ b/web/app/routes/channel-new.tsx
@@ -1,9 +1,10 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
-import { data, Link, redirect, useActionData } from "react-router";
-import { buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
+import { data, Form, Link, redirect, useActionData } from "react-router";
+import { BusyFields, buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
 import { requireMemberInScope } from "@/lib/auth/guards.server";
 import { recordAdminEvent } from "@/lib/db/audit.server";
 import { type ChannelCreateOutcome, createChannel } from "@/lib/db/queries.channels.server";
+import { useSubmittingIntent } from "@/lib/pending";
 import { useWsPath } from "@/lib/ws-path";
 import { wsPathServer } from "@/lib/ws-url.server";
 
@@ -71,6 +72,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
 export default function ChannelNew() {
   const state = useActionData<typeof action>();
   const wsPath = useWsPath();
+  // A landed create redirects to the new channel, so the wait spans the POST and that navigation.
+  // The unique index makes a double-submit safe on the server (the loser reads name_taken), but
+  // "that name already exists" is a confusing answer to your own second click.
+  const busy = useSubmittingIntent() !== null;
   return (
     <div className="space-y-8">
       <PageHeader
@@ -90,29 +95,32 @@ export default function ChannelNew() {
             A channel is a named group: skills placed in it are delivered to its members. Any member
             can create one — the CLI creates them on first use the same way.
           </p>
-          {/* A full-page POST: a landed create redirects to the new channel; a refusal re-renders
-              here with the typed copy. */}
-          <form method="post" className="flex flex-wrap items-end gap-2">
-            <label className="block flex-1">
-              <span className="mb-1 block font-medium text-sm text-dim">Channel name</span>
-              <input
-                type="text"
-                name="name"
-                required
-                autoComplete="off"
-                spellCheck={false}
-                placeholder="frontend-guild"
-                pattern="[a-z0-9][a-z0-9-]*"
-                maxLength={64}
-                key={state?.submittedName ?? "initial"}
-                defaultValue={state?.submittedName ?? ""}
-                className="block h-11 w-full min-w-56 rounded-md border border-line px-3 text-ink text-sm placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
-              />
-            </label>
-            <button type="submit" className={`${buttonClasses("quiet")} min-h-11`}>
-              Create channel
-            </button>
-          </form>
+          {/* A landed create redirects to the new channel; a refusal re-renders here with the
+              typed copy. React Router's <Form> (not a bare one) so the submit is observable as
+              navigation state — it still posts natively if scripts never loaded. */}
+          <Form method="post">
+            <BusyFields busy={busy} className="flex flex-wrap items-end gap-2">
+              <label className="block flex-1">
+                <span className="mb-1 block font-medium text-sm text-dim">Channel name</span>
+                <input
+                  type="text"
+                  name="name"
+                  required
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="frontend-guild"
+                  pattern="[a-z0-9][a-z0-9-]*"
+                  maxLength={64}
+                  key={state?.submittedName ?? "initial"}
+                  defaultValue={state?.submittedName ?? ""}
+                  className="block h-11 w-full min-w-56 rounded-md border border-line px-3 text-ink text-sm placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
+                />
+              </label>
+              <button type="submit" className={`${buttonClasses("quiet")} min-h-11`}>
+                {busy ? "Creating…" : "Create channel"}
+              </button>
+            </BusyFields>
+          </Form>
           {state !== undefined && state.error.length > 0 && (
             <p className="text-red-600 text-sm" role="alert">
               {state.error}

--- a/web/app/routes/claim.tsx
+++ b/web/app/routes/claim.tsx
@@ -9,11 +9,12 @@ import {
   useActionData,
   useLoaderData,
 } from "react-router";
-import { buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses } from "@/components/ui";
 import { notFound } from "@/lib/auth/guards.server";
 import { withRegistrationCeremony } from "@/lib/auth/registration.server";
 import { getAuth } from "@/lib/auth/server";
 import { claimableWorkspace, consumeClaim } from "@/lib/db/identity.server";
+import { useSubmittingIntent } from "@/lib/pending";
 import { allowPublicRead, clientKeyFromXff } from "@/lib/rate-limit.server";
 
 export const meta: MetaFunction = () => [{ title: "Finish setup · Topos" }];
@@ -116,6 +117,11 @@ const INPUT =
 export default function ClaimPage() {
   const { workspaceName, code } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
+  // The claim is a sign-up (a deliberate slow password hash) plus the consuming transaction, and
+  // it lands by REDIRECT — so the wait covers the submit AND the navigation to the dashboard.
+  // Nothing about the page changes until then, which is exactly when a second click gets tried;
+  // the code is single-use, so that second submit would race itself into the uniform miss.
+  const busy = useSubmittingIntent() !== null;
   return (
     <Shell>
       <p className="font-medium text-faint text-xs uppercase tracking-wide">Finish setup</p>
@@ -125,44 +131,46 @@ export default function ClaimPage() {
       <p className="mt-1 text-faint text-sm">
         Create the first account on this install — it becomes the workspace owner.
       </p>
-      <Form method="post" className="mt-6 space-y-3">
+      <Form method="post" className="mt-6">
         <input type="hidden" name="code" value={code} />
-        <label className="block">
-          <span className="mb-1 block font-medium text-dim text-sm">Name</span>
-          <input
-            type="text"
-            name="name"
-            autoComplete="name"
-            className={INPUT}
-            placeholder="Ada Lovelace"
-          />
-        </label>
-        <label className="block">
-          <span className="mb-1 block font-medium text-dim text-sm">Email</span>
-          <input
-            type="email"
-            name="email"
-            required
-            autoComplete="email"
-            className={INPUT}
-            placeholder="you@company.com"
-          />
-        </label>
-        <label className="block">
-          <span className="mb-1 block font-medium text-dim text-sm">Password</span>
-          <input
-            type="password"
-            name="password"
-            required
-            minLength={8}
-            autoComplete="new-password"
-            className={INPUT}
-            placeholder="••••••••"
-          />
-        </label>
-        <button type="submit" className={`${buttonClasses("primary")} min-h-11 w-full`}>
-          Claim this workspace
-        </button>
+        <BusyFields busy={busy} className="space-y-3">
+          <label className="block">
+            <span className="mb-1 block font-medium text-dim text-sm">Name</span>
+            <input
+              type="text"
+              name="name"
+              autoComplete="name"
+              className={INPUT}
+              placeholder="Ada Lovelace"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block font-medium text-dim text-sm">Email</span>
+            <input
+              type="email"
+              name="email"
+              required
+              autoComplete="email"
+              className={INPUT}
+              placeholder="you@company.com"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block font-medium text-dim text-sm">Password</span>
+            <input
+              type="password"
+              name="password"
+              required
+              minLength={8}
+              autoComplete="new-password"
+              className={INPUT}
+              placeholder="••••••••"
+            />
+          </label>
+          <button type="submit" className={`${buttonClasses("primary")} min-h-11 w-full`}>
+            {busy ? "Claiming…" : "Claim this workspace"}
+          </button>
+        </BusyFields>
       </Form>
       {actionData?.error !== undefined && (
         <p className="mt-3 text-red-600 text-sm" role="alert">

--- a/web/app/routes/invite-redeem.tsx
+++ b/web/app/routes/invite-redeem.tsx
@@ -8,9 +8,8 @@ import {
   redirect,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from "react-router";
-import { buttonClasses, Chip } from "@/components/ui";
+import { BusyFields, buttonClasses, Chip } from "@/components/ui";
 import { composition } from "@/composition.server";
 import { actorFromSession, notFound } from "@/lib/auth/guards.server";
 import { withInvitationCeremony } from "@/lib/auth/registration.server";
@@ -23,6 +22,7 @@ import {
   mintInvitationSignIn,
 } from "@/lib/db/identity.server";
 import { mailDelivery } from "@/lib/mail/transport.server";
+import { useSubmittingIntent } from "@/lib/pending";
 import { personDisplay } from "@/lib/person-display";
 import { allowPublicRead, clientKeyFromXff } from "@/lib/rate-limit.server";
 import { wsPathServer } from "@/lib/ws-url.server";
@@ -437,17 +437,17 @@ function BranchArm({ data }: { data: ViewData }) {
 
 /** Signed in as the invited address — a live session plus the explicit click is the ceremony. */
 function OneClickAccept() {
-  const busy = useNavigation().state !== "idle";
+  const flying = useSubmittingIntent();
   return (
     <div className="flex flex-col gap-3">
       <Form method="post">
         <input type="hidden" name="intent" value="accept" />
         <button
           type="submit"
-          disabled={busy}
+          disabled={flying !== null}
           className={`${buttonClasses("primary")} min-h-11 w-full`}
         >
-          {busy ? "Working…" : "Accept invitation"}
+          {flying === "accept" ? "Accepting…" : "Accept invitation"}
         </button>
       </Form>
       <DeclineArm />
@@ -457,48 +457,48 @@ function OneClickAccept() {
 
 /** A brand-new person: the account mint, email locked to the invited address. */
 function CreateAccount({ passwordless }: { passwordless: boolean }) {
-  const busy = useNavigation().state !== "idle";
+  const flying = useSubmittingIntent();
   return (
     <div className="flex flex-col gap-3">
-      <Form method="post" className="flex flex-col gap-3">
+      <Form method="post">
         <input type="hidden" name="intent" value="accept-new" />
-        <label className="block">
-          <span className="mb-1 block font-medium text-dim text-sm">Your name (optional)</span>
-          <input
-            type="text"
-            name="name"
-            autoComplete="name"
-            className={INPUT}
-            placeholder="Ada Lovelace"
-          />
-        </label>
-        {!passwordless && (
+        {/* Minting the account is a sign-up (slow hash) plus the accept transaction, then a
+            redirect into the workspace — the whole stretch stays inert here. */}
+        <BusyFields busy={flying !== null} className="flex flex-col gap-3">
           <label className="block">
-            <span className="mb-1 block font-medium text-dim text-sm">Choose a password</span>
+            <span className="mb-1 block font-medium text-dim text-sm">Your name (optional)</span>
             <input
-              type="password"
-              name="password"
-              required
-              minLength={8}
-              autoComplete="new-password"
+              type="text"
+              name="name"
+              autoComplete="name"
               className={INPUT}
-              placeholder="••••••••"
+              placeholder="Ada Lovelace"
             />
           </label>
-        )}
-        <button
-          type="submit"
-          disabled={busy}
-          className={`${buttonClasses("primary")} min-h-11 w-full`}
-        >
-          {busy ? "Working…" : "Accept and create my account"}
-        </button>
-        {passwordless && (
-          <p className="text-center text-faint text-xs">
-            No password needed — this link came to your mailbox, and future sign-ins go the same
-            way.
-          </p>
-        )}
+          {!passwordless && (
+            <label className="block">
+              <span className="mb-1 block font-medium text-dim text-sm">Choose a password</span>
+              <input
+                type="password"
+                name="password"
+                required
+                minLength={8}
+                autoComplete="new-password"
+                className={INPUT}
+                placeholder="••••••••"
+              />
+            </label>
+          )}
+          <button type="submit" className={`${buttonClasses("primary")} min-h-11 w-full`}>
+            {flying === "accept-new" ? "Creating your account…" : "Accept and create my account"}
+          </button>
+          {passwordless && (
+            <p className="text-center text-faint text-xs">
+              No password needed — this link came to your mailbox, and future sign-ins go the same
+              way.
+            </p>
+          )}
+        </BusyFields>
       </Form>
       <DeclineArm />
     </div>
@@ -528,7 +528,7 @@ function SwitchAccount({
   invitedEmail: string;
   signedInEmail: string | null;
 }) {
-  const busy = useNavigation().state !== "idle";
+  const flying = useSubmittingIntent();
   return (
     <div className="flex flex-col gap-3">
       <p className="text-center text-dim text-sm">
@@ -540,10 +540,10 @@ function SwitchAccount({
         <input type="hidden" name="intent" value="switch" />
         <button
           type="submit"
-          disabled={busy}
+          disabled={flying !== null}
           className={`${buttonClasses("primary")} min-h-11 w-full`}
         >
-          Sign out and continue as {invitedEmail}
+          {flying === "switch" ? "Signing out…" : `Sign out and continue as ${invitedEmail}`}
         </button>
       </Form>
       <DeclineArm />
@@ -553,7 +553,7 @@ function SwitchAccount({
 
 /** Signed in as the invited address, but the mailbox was never proven — one round-trip first. */
 function UnverifiedFence({ mailArmed }: { mailArmed: boolean }) {
-  const busy = useNavigation().state !== "idle";
+  const flying = useSubmittingIntent();
   return (
     <div className="flex flex-col gap-3">
       <p className="text-center text-dim text-sm">
@@ -565,10 +565,10 @@ function UnverifiedFence({ mailArmed }: { mailArmed: boolean }) {
           <input type="hidden" name="intent" value="send-verification" />
           <button
             type="submit"
-            disabled={busy}
+            disabled={flying !== null}
             className={`${buttonClasses("primary")} min-h-11 w-full`}
           >
-            Send the verification mail
+            {flying === "send-verification" ? "Sending…" : "Send the verification mail"}
           </button>
         </Form>
       ) : (
@@ -583,16 +583,16 @@ function UnverifiedFence({ mailArmed }: { mailArmed: boolean }) {
 
 /** The quiet decline — recorded; whoever invited you sees it; re-invitable. */
 function DeclineArm() {
-  const busy = useNavigation().state !== "idle";
+  const flying = useSubmittingIntent();
   return (
     <Form method="post" className="text-center">
       <input type="hidden" name="intent" value="decline" />
       <button
         type="submit"
-        disabled={busy}
-        className="text-faint text-xs underline-offset-2 hover:underline"
+        disabled={flying !== null}
+        className="text-faint text-xs underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
       >
-        Decline this invitation
+        {flying === "decline" ? "Declining…" : "Decline this invitation"}
       </button>
     </Form>
   );

--- a/web/app/routes/login.tsx
+++ b/web/app/routes/login.tsx
@@ -5,6 +5,7 @@ import {
   useLoaderData,
   useNavigate,
 } from "react-router";
+import { BusyFields } from "@/components/ui";
 import { composition } from "@/composition.server";
 import { authClient } from "@/lib/auth/client";
 import { safeNextPath } from "@/lib/auth/guards.server";
@@ -53,12 +54,37 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 type Mode = "signin" | "signup";
 
+/**
+ * The rung with a request on the wire — at most ONE at a time. Every rung goes inert while any is
+ * in flight (starting Google mid-magic-link would race two sign-ins against one page), and the
+ * busy rung is the one that swaps its label, so the wait always names what it is waiting for.
+ * Sign-in is the page where a slow answer is most likely — a mailed link is an SMTP round-trip,
+ * a password is a deliberate slow hash — and it is exactly where an unmarked wait reads as a
+ * dead button.
+ */
+type Busy = { rung: "password" } | { rung: "magic" } | { rung: "social"; provider: string } | null;
+
+/**
+ * What a rung says when its call REJECTED rather than answering. Better Auth's client returns
+ * `{ error }` for anything the server decided and throws only when the request never completed —
+ * offline, connection reset — so this line carries no information about the account and is not
+ * an enumeration risk. It gets its own words because a rung's constant refusal would send
+ * someone off to re-check a password that was fine.
+ *
+ * Every rejection path MUST re-arm the form. The fields are inside a disabled fieldset by then,
+ * so a busy state left set is a login page you can only escape by reloading — the exact
+ * dead-looking form this whole change exists to prevent.
+ */
+const UNREACHABLE = "Couldn’t reach the server. Check your connection and try again.";
+
 const INPUT =
   "block h-11 w-full rounded-md border border-line px-3 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25";
 const PRIMARY_BTN =
-  "h-11 w-full rounded-md bg-accent font-mono text-[13px] text-on-accent hover:bg-accent-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:opacity-60";
+  "h-11 w-full rounded-md bg-accent font-mono text-[13px] text-on-accent hover:bg-accent-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60";
 const QUIET_BTN =
-  "flex h-11 w-full items-center justify-center gap-2 rounded-md border border-line bg-panel font-mono text-[13px] text-dim hover:bg-panel2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
+  "flex h-11 w-full items-center justify-center gap-2 rounded-md border border-line bg-panel font-mono text-[13px] text-dim hover:bg-panel2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60";
+/** The two quiet text toggles (rung switch, sign-in/sign-up switch) — inert while a rung flies. */
+const TOGGLE_BTN = "disabled:cursor-not-allowed disabled:opacity-60";
 
 /** The label/icon map for social providers — google today; an unknown id gets a titled fallback. */
 function socialLabel(id: string): string {
@@ -84,7 +110,7 @@ export default function LoginPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [pending, setPending] = useState(false);
+  const [busy, setBusy] = useState<Busy>(null);
   const [error, setError] = useState<string | null>(null);
   const [magicSent, setMagicSent] = useState(false);
   const [verifySent, setVerifySent] = useState(false);
@@ -97,25 +123,32 @@ export default function LoginPage() {
   // composition that turned the password rung OFF never renders (or submits) a password form,
   // and its sign-up motion is whatever its remaining rungs provide (invite + magic link/social).
   const showMagic = magicLink && !signup && (!passwordRevealed || !emailAndPassword);
+  const anyBusy = busy !== null;
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (pending) return;
-    setPending(true);
+    if (anyBusy) return;
+    setBusy({ rung: "password" });
     setError(null);
     const address = email.trim();
-    const { error: authError } =
-      mode === "signin"
-        ? await authClient.signIn.email({ email: address, password })
-        : await authClient.signUp.email({
-            email: address,
-            password,
-            // Better Auth requires a name on sign-up; the email is an honest default when the
-            // optional field is left blank.
-            name: name.trim() || address,
-          });
+    const attempt = await (mode === "signin"
+      ? authClient.signIn.email({ email: address, password })
+      : authClient.signUp.email({
+          email: address,
+          password,
+          // Better Auth requires a name on sign-up; the email is an honest default when the
+          // optional field is left blank.
+          name: name.trim() || address,
+        })
+    ).catch(() => null);
+    if (attempt === null) {
+      setBusy(null);
+      setError(UNREACHABLE);
+      return;
+    }
+    const { error: authError } = attempt;
     if (authError) {
-      setPending(false);
+      setBusy(null);
       // GATED, the sign-up refusal is CONSTANT whatever failed — an uninvited address, an
       // expired invitation, and a taken email all read the same, so the form enumerates
       // nothing. OPEN, sign-up isn't invitation-framed: a failure gets a plain retry line
@@ -132,43 +165,66 @@ export default function LoginPage() {
     if (mode === "signup" && mailArmed) {
       // The seat binds only after the mailbox round-trip — hold here instead of navigating
       // into an app the account cannot enter yet.
-      setPending(false);
+      setBusy(null);
       setVerifySent(true);
       return;
     }
-    // Sign-up signs in on success, so both rungs land the same place.
+    // Sign-up signs in on success, so both rungs land the same place. The rung stays BUSY across
+    // the navigate: this card is on its way out, and re-arming it for those frames would offer a
+    // second submit of a sign-in that already succeeded.
     navigate(next);
   }
 
   async function submitMagicLink(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (anyBusy) return;
     const address = email.trim();
     if (!address) {
       setError("Enter your email first.");
       return;
     }
     setError(null);
-    const { error: linkError } = await authClient.signIn.magicLink({
-      email: address,
-      callbackURL: next,
-    });
-    if (linkError) {
+    // Held busy from here: the send is an SMTP round-trip on the server, the slowest wait the
+    // page has, and until it answers this card must not look idle.
+    setBusy({ rung: "magic" });
+    const sent = await authClient.signIn
+      .magicLink({ email: address, callbackURL: next })
+      .catch(() => null);
+    if (sent === null) {
+      setBusy(null);
+      setError(UNREACHABLE);
+      return;
+    }
+    if (sent.error) {
+      setBusy(null);
       setError("Couldn’t send the link. Check the address and try again.");
       return;
     }
+    // The sent card replaces this one — leaving busy set keeps the form inert for those frames.
     setMagicSent(true);
   }
 
   async function continueWithSocial(provider: string) {
+    if (anyBusy) return;
     setError(null);
-    const { error: socialError } = await authClient.signIn.social({
-      // The composed provider id is a string; the client types it as its known-provider union.
-      provider: provider as Parameters<typeof authClient.signIn.social>[0]["provider"],
-      callbackURL: next,
-    });
-    if (socialError) {
+    setBusy({ rung: "social", provider });
+    const started = await authClient.signIn
+      .social({
+        // The composed provider id is a string; the client types it as its known-provider union.
+        provider: provider as Parameters<typeof authClient.signIn.social>[0]["provider"],
+        callbackURL: next,
+      })
+      .catch(() => null);
+    if (started === null) {
+      setBusy(null);
+      setError(UNREACHABLE);
+      return;
+    }
+    if (started.error) {
+      setBusy(null);
       setError("Couldn’t start that sign-in. Try again.");
     }
+    // Success hands the browser to the provider — stay busy through the redirect.
   }
 
   if (magicSent) {
@@ -214,52 +270,62 @@ export default function LoginPage() {
       </p>
 
       {showMagic ? (
-        <form onSubmit={submitMagicLink} className="mt-6 space-y-3">
-          <EmailField value={email} onChange={setEmail} />
-          <button type="submit" className={PRIMARY_BTN}>
-            {registrationOpen ? "Continue with email" : "Email me a sign-in link"}
-          </button>
+        <form onSubmit={submitMagicLink} className="mt-6">
+          <BusyFields busy={anyBusy} className="space-y-3">
+            <EmailField value={email} onChange={setEmail} />
+            <button type="submit" className={PRIMARY_BTN}>
+              {busy?.rung === "magic"
+                ? "Sending the link…"
+                : registrationOpen
+                  ? "Continue with email"
+                  : "Email me a sign-in link"}
+            </button>
+          </BusyFields>
         </form>
       ) : !emailAndPassword ? null : (
-        <form onSubmit={submit} className="mt-6 space-y-3">
-          {signup && (
+        <form onSubmit={submit} className="mt-6">
+          <BusyFields busy={anyBusy} className="space-y-3">
+            {signup && (
+              <label className="block">
+                <span className="mb-1 block text-sm font-medium text-dim">Name</span>
+                <input
+                  type="text"
+                  name="name"
+                  autoComplete="name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className={INPUT}
+                  placeholder="Ada Lovelace"
+                />
+              </label>
+            )}
+            <EmailField value={email} onChange={setEmail} />
             <label className="block">
-              <span className="mb-1 block text-sm font-medium text-dim">Name</span>
+              <span className="mb-1 block text-sm font-medium text-dim">Password</span>
               <input
-                type="text"
-                name="name"
-                autoComplete="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
+                type="password"
+                name="password"
+                required
+                minLength={8}
+                autoComplete={signup ? "new-password" : "current-password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
                 className={INPUT}
-                placeholder="Ada Lovelace"
+                placeholder="••••••••"
               />
             </label>
-          )}
-          <EmailField value={email} onChange={setEmail} />
-          <label className="block">
-            <span className="mb-1 block text-sm font-medium text-dim">Password</span>
-            <input
-              type="password"
-              name="password"
-              required
-              minLength={8}
-              autoComplete={signup ? "new-password" : "current-password"}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className={INPUT}
-              placeholder="••••••••"
-            />
-          </label>
-          <button type="submit" disabled={pending} className={PRIMARY_BTN}>
-            {pending
-              ? signup
-                ? "Creating…"
-                : "Signing in…"
-              : signup
-                ? "Create account"
-                : "Sign in"}
-          </button>
+            {/* The label names THIS rung's wait only: another rung in flight disables the button
+                without pretending a password is being checked. */}
+            <button type="submit" className={PRIMARY_BTN}>
+              {busy?.rung === "password"
+                ? signup
+                  ? "Creating…"
+                  : "Signing in…"
+                : signup
+                  ? "Create account"
+                  : "Sign in"}
+            </button>
+          </BusyFields>
         </form>
       )}
 
@@ -278,10 +344,13 @@ export default function LoginPage() {
                 key={id}
                 type="button"
                 onClick={() => continueWithSocial(id)}
+                disabled={anyBusy}
                 className={QUIET_BTN}
               >
                 {id === "google" && <GoogleIcon />}
-                {socialLabel(id)}
+                {busy?.rung === "social" && busy.provider === id
+                  ? "Taking you there…"
+                  : socialLabel(id)}
               </button>
             ))}
           </div>
@@ -292,11 +361,12 @@ export default function LoginPage() {
       {magicLink && !signup && emailAndPassword && (
         <button
           type="button"
+          disabled={anyBusy}
           onClick={() => {
             setPasswordRevealed((v) => !v);
             setError(null);
           }}
-          className="mt-4 block w-full text-center text-sm text-dim underline-offset-2 hover:text-ink hover:underline"
+          className={`mt-4 block w-full text-center text-sm text-dim underline-offset-2 hover:text-ink hover:underline ${TOGGLE_BTN}`}
         >
           {passwordRevealed
             ? registrationOpen
@@ -311,11 +381,12 @@ export default function LoginPage() {
           {signup ? "Already have an account?" : "New to Topos?"}{" "}
           <button
             type="button"
+            disabled={anyBusy}
             onClick={() => {
               setMode(signup ? "signin" : "signup");
               setError(null);
             }}
-            className="border-b border-hairline text-ink transition-colors hover:border-ink"
+            className={`border-b border-hairline text-ink transition-colors hover:border-ink ${TOGGLE_BTN}`}
           >
             {signup ? "Sign in" : "Create an account"}
           </button>

--- a/web/app/routes/profile.tsx
+++ b/web/app/routes/profile.tsx
@@ -153,6 +153,23 @@ export default function ProfilePage() {
   );
 }
 
+/**
+ * Which ROW of a section is on the wire, by the hidden id its form posts — or null when the
+ * section is idle. Each section here drives every one of its rows from ONE fetcher, so
+ * `fetcher.state` alone cannot tell the clicked row from its neighbours; without the id the whole
+ * list would announce a wait that belongs to one line of it.
+ */
+function flyingSkillId(fetcher: { state: string; formData?: FormData }): string | null {
+  return fetcher.state === "idle" ? null : (fetcher.formData?.get("skill_id")?.toString() ?? null);
+}
+
+/** The channel-row twin of [`flyingSkillId`]. */
+function flyingChannelId(fetcher: { state: string; formData?: FormData }): string | null {
+  return fetcher.state === "idle"
+    ? null
+    : (fetcher.formData?.get("channel_id")?.toString() ?? null);
+}
+
 function DeliveredSection({
   delivered,
 }: {
@@ -160,6 +177,9 @@ function DeliveredSection({
 }) {
   const wsPath = useWsPath();
   const fetcher = useFetcher<ProfileActionData>();
+  // ONE fetcher serves every row, so every row's button disables together — but only the row that
+  // was clicked names its wait. Without the id check the whole list would read "Removing…".
+  const removing = flyingSkillId(fetcher);
   const excludedNote =
     fetcher.data?.intent === "remove-skill" && fetcher.data.status === "excluded"
       ? "Removed — a channel still carries it, so a personal exclude line now holds it back. Adding it again clears the exclude."
@@ -210,7 +230,7 @@ function DeliveredSection({
                       disabled={fetcher.state !== "idle"}
                       className={buttonClasses("quiet")}
                     >
-                      Remove
+                      {removing === skill.skillId ? "Removing…" : "Remove"}
                     </button>
                   </fetcher.Form>
                 </span>
@@ -230,6 +250,10 @@ function ChannelsSection({
 }) {
   const fetcher = useFetcher<ProfileActionData>();
   const wsPath = useWsPath();
+  // Carrying or dropping a channel rewrites the person's profile rows and changes what every one
+  // of their machines is owed — this toggle had no in-flight state at all, so a slow answer read
+  // as a dead button and invited the second click that toggles it straight back.
+  const toggling = flyingChannelId(fetcher);
   return (
     <section aria-labelledby="profile-channels-heading" className="space-y-3">
       <SectionHeading>
@@ -266,7 +290,12 @@ function ChannelsSection({
                     value={channel.included ? "remove-channel" : "include-channel"}
                   />
                   <input type="hidden" name="channel_id" value={channel.channelId} />
-                  <ChannelToggle name={channel.name} included={channel.included} />
+                  <ChannelToggle
+                    name={channel.name}
+                    included={channel.included}
+                    busy={fetcher.state !== "idle"}
+                    flying={toggling === channel.channelId}
+                  />
                 </fetcher.Form>
               </span>
             </li>
@@ -277,10 +306,28 @@ function ChannelsSection({
   );
 }
 
-function ChannelToggle({ name, included }: { name: string; included: boolean }) {
+function ChannelToggle({
+  name,
+  included,
+  busy,
+  flying,
+}: {
+  name: string;
+  included: boolean;
+  /** Any row of this section is on the wire — every toggle disables together. */
+  busy: boolean;
+  /** THIS row is the one on the wire — only it names the wait. */
+  flying: boolean;
+}) {
   return (
-    <button type="submit" className={buttonClasses("quiet")}>
-      {included ? `Drop ${name}` : `Carry ${name}`}
+    <button type="submit" disabled={busy} className={buttonClasses("quiet")}>
+      {flying
+        ? included
+          ? `Dropping ${name}…`
+          : `Carrying ${name}…`
+        : included
+          ? `Drop ${name}`
+          : `Carry ${name}`}
     </button>
   );
 }
@@ -313,6 +360,7 @@ function AddSection({
   addable: ReturnType<typeof useLoaderData<typeof loader>>["addable"];
 }) {
   const fetcher = useFetcher<ProfileActionData>();
+  const adding = flyingSkillId(fetcher);
   if (addable.length === 0) {
     return null;
   }
@@ -343,7 +391,7 @@ function AddSection({
                     className={buttonClasses("quiet")}
                   >
                     <Plus aria-hidden className="mr-1 inline size-3.5" />
-                    Add
+                    {adding === skill.skillId ? "Adding…" : "Add"}
                   </button>
                 </fetcher.Form>
               </span>

--- a/web/app/routes/recovery.tsx
+++ b/web/app/routes/recovery.tsx
@@ -8,9 +8,10 @@ import {
   redirect,
   useActionData,
 } from "react-router";
-import { buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses } from "@/components/ui";
 import { notFound } from "@/lib/auth/guards.server";
 import { consumeRecoveryCode } from "@/lib/auth/recovery.server";
+import { useSubmittingIntent } from "@/lib/pending";
 import { allowPublicRead, clientKeyFromXff } from "@/lib/rate-limit.server";
 
 export const meta: MetaFunction = () => [{ title: "Account recovery · Topos" }];
@@ -66,6 +67,10 @@ const INPUT =
 
 export default function RecoveryPage() {
   const actionData = useActionData<typeof action>();
+  // Consuming the code is a password hash plus a write, and a landed reset REDIRECTS to /login —
+  // so the wait spans both. The code is single-use: a second submit while the first is on the
+  // wire spends it and answers the one constant refusal, reading as "my code didn't work".
+  const busy = useSubmittingIntent() !== null;
   return (
     <Shell>
       <p className="font-medium text-faint text-xs uppercase tracking-wide">Account recovery</p>
@@ -75,34 +80,36 @@ export default function RecoveryPage() {
       <p className="mt-1 text-faint text-sm">
         Enter the recovery code from the server operator and choose a new password.
       </p>
-      <Form method="post" className="mt-6 space-y-3">
-        <label className="block">
-          <span className="mb-1 block font-medium text-dim text-sm">Recovery code</span>
-          <input
-            type="text"
-            name="code"
-            required
-            autoComplete="off"
-            spellCheck={false}
-            className={`${INPUT} font-mono`}
-            placeholder="paste the code"
-          />
-        </label>
-        <label className="block">
-          <span className="mb-1 block font-medium text-dim text-sm">New password</span>
-          <input
-            type="password"
-            name="password"
-            required
-            minLength={8}
-            autoComplete="new-password"
-            className={INPUT}
-            placeholder="••••••••"
-          />
-        </label>
-        <button type="submit" className={`${buttonClasses("primary")} min-h-11 w-full`}>
-          Reset password
-        </button>
+      <Form method="post" className="mt-6">
+        <BusyFields busy={busy} className="space-y-3">
+          <label className="block">
+            <span className="mb-1 block font-medium text-dim text-sm">Recovery code</span>
+            <input
+              type="text"
+              name="code"
+              required
+              autoComplete="off"
+              spellCheck={false}
+              className={`${INPUT} font-mono`}
+              placeholder="paste the code"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block font-medium text-dim text-sm">New password</span>
+            <input
+              type="password"
+              name="password"
+              required
+              minLength={8}
+              autoComplete="new-password"
+              className={INPUT}
+              placeholder="••••••••"
+            />
+          </label>
+          <button type="submit" className={`${buttonClasses("primary")} min-h-11 w-full`}>
+            {busy ? "Resetting…" : "Reset password"}
+          </button>
+        </BusyFields>
       </Form>
       {actionData?.error !== undefined && (
         <p className="mt-3 text-red-600 text-sm" role="alert">

--- a/web/app/routes/skill-import.tsx
+++ b/web/app/routes/skill-import.tsx
@@ -1,18 +1,11 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
-import {
-  data,
-  Form,
-  Link,
-  redirect,
-  useActionData,
-  useLoaderData,
-  useNavigation,
-} from "react-router";
-import { buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
+import { data, Form, Link, redirect, useActionData, useLoaderData } from "react-router";
+import { BusyFields, buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
 import { requireMemberInScope } from "@/lib/auth/guards.server";
 import { mintBundleId } from "@/lib/db/identity.server";
 import { inFinalTx, registerGenesisBundleInTx } from "@/lib/db/queries.custody.server";
 import { fetchUpstreamTree, governedCopiesOf, resolveTreeSource } from "@/lib/db/upstream.server";
+import { useSubmittingIntent } from "@/lib/pending";
 import { publishVersion } from "@/lib/plane/custody.server";
 import { allowUpstreamFetch } from "@/lib/rate-limit.server";
 import { useWsPath } from "@/lib/ws-path";
@@ -288,9 +281,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function SkillImport() {
   const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
   const wsPath = useWsPath();
-  const busy = navigation.state !== "idle";
+  const flying = useSubmittingIntent();
+  const busy = flying !== null;
   const preview =
     actionData !== undefined && actionData.form === "preview" && actionData.error === undefined
       ? actionData
@@ -312,21 +305,24 @@ export default function SkillImport() {
         repository changes later, the change arrives as a proposal in the review queue, never a
         silent update.
       </p>
-      <Form method="post" className="flex max-w-2xl items-end gap-2">
+      <Form method="post" className="max-w-2xl">
         <input type="hidden" name="intent" value="preview" />
-        <label className="block flex-1">
-          <span className="mb-1 block font-medium text-dim text-sm">Repository or folder</span>
-          <input
-            type="text"
-            name="source"
-            required
-            placeholder="vercel-labs/skills or https://github.com/owner/repo/tree/main/skills/x"
-            className="block h-11 w-full rounded-md border border-line px-3 font-mono text-[13px] text-ink placeholder:text-faint focus:border-accent focus:outline-none"
-          />
-        </label>
-        <button type="submit" disabled={busy} className={`${buttonClasses("primary")} min-h-11`}>
-          {busy ? "Fetching…" : "Preview"}
-        </button>
+        {/* The preview is a live GitHub fetch on the server — seconds, not milliseconds. */}
+        <BusyFields busy={busy} className="flex items-end gap-2">
+          <label className="block flex-1">
+            <span className="mb-1 block font-medium text-dim text-sm">Repository or folder</span>
+            <input
+              type="text"
+              name="source"
+              required
+              placeholder="vercel-labs/skills or https://github.com/owner/repo/tree/main/skills/x"
+              className="block h-11 w-full rounded-md border border-line px-3 font-mono text-[13px] text-ink placeholder:text-faint focus:border-accent focus:outline-none"
+            />
+          </label>
+          <button type="submit" className={`${buttonClasses("primary")} min-h-11`}>
+            {flying === "preview" ? "Fetching…" : "Preview"}
+          </button>
+        </BusyFields>
       </Form>
       {error !== undefined && (
         <p role="alert" className="text-red-700 text-sm">
@@ -339,10 +335,10 @@ export default function SkillImport() {
 }
 
 function PreviewCard({ preview }: { preview: PreviewData }) {
-  const navigation = useNavigation();
   const { wsName, refHost } = useLoaderData<typeof loader>();
   const wsPath = useWsPath();
-  const busy = navigation.state !== "idle";
+  const flying = useSubmittingIntent();
+  const busy = flying !== null;
   return (
     <section aria-labelledby="import-preview-heading" className="max-w-2xl space-y-3">
       <SectionHeading>
@@ -407,29 +403,29 @@ function PreviewCard({ preview }: { preview: PreviewData }) {
             The archive carried no commit stamp — try again (the publish pins an exact commit).
           </p>
         ) : (
-          <Form method="post" className="flex items-end gap-2">
+          <Form method="post">
             <input type="hidden" name="intent" value="publish" />
             <input type="hidden" name="repo" value={preview.repo} />
             <input type="hidden" name="subdir" value={preview.subdir} />
             <input type="hidden" name="commit" value={preview.commit} />
-            <label className="block flex-1">
-              <span className="mb-1 block font-medium text-dim text-sm">Publish as</span>
-              <input
-                type="text"
-                name="name"
-                required
-                defaultValue={preview.suggestedName}
-                pattern="[a-z0-9][a-z0-9-]*"
-                className="block h-11 w-full rounded-md border border-line px-3 font-mono text-[13px] text-ink focus:border-accent focus:outline-none"
-              />
-            </label>
-            <button
-              type="submit"
-              disabled={busy}
-              className={`${buttonClasses("primary")} min-h-11`}
-            >
-              {busy ? "Publishing…" : "Publish to the workspace"}
-            </button>
+            {/* A publish re-fetches the repo at the pinned commit and writes — the slowest act
+                on this page, and the name is what it writes under. */}
+            <BusyFields busy={busy} className="flex items-end gap-2">
+              <label className="block flex-1">
+                <span className="mb-1 block font-medium text-dim text-sm">Publish as</span>
+                <input
+                  type="text"
+                  name="name"
+                  required
+                  defaultValue={preview.suggestedName}
+                  pattern="[a-z0-9][a-z0-9-]*"
+                  className="block h-11 w-full rounded-md border border-line px-3 font-mono text-[13px] text-ink focus:border-accent focus:outline-none"
+                />
+              </label>
+              <button type="submit" className={`${buttonClasses("primary")} min-h-11`}>
+                {flying === "publish" ? "Publishing…" : "Publish to the workspace"}
+              </button>
+            </BusyFields>
           </Form>
         )}
       </Card>

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -8,9 +8,8 @@ import {
   redirect,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from "react-router";
-import { buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses } from "@/components/ui";
 import { composition } from "@/composition.server";
 import {
   actorFromSession,
@@ -32,6 +31,7 @@ import {
   workspaceByName,
 } from "@/lib/db/identity.server";
 import { membershipsFor } from "@/lib/db/queries.server";
+import { useSubmittingIntent } from "@/lib/pending";
 import { allowVerifyLookup } from "@/lib/rate-limit.server";
 
 export const meta: MetaFunction = () => [{ title: "Approve a login · Topos" }];
@@ -398,25 +398,27 @@ export default function VerifyPage() {
 
 /** State one: the code form — a POST, so the code never lands in a URL. */
 function CodeLookup() {
-  const busy = useNavigation().state !== "idle";
+  const busy = useSubmittingIntent() !== null;
   return (
-    <Form method="post" className="flex items-end gap-2">
+    <Form method="post">
       <input type="hidden" name="intent" value="lookup" />
-      <label className="block flex-1">
-        <span className="mb-1 block font-medium text-dim text-sm">Code</span>
-        <input
-          type="text"
-          name="code"
-          required
-          autoComplete="off"
-          spellCheck={false}
-          className={`${INPUT} font-mono uppercase`}
-          placeholder="AB29-CD34"
-        />
-      </label>
-      <button type="submit" disabled={busy} className={`${buttonClasses("quiet")} min-h-11`}>
-        Look up
-      </button>
+      <BusyFields busy={busy} className="flex items-end gap-2">
+        <label className="block flex-1">
+          <span className="mb-1 block font-medium text-dim text-sm">Code</span>
+          <input
+            type="text"
+            name="code"
+            required
+            autoComplete="off"
+            spellCheck={false}
+            className={`${INPUT} font-mono uppercase`}
+            placeholder="AB29-CD34"
+          />
+        </label>
+        <button type="submit" className={`${buttonClasses("quiet")} min-h-11`}>
+          {busy ? "Looking up…" : "Look up"}
+        </button>
+      </BusyFields>
     </Form>
   );
 }
@@ -434,8 +436,10 @@ interface ResolvedCard extends PendingLoginFlowView {
  * lookup input held.
  */
 function PendingRequest({ card, loopback }: { card: ResolvedCard; loopback: Loopback | null }) {
-  const navigation = useNavigation();
-  const submitting = navigation.state !== "idle";
+  // WHICH arm is on the wire — both disable together (one decision per request), but only the one
+  // that was clicked names its wait. Without this the approve button read "Working…" for a deny.
+  const flying = useSubmittingIntent();
+  const submitting = flying !== null;
   const passThrough = (
     <>
       {loopback !== null && (
@@ -488,7 +492,7 @@ function PendingRequest({ card, loopback }: { card: ResolvedCard; loopback: Loop
           disabled={submitting}
           className={`${buttonClasses("primary")} min-h-11 w-full`}
         >
-          {submitting ? "Working…" : `Approve “${card.requestedName}”`}
+          {flying === "approve" ? "Approving…" : `Approve “${card.requestedName}”`}
         </button>
       </Form>
       <Form method="post">
@@ -500,7 +504,7 @@ function PendingRequest({ card, loopback }: { card: ResolvedCard; loopback: Loop
           disabled={submitting}
           className={`${buttonClasses("danger")} min-h-11 w-full`}
         >
-          Deny — this isn’t me
+          {flying === "deny" ? "Denying…" : "Deny — this isn’t me"}
         </button>
       </Form>
     </div>

--- a/web/app/routes/workspace-new.tsx
+++ b/web/app/routes/workspace-new.tsx
@@ -12,12 +12,13 @@ import {
   useLocation,
   useNavigation,
 } from "react-router";
-import { buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
+import { BusyFields, buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
 import { actorFromSession, notFound, requireSession, safeNextPath } from "@/lib/auth/guards.server";
 import { getAuth } from "@/lib/auth/server";
 import { announceCeremony } from "@/lib/ceremony-event";
 import { createWorkspace, workspaceNameAvailable } from "@/lib/db/workspace-create.server";
 import { destinationPathname } from "@/lib/destination-path";
+import { useSubmittingIntent } from "@/lib/pending";
 import { followBase } from "@/lib/plane/follow-base.server";
 import { isWorkspaceNameShape, toWorkspaceSlug, WORKSPACE_NAME_MAX } from "@/lib/workspace-name";
 import { wsPathServer } from "@/lib/ws-url.server";
@@ -236,6 +237,7 @@ function CreateForm({
   const checkData = check.data && "available" in check.data ? check.data : undefined;
   const forCurrent = checkData !== undefined && checkData.name === slug;
   const checking = check.state !== "idle";
+  const busy = useSubmittingIntent() !== null;
 
   function onDisplayNameChange(value: string) {
     setDisplayName(value);
@@ -260,54 +262,59 @@ function CreateForm({
           <span id="create-workspace-heading">Name it</span>
         </SectionHeading>
         <Card className="space-y-4 px-4 py-4">
-          <Form method="post" className="space-y-4">
+          <Form method="post">
             {next !== null && <input type="hidden" name="next" value={next} />}
-            <label className="block">
-              <span className="mb-1 block font-medium text-dim text-sm">Workspace name</span>
-              <input
-                type="text"
-                name="displayName"
-                required
-                autoComplete="off"
-                spellCheck={false}
-                placeholder="Acme Engineering"
-                maxLength={100}
-                value={displayName}
-                onChange={(e) => onDisplayNameChange(e.target.value)}
-                className={INPUT}
-              />
-            </label>
+            {/* The create is one transaction (workspace + default channel + owner seat + audit)
+                and lands by REDIRECT into the new workspace, so the wait spans both. The
+                availability probe is a FETCHER, never navigation state — it can't dim the form. */}
+            <BusyFields busy={busy} className="space-y-4">
+              <label className="block">
+                <span className="mb-1 block font-medium text-dim text-sm">Workspace name</span>
+                <input
+                  type="text"
+                  name="displayName"
+                  required
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="Acme Engineering"
+                  maxLength={100}
+                  value={displayName}
+                  onChange={(e) => onDisplayNameChange(e.target.value)}
+                  className={INPUT}
+                />
+              </label>
 
-            <label className="block">
-              <span className="mb-1 block font-medium text-dim text-sm">Address</span>
-              <input
-                type="text"
-                name="slug"
-                required
-                autoComplete="off"
-                spellCheck={false}
-                placeholder="acme-engineering"
-                pattern="[a-z0-9][a-z0-9-]*"
-                maxLength={WORKSPACE_NAME_MAX}
-                value={slug}
-                onChange={(e) => onSlugChange(e.target.value)}
-                className={`${INPUT} font-mono`}
-              />
-              <AddressStatus
-                slug={slug}
-                origin={origin}
-                checking={checking}
-                available={forCurrent ? checkData?.available : undefined}
-              />
-            </label>
+              <label className="block">
+                <span className="mb-1 block font-medium text-dim text-sm">Address</span>
+                <input
+                  type="text"
+                  name="slug"
+                  required
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="acme-engineering"
+                  pattern="[a-z0-9][a-z0-9-]*"
+                  maxLength={WORKSPACE_NAME_MAX}
+                  value={slug}
+                  onChange={(e) => onSlugChange(e.target.value)}
+                  className={`${INPUT} font-mono`}
+                />
+                <AddressStatus
+                  slug={slug}
+                  origin={origin}
+                  checking={checking}
+                  available={forCurrent ? checkData?.available : undefined}
+                />
+              </label>
 
-            <button
-              type="submit"
-              disabled={slug.length === 0 || displayName.trim().length === 0}
-              className={`${buttonClasses("primary")} min-h-11`}
-            >
-              Create workspace
-            </button>
+              <button
+                type="submit"
+                disabled={slug.length === 0 || displayName.trim().length === 0}
+                className={`${buttonClasses("primary")} min-h-11`}
+              >
+                {busy ? "Creating…" : "Create workspace"}
+              </button>
+            </BusyFields>
           </Form>
 
           {actionData !== undefined && actionData.error.length > 0 && (

--- a/web/tests/e2e/form-pending.spec.ts
+++ b/web/tests/e2e/form-pending.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+import { gotoSettled } from "./sign-in";
+
+/**
+ * In-flight state must be scoped to the form's OWN submission. `useNavigation()` reports every
+ * navigation on the page — a sidebar link, a breadcrumb, the header's own "All channels" — so a
+ * form keyed on a bare `state !== "idle"` goes inert and claims to be working while you are
+ * merely leaving. `useSubmittingIntent()` scopes it to a POST.
+ */
+
+test("leaving the page does not make the create form claim it is working", async ({ page }) => {
+  await gotoSettled(page, "/channels/new");
+
+  const name = page.getByLabel("Channel name");
+  const create = page.getByRole("button", { name: "Create channel" });
+  await expect(create).toBeVisible();
+
+  // Hold the destination's loader so the departing navigation is observable while THIS page,
+  // and its form, are still mounted.
+  let release: () => void = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route("**/channels.data*", async (route) => {
+    await held;
+    await route.continue();
+  });
+
+  await page.getByRole("link", { name: "All channels" }).click();
+
+  // Mid-navigation the form is untouched: nothing of ours is on the wire.
+  await expect(create).toBeVisible();
+  await expect(create).toBeEnabled();
+  await expect(name).toBeEnabled();
+
+  release();
+  await page.waitForURL(/\/channels$/);
+});
+
+/** A fresh, charset-legal channel name — the create lands for real, so it must not collide. */
+function uniqueChannelName(): string {
+  return `pending-probe-${Date.now().toString(36)}`;
+}
+
+test("submitting the create form does mark it in flight", async ({ page }) => {
+  await gotoSettled(page, "/channels/new");
+
+  const channel = uniqueChannelName();
+  const name = page.getByLabel("Channel name");
+  await name.fill(channel);
+
+  let release: () => void = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // The form posts to its own route; hold the action so the in-flight frame is observable.
+  await page.route("**/channels/new*", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    await held;
+    await route.continue();
+  });
+
+  await page.getByRole("button", { name: "Create channel" }).click();
+
+  await expect(page.getByRole("button", { name: "Creating…" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Creating…" })).toBeDisabled();
+  await expect(name).toBeDisabled();
+
+  release();
+  // A landed create redirects onto the new channel — the wait spans the POST and that navigation.
+  await page.waitForURL(new RegExp(`/channels/${channel}$`));
+});

--- a/web/tests/e2e/login-pending.spec.ts
+++ b/web/tests/e2e/login-pending.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The sign-in page must never look idle while it is waiting. Every rung here crosses the network
+ * before anything on screen changes — the magic link is an SMTP round-trip, a password is a
+ * deliberate slow hash — so without an in-flight state the click reads as "nothing happened" and
+ * the obvious next move is to click again.
+ *
+ * Each test HOLDS the auth request open (a route handler that resolves only when the assertions
+ * are done) so the in-flight frame is observable at all, then releases it. The suite runs
+ * MAIL-ARMED, so the OSS composition arms the magic-link rung and `/login` leads with it — the
+ * password rung sits behind the quiet "Sign in with a password instead" toggle.
+ *
+ * These run SIGNED OUT: the project's storageState carries a seeded member, whom `/login` would
+ * bounce, so each test clears its context cookies first.
+ */
+
+test.beforeEach(async ({ context }) => {
+  await context.clearCookies();
+});
+
+test("the magic-link rung: the field and button go inert and the button names the wait", async ({
+  page,
+}) => {
+  await page.goto("/login");
+
+  const email = page.getByLabel("Email");
+  const submit = page.getByRole("button", { name: "Email me a sign-in link" });
+  await expect(submit).toBeEnabled();
+  await email.fill("pending-magic@e2e.test");
+
+  // Hold the send open so the in-flight frame is observable, and release it from inside the
+  // assertions below.
+  let release: () => void = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route("**/api/auth/sign-in/magic-link", async (route) => {
+    await held;
+    await route.continue();
+  });
+
+  await submit.click();
+
+  // The whole point: mid-flight the page SAYS it is working, and cannot be submitted again.
+  await expect(page.getByRole("button", { name: "Sending the link…" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sending the link…" })).toBeDisabled();
+  await expect(email).toBeDisabled();
+
+  release();
+  // …and the wait resolves into the sent card.
+  await expect(page.getByText("Check your email")).toBeVisible();
+});
+
+test("the password rung: both fields and the button go inert while the credential is checked", async ({
+  page,
+}) => {
+  await page.goto("/login");
+  // Magic link leads when mail is armed; the password rung is the quiet alternative under it.
+  await page.getByRole("button", { name: "Sign in with a password instead" }).click();
+
+  const email = page.getByLabel("Email");
+  const password = page.getByLabel("Password");
+  await email.fill("pending-password@e2e.test");
+  await password.fill("e2e-password-1234");
+
+  let release: () => void = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route("**/api/auth/sign-in/email", async (route) => {
+    await held;
+    await route.continue();
+  });
+
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+
+  await expect(page.getByRole("button", { name: "Signing in…" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Signing in…" })).toBeDisabled();
+  await expect(email).toBeDisabled();
+  await expect(password).toBeDisabled();
+  // The rung switch is inert too — flipping the form out from under a live request would strand it.
+  await expect(page.getByRole("button", { name: /sign-in link instead/i })).toBeDisabled();
+
+  release();
+  // This address has no account, so the answer is the page's one constant refusal — and the form
+  // comes back ARMED, so a corrected password can be tried immediately.
+  await expect(page.getByRole("alert")).toContainText("Couldn’t sign in");
+  await expect(email).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Sign in", exact: true })).toBeEnabled();
+});
+
+test("a request that never completes re-arms the form instead of locking it", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill("offline@e2e.test");
+
+  // Better Auth's client REJECTS on a transport failure (it returns `{ error }` only for
+  // answers the server gave), and a rejection that skipped the re-arm would leave every
+  // control inside the disabled fieldset stuck until a reload.
+  await page.route("**/api/auth/sign-in/magic-link", (route) => route.abort("failed"));
+
+  const email = page.getByLabel("Email");
+  await page.getByRole("button", { name: "Email me a sign-in link" }).click();
+
+  await expect(page.getByRole("alert")).toContainText("Couldn’t reach the server");
+  await expect(email).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Email me a sign-in link" })).toBeEnabled();
+  // The rung switch comes back too — the whole card re-arms, not just the field that failed.
+  await expect(page.getByRole("button", { name: "Sign in with a password instead" })).toBeEnabled();
+});
+
+test("a second click during the send cannot post the magic link twice", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill("double-click@e2e.test");
+
+  let sends = 0;
+  let release: () => void = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route("**/api/auth/sign-in/magic-link", async (route) => {
+    sends += 1;
+    await held;
+    await route.continue();
+  });
+
+  const submit = page.getByRole("button", { name: "Email me a sign-in link" });
+  await submit.click();
+  const sending = page.getByRole("button", { name: "Sending the link…" });
+  await expect(sending).toBeDisabled();
+  // A disabled button swallows the click; assert the request count, not just the attribute.
+  await sending.click({ force: true, trial: false }).catch(() => {});
+
+  release();
+  await expect(page.getByText("Check your email")).toBeVisible();
+  expect(sends).toBe(1);
+});


### PR DESCRIPTION
Signing in with a mailed link did nothing visible for the length of an SMTP round-trip and then swapped the card for "check your email". The click looked like it had missed; the only thing left to try was clicking again.

## The shape of the fix

`BusyFields` (`app/components/ui.tsx`) — a native `<fieldset disabled>` wrapper, so a form's controls go inert in one attribute, no per-field bookkeeping. `useSubmittingIntent()` (`app/lib/pending.ts`) — the navigation-driven half, scoped to the form's own POST and carrying the submitted `intent` so a route serving several arms names the wait for the arm that was clicked.

The submit button keeps its pending label readable while the fields dim; a disabled fieldset's inputs get the inert look from one rule in `app.css`.

## What changed

**Sign-in** carried the reported bug and gets the most. One busy state across all three rungs — starting Google mid-magic-link would race two sign-ins against one page — and only the rung on the wire changes its label. A rejected call (offline, connection reset) re-arms the card: Better Auth's client throws rather than answering there, and a busy state left set behind disabled fields is a page you can only escape by reloading.

**Three forms had no in-flight state at all:** the claim ceremony, the recovery hatch, and the channel create. The last was a bare `<form>`, so its submit was invisible to the router — it becomes a `<Form>`. Both single-use-code pages could spend their code on a second click and then report that the code did not work.

**Several arms sharing one navigation or one fetcher** now key their label on which intent or row is in flight — the invitation page, the login-approval card, the profile rows, the skill import. Approve used to read "Working…" when you clicked Deny. The profile channel toggle had no in-flight state at all.

## Verification

- 5 rounds of codex review; 4 issues found and fixed at root (rejected-call lockout, skill-import intent collision, an unwrapped publish field, unscoped navigation state). Final round clean.
- New e2e: `login-pending.spec.ts` (4) + `form-pending.spec.ts` (2). Each was checked against the unfixed code and fails there — the pending assertions, the re-arm-on-rejection, and the leaving-the-page-is-not-a-submit case all go red without their fix.
- `bun run check` · vitest 585 · Playwright 130 · `cargo xtask ci` — all green.
- Idle vs in-flight compared visually on the sign-in card; the restructured flex forms (channel create, members invite, skill import, verify) checked for layout drift — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)