### PR TITLE
docs: rewrite the README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ its next session — Claude Code, Cursor, Codex, and [70+ more](https://topos.sh
 When someone improves a skill while working, the improvement comes back to the team as a
 reviewable change instead of dying on their machine.
 
-A skill is a plain folder with a `SKILL.md` — the same open format the
-[skills.sh](https://skills.sh) ecosystem already uses. Underneath is a git repo: every version
-is kept, any update can be rolled back, and you can take everything and leave at any time.
+Underneath is a git repo: every version is kept, any update can be rolled back, and you can take
+everything and leave at any time.
 
 Use it with [Topos Cloud](https://topos.sh) or [self-host](#self-hosting) the whole product
 from this repository.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![CI](https://github.com/topos-sh/topos/actions/workflows/ci.yml/badge.svg)](https://github.com/topos-sh/topos/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-Topos keeps every AI agent in your team up to date. 
+Topos keeps every AI agent on your team up to date.
 
-It distributes skills, memory files, and other context bundles to each agent based on it's role, and lets anyone contribute improvements back.
+It distributes skills, memory files, and other context bundles to each agent based on its role, and lets anyone contribute improvements back.
 With topos you can set up and maintain useful agents for non-technical people or create a cross-project deterministic context for coding agents or create a cloud agent and update it with new behaviors on the fly.
 
 Topos knows all major harnesses: Claude Code, Cursor, Codex, OpenClaw, Hermes and [70+ more](https://topos.sh/docs/harnesses) so you / your team can use different agents.
@@ -14,11 +14,11 @@ Use it with [Topos Cloud](https://topos.sh) or [self-host](#self-hosting).
 
 ## Quickstart
 
-**1. Create a workspace** — your team's shared home for skills. Sign up at
+**1. Create a workspace** - your team's shared home for skills. Sign up at
 [topos.sh](https://topos.sh) and pick a name; your team's address is `https://topos.sh/<name>`.
-Already invited? The address is in the invitation mail — skip to step 2.
+Already invited? The address is in the invitation mail - skip to step 2.
 
-**2. Set up.** Paste this to the agent you already use — it installs the CLI and logs in, and
+**2. Set up.** Paste this to the agent you already use - it installs the CLI and logs in, and
 the one browser approval stays yours:
 
 ```text
@@ -35,8 +35,8 @@ topos login https://topos.sh/acme
 That is the whole setup: this machine receives everything the workspace has for you, and
 updates apply silently at the start of each agent session.
 
-**3. Share a skill.** Point `publish` at any skill folder you already have — here, a Claude
-Code one. A bare run is a preview — it prints what would happen and changes nothing; `--yes`
+**3. Share a skill.** Point `publish` at any skill folder you already have - here, a Claude
+Code one. A bare run is a preview - it prints what would happen and changes nothing; `--yes`
 applies it:
 
 ```sh
@@ -45,7 +45,7 @@ topos publish pr-describe --yes
 ```
 
 The skill is now the team's: one name, one history, one version everyone gets. Every teammate's
-machine picks it up on its own — they run nothing.
+machine picks it up on its own - they run nothing.
 
 **4. Bring the team in.**
 
@@ -58,7 +58,7 @@ The invitation mail carries everything they need, including a line to paste to t
 
 ## Everyday use
 
-The CLI is built for agents to drive, not for hands — using it directly works, but can be
+The CLI is built for agents to drive, not for hands - using it directly works, but can be
 frustrating. Agents already know it: the built-in `topos` skill lands in their skills
 directories at setup. So tell your agent what you want and let it run the commands. The goal is
 for Topos to be invisible: all of this happens while everyone just works. In the flows below,
@@ -68,7 +68,7 @@ for Topos to be invisible: all of this happens while everyone just works. In the
 
 Dana in sales never opens a terminal, but her agent could be doing her CRM follow-ups. Your
 team's `sales` channel carries the CRM skills (channels are created in the browser). Invite
-her — from the workspace's Members page in the browser, or:
+her - from the workspace's Members page in the browser, or:
 
 ```sh
 # Ask your agent: "Invite dana@acme.com and set her up with our sales skills."
@@ -81,24 +81,24 @@ The mail she receives carries one line for her agent, and she pastes it:
 Set up Topos for us: fetch https://topos.sh/agent and follow it. Our invite: https://topos.sh/acme/invite/…
 ```
 
-Her agent installs the CLI, joins the workspace, and subscribes her to `sales` — one browser
+Her agent installs the CLI, joins the workspace, and subscribes her to `sales` - one browser
 visit is hers: create her account, then approve the machine. The channel's skills are on her
 machine before her next session.
 
 Later the CRM changes, so you update the skill in the channel:
 
 ```sh
-# Ask your agent: "The CRM adds a discount field — update crm-follow-up."
+# Ask your agent: "The CRM adds a discount field - update crm-follow-up."
 topos publish crm-follow-up -m "Fill the new discount field" --yes
 ```
 
-At Dana's next session her agent already works the new way — she did nothing, and you never
+At Dana's next session her agent already works the new way - she did nothing, and you never
 touched her machine. Protect the skill, and her agent's improvements come back as proposals
 you approve.
 
 ### Pin a project's skills
 
-A backend team wants every agent working in its repo — teammates' and CI's — on the same
+A backend team wants every agent working in its repo - teammates' and CI's - on the same
 skills:
 
 ```sh
@@ -110,7 +110,7 @@ topos add vercel-labs/skills/find-skills --yes
 ```
 
 The `--yes` confirms a GitHub source this machine has not used before. The commands install the
-skills and write `topos.toml` at the repo root — commit it, and every machine in the checkout
+skills and write `topos.toml` at the repo root - commit it, and every machine in the checkout
 converges on the same set. The entries it adds:
 
 ```toml
@@ -120,7 +120,7 @@ converges on the same set. The entries it adds:
 "github.com/vercel-labs/skills/find-skills" = "*"      # tracks the repo; moves on `topos update`
 ```
 
-One command refreshes every skill on the machine — agents with hooks run it themselves at
+One command refreshes every skill on the machine - agents with hooks run it themselves at
 session start ([which agents](https://topos.sh/docs/harnesses)):
 
 ```sh
@@ -129,11 +129,11 @@ topos update
 
 ### Roll out an internal tool change company-wide
 
-The internal customer-lookup service ships v2 — new endpoints, token auth. One publish updates
+The internal customer-lookup service ships v2 - new endpoints, token auth. One publish updates
 every agent that carries the skill:
 
 ```sh
-# Ask your agent: "Our customer-lookup API moved to v2 — update the skill and roll it out."
+# Ask your agent: "Our customer-lookup API moved to v2 - update the skill and roll it out."
 topos publish customer-lookup -m "v2 endpoints, token auth" --yes
 ```
 
@@ -152,7 +152,7 @@ topos revert customer-lookup --to <version> --yes
 
 ### Keep a cloud agent current
 
-A scheduled agent triages new support tickets every night — labels them, routes escalations —
+A scheduled agent triages new support tickets every night - labels them, routes escalations -
 with no human at the keyboard. Enroll it once, somewhere `~/.topos` persists (the login is one
 browser approval):
 
@@ -161,7 +161,7 @@ curl -fsSL https://topos.sh/install | sh
 topos login https://topos.sh/acme
 ```
 
-Still on that machine, provision it with its skill and a dedicated channel — anything the team
+Still on that machine, provision it with its skill and a dedicated channel - anything the team
 later places in that channel reaches this agent too:
 
 ```sh
@@ -176,11 +176,11 @@ Every run then starts with a refresh:
 topos update
 ```
 
-From here its behavior is steered from anywhere, live at the next run — no redeploy. One way:
+From here its behavior is steered from anywhere, live at the next run - no redeploy. One way:
 update a skill it carries:
 
 ```sh
-# Ask your agent: "Triage keeps missing escalations — fix the ticket-triage skill."
+# Ask your agent: "Triage keeps missing escalations - fix the ticket-triage skill."
 topos publish ticket-triage -m "Escalate anything from enterprise accounts" --yes
 ```
 
@@ -192,13 +192,13 @@ topos publish dedupe-tickets --to triage-bot --yes
 ```
 
 One rule across all commands: anything that reaches other people, throws away local work, or
-adds from a GitHub repository you have not used before previews first — a bare run prints what
+adds from a GitHub repository you have not used before previews first - a bare run prints what
 would change and changes nothing, and `--yes` applies it. Everything else applies immediately
 and prints an undo command. Agents use the same commands with `--json`, which never prompts.
 
 ## Docs
 
-**[topos.sh/docs](https://topos.sh/docs)** — quickstart, getting skills, publishing, review,
+**[topos.sh/docs](https://topos.sh/docs)** - quickstart, getting skills, publishing, review,
 running a team, self-hosting, and the full
 [CLI reference](https://topos.sh/docs/cli). Written for humans and agents alike:
 every page is also plain markdown at its URL + `.md`, [topos.sh/agent](https://topos.sh/agent)
@@ -210,7 +210,7 @@ directories already covers what Topos is, the commands, and when to offer sharin
 back. If your repo has an `AGENTS.md`, one line routing agents to that skill is enough:
 
 ```md
-Team skills here are managed by topos — read the `topos` skill before working with them (not installed? https://topos.sh/agent).
+Team skills here are managed by topos - read the `topos` skill before working with them (not installed? https://topos.sh/agent).
 ```
 
 ## Self-hosting
@@ -226,22 +226,22 @@ docker compose up -d --build
 ```
 
 The two secrets are required even for a laptop try-out. Open `http://localhost:3000` in a
-browser — the first browser visit creates the workspace and prints a one-time setup link to the
+browser - the first browser visit creates the workspace and prints a one-time setup link to the
 logs:
 
 ```sh
 docker compose logs web | grep 'Finish setup:'
 ```
 
-Open that link and create the first account — it makes you the owner. Then connect a machine
+Open that link and create the first account - it makes you the owner. Then connect a machine
 and use it exactly like the quickstart above:
 
 ```sh
 topos login http://localhost:3000
 ```
 
-That is a complete single-team install. For a real deployment — reverse proxy and TLS, mail for
-invitations, upgrades, backups, your own Postgres — follow the guide:
+That is a complete single-team install. For a real deployment - reverse proxy and TLS, mail for
+invitations, upgrades, backups, your own Postgres - follow the guide:
 [topos.sh/docs/self-host](https://topos.sh/docs/self-host).
 
 ## Contributing
@@ -251,5 +251,5 @@ Build and test instructions are in [`CONTRIBUTING.md`](CONTRIBUTING.md); the des
 
 ## License
 
-Apache-2.0 — see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE). No CLA; contributions are under
+Apache-2.0 - see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE). No CLA; contributions are under
 the same license.

--- a/README.md
+++ b/README.md
@@ -3,17 +3,14 @@
 [![CI](https://github.com/topos-sh/topos/actions/workflows/ci.yml/badge.svg)](https://github.com/topos-sh/topos/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-Topos keeps every AI agent on your team up to date. Publish a skill once (the deploy checklist,
-the code-review standard, the release process) and every teammate's agent has it at the start of
-its next session — Claude Code, Cursor, Codex, and [70+ more](https://topos.sh/docs/harnesses).
-When someone improves a skill while working, the improvement comes back to the team as a
-reviewable change instead of dying on their machine.
+Topos keeps every AI agent in your team up to date. 
 
-Underneath is a git repo: every version is kept, any update can be rolled back, and you can take
-everything and leave at any time.
+It distributes skills, memory files, and other context bundles to each agent based on it's role, and lets anyone contribute improvements back.
+With topos you can set up and maintain useful agents for non-technical people or create a cross-project deterministic context for coding agents or create a cloud agent and update it with new behaviors on the fly.
 
-Use it with [Topos Cloud](https://topos.sh) or [self-host](#self-hosting) the whole product
-from this repository.
+Topos knows all major harnesses: Claude Code, Cursor, Codex, OpenClaw, Hermes and [70+ more](https://topos.sh/docs/harnesses) so you / your team can use different agents.
+
+Use it with [Topos Cloud](https://topos.sh) or [self-host](#self-hosting).
 
 ## Quickstart
 


### PR DESCRIPTION
Reworks the README opening (authored by @robertkrajewski, committed from this branch).

- Leads with distribution: skills, memory files, and other context bundles routed to each agent by role, with contribution back.
- Adds the use-case sentence (non-technical people / cross-project coding context / cloud agents updated on the fly).
- Names harness breadth up front (Claude Code, Cursor, Codex, OpenClaw, Hermes, 70+ more) — all verified present in `crates/topos-harness/`.
- Drops the `A skill is a plain folder with a SKILL.md …` sentence and the git-repo paragraph.

Two commits: the original single-sentence removal, then the full rewrite on top. Squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)