### PR TITLE
Put a price on the landing page

### DIFF
--- a/web/app/components/landing/landing-page.tsx
+++ b/web/app/components/landing/landing-page.tsx
@@ -5,6 +5,7 @@ import { FounderAddressBlock } from "@/components/landing/founder-email";
 import { HarnessMark, hasHarnessMark } from "@/components/landing/harness-marks";
 import { MicroLabel, SectionHeading, WRAP } from "@/components/landing/landing-kit";
 import { LoopBands } from "@/components/landing/loop-bands";
+import { PricingBand } from "@/components/landing/pricing-band";
 import { RoutingStar } from "@/components/landing/routing-star";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -364,6 +365,9 @@ export function LandingPage({
             <a href="#demo" className="transition-colors hover:text-ink max-sm:hidden">
               How it works
             </a>
+            <a href="#pricing" className="transition-colors hover:text-ink max-sm:hidden">
+              Pricing
+            </a>
             <a href="#faq" className="transition-colors hover:text-ink max-sm:hidden">
               FAQ
             </a>
@@ -491,6 +495,8 @@ export function LandingPage({
 
       <LoopBands rail={FLEET_RAIL} />
 
+      <PricingBand ctaTo={ctaTo} ctaLabel={ctaLabel} docsHref={DOCS} />
+
       <section id="faq" className="pt-[84px] lg:pt-[116px]">
         <div className={WRAP}>
           <MicroLabel>FAQ</MicroLabel>
@@ -508,7 +514,7 @@ export function LandingPage({
         </div>
       </section>
 
-      <section className="pt-[84px] lg:pt-[116px]">
+      <section id="contact" className="pt-[84px] lg:pt-[116px]">
         <div className={WRAP}>
           <MicroLabel>Design partners</MicroLabel>
           <SectionHeading>Setting this up for a team? Email me.</SectionHeading>

--- a/web/app/components/landing/landing-page.tsx
+++ b/web/app/components/landing/landing-page.tsx
@@ -497,6 +497,24 @@ export function LandingPage({
 
       <PricingBand ctaTo={ctaTo} ctaLabel={ctaLabel} docsHref={DOCS} />
 
+      {/* Directly under pricing, so the Enterprise arm's "Talk to us" lands on the next screen
+          rather than past the FAQ. It opens on its heading — no micro-label — which is what marks
+          it as the page's one personal address rather than another catalogued band. */}
+      <section id="contact" className="pt-[84px] lg:pt-[116px]">
+        <div className={WRAP}>
+          <SectionHeading>Setting this up for a team? Email me.</SectionHeading>
+          <p className="mt-4 max-w-[62ch] text-dim">
+            Topos is in closed beta and I set up the first teams personally. Tell me how your team
+            works with agents and I’ll get your first shared skills flowing, and your feedback
+            shapes what gets built next.
+          </p>
+          <p className="mt-3 text-[13px] text-faint">Robert, founder</p>
+          <div className="mt-5">
+            <FounderAddressBlock />
+          </div>
+        </div>
+      </section>
+
       <section id="faq" className="pt-[84px] lg:pt-[116px]">
         <div className={WRAP}>
           <MicroLabel>FAQ</MicroLabel>
@@ -511,22 +529,6 @@ export function LandingPage({
               </div>
             ))}
           </dl>
-        </div>
-      </section>
-
-      <section id="contact" className="pt-[84px] lg:pt-[116px]">
-        <div className={WRAP}>
-          <MicroLabel>Design partners</MicroLabel>
-          <SectionHeading>Setting this up for a team? Email me.</SectionHeading>
-          <p className="mt-4 max-w-[62ch] text-dim">
-            Topos is in closed beta and I set up the first teams personally. Tell me how your team
-            works with agents and I’ll get your first shared skills flowing, and your feedback
-            shapes what gets built next.
-          </p>
-          <p className="mt-3 text-[13px] text-faint">Robert, founder</p>
-          <div className="mt-5">
-            <FounderAddressBlock />
-          </div>
         </div>
       </section>
 

--- a/web/app/components/landing/pricing-band.tsx
+++ b/web/app/components/landing/pricing-band.tsx
@@ -1,0 +1,170 @@
+import { Link } from "react-router";
+import { MicroLabel, SectionHeading, WRAP } from "@/components/landing/landing-kit";
+
+/**
+ * The pricing band: three tiers standing on three steps of the neutral ramp, so the hierarchy is
+ * carried by the paper rather than by colour. The free self-hosted tier sits at GROUND level — an
+ * outline on the page, not a card raised off it — which keeps it present and honest without
+ * competing for the eye; the hosted tier is the only one raised onto `panel` with the card shadow,
+ * and it holds the band's two placed objects: the chip and the one accent button.
+ *
+ * A seat is a person, not a machine and not an agent: the number a buyer can count without
+ * inspecting anything.
+ */
+
+type Surface = "ground" | "panel" | "lead";
+
+type Tier = {
+  label: string;
+  price: string;
+  /** The unit, set beside the figure at body weight so the number keeps the display voice. */
+  per: string;
+  desc: string;
+  feats: string[];
+  surface: Surface;
+};
+
+const TIERS: Tier[] = [
+  {
+    label: "Self-hosted",
+    price: "$0",
+    per: "forever",
+    desc: "Apache-2.0. Your machines, your git, your data. Unlimited people.",
+    feats: [
+      "The complete product",
+      "Unlimited skills and versions",
+      "Contribute-back review",
+      "Community support",
+    ],
+    surface: "ground",
+  },
+  {
+    label: "Team",
+    price: "$20",
+    per: "/ seat / month",
+    desc: "Hosted by us. Nothing to run, nothing to keep patched.",
+    feats: [
+      "Everything in self-hosted",
+      "Hosted plane, backed up",
+      "Fleet visibility and one-click revert",
+      "Email support",
+    ],
+    surface: "lead",
+  },
+  {
+    label: "Enterprise",
+    price: "$40",
+    per: "/ seat / month",
+    desc: "For companies that need the paperwork to line up.",
+    feats: [
+      "Everything in Team",
+      "SSO and SCIM provisioning",
+      "Audit export and retention",
+      "SLA and priority support",
+    ],
+    surface: "panel",
+  },
+];
+
+/** Three card shells, one per step of the ramp. Written out so the cascade stays readable. */
+const SHELL: Record<Surface, string> = {
+  ground: "border-line-soft bg-ground p-6",
+  panel: "border-line-soft bg-panel p-6",
+  lead: "border-line bg-panel p-7 shadow-card",
+};
+
+const BUTTON_BASE =
+  "mt-6 inline-flex h-9 items-center justify-center rounded-md font-mono text-[12.5px] transition-colors focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 active:scale-[0.98]";
+const BUTTON_PRIMARY = `${BUTTON_BASE} bg-accent text-on-accent hover:bg-accent-deep`;
+const BUTTON_QUIET = `${BUTTON_BASE} border border-line bg-panel text-dim hover:bg-panel2`;
+/** On the ground card the quiet button drops its fill too, or it reads as the raised one. */
+const BUTTON_QUIET_ON_GROUND = `${BUTTON_BASE} border border-line-soft text-dim hover:bg-panel`;
+
+function Figure({ price, per }: { price: string; per: string }) {
+  return (
+    <p className="mt-4 font-display font-semibold text-[27px] text-ink tracking-[-0.03em] tabular-nums">
+      {price}
+      <span className="ml-1.5 font-normal font-sans text-[13px] text-faint tracking-normal">
+        {per}
+      </span>
+    </p>
+  );
+}
+
+export function PricingBand({
+  ctaTo,
+  ctaLabel,
+  docsHref,
+}: {
+  /** Where the hosted tier's primary action goes — the page's own tenancy-aware target. */
+  ctaTo: string;
+  ctaLabel: string;
+  docsHref: string;
+}) {
+  return (
+    <section id="pricing" className="pt-[84px] lg:pt-[116px]">
+      <div className={WRAP}>
+        <MicroLabel>Pricing</MicroLabel>
+        <SectionHeading className="max-w-[44ch]">
+          Free to run yourself. Paid when you want it hosted.
+        </SectionHeading>
+        <p className="mt-4 max-w-[58ch] text-dim">
+          A seat is anyone who works with an AI agent. Skills, versions, history and contribute-back
+          are unlimited on every tier.
+        </p>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-3">
+          {TIERS.map((tier) => (
+            <div
+              key={tier.label}
+              className={`flex flex-col rounded-lg border ${SHELL[tier.surface]}`}
+            >
+              <div className="flex min-h-[22px] items-center justify-between gap-2.5">
+                <MicroLabel>{tier.label}</MicroLabel>
+                {tier.surface === "lead" && (
+                  <span className="rounded-full bg-accent px-2.5 py-[3px] font-display font-medium text-[10px] text-on-accent uppercase leading-[1.2] tracking-[0.12em]">
+                    Most teams
+                  </span>
+                )}
+              </div>
+
+              <Figure price={tier.price} per={tier.per} />
+
+              <p className="mt-3 min-h-[40px] text-[13.5px] text-faint leading-[1.5]">
+                {tier.desc}
+              </p>
+
+              <ul className="mt-4 flex flex-col">
+                {tier.feats.map((feat) => (
+                  <li
+                    key={feat}
+                    className="border-line-soft border-t py-[9px] text-[14px] text-dim first:border-t-0"
+                  >
+                    {feat}
+                  </li>
+                ))}
+              </ul>
+
+              {/* The action sits on the card's floor, so three cards of unequal copy still line up. */}
+              <div className="mt-auto flex flex-col">
+                {tier.surface === "lead" ? (
+                  <Link to={ctaTo} className={BUTTON_PRIMARY}>
+                    {ctaLabel}
+                  </Link>
+                ) : tier.surface === "ground" ? (
+                  <a href={`${docsHref}/install`} className={BUTTON_QUIET_ON_GROUND}>
+                    Read the install guide
+                  </a>
+                ) : (
+                  <a href="#contact" className={BUTTON_QUIET}>
+                    Talk to us
+                  </a>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/tests/e2e/landing.spec.ts
+++ b/web/tests/e2e/landing.spec.ts
@@ -84,18 +84,35 @@ test.describe("the public landing page", () => {
       page.getByText("Use sentence case for headings. No exclamation points."),
     ).toBeVisible();
 
-    // 6 — the FAQ, fully visible text (no accordion): six questions, six answers on the page.
+    // 6 — the pricing band: three tiers, the seat definition, and the one accent CTA. The tier
+    // figures are asserted as text because the hierarchy between the three cards is carried by the
+    // neutral ramp, which the DOM does not spell.
+    const pricing = page.locator("#pricing");
+    await expect(pricing).toContainText("Self-hosted");
+    await expect(pricing).toContainText("$0");
+    await expect(pricing).toContainText("Team");
+    await expect(pricing).toContainText("$20");
+    await expect(pricing).toContainText("Enterprise");
+    await expect(pricing).toContainText("$40");
+    await expect(pricing).toContainText("A seat is anyone who works with an AI agent");
+    await expect(pricing.getByRole("link", { name: "Talk to us" })).toHaveAttribute(
+      "href",
+      "#contact",
+    );
+
+    // 7 — the FAQ, fully visible text (no accordion): six questions, six answers on the page.
     const faq = page.locator("#faq");
     await expect(faq.locator("dt")).toHaveCount(6);
     await expect(faq.locator("dd")).toHaveCount(6);
     await expect(faq.locator("dd").first()).toBeVisible();
 
-    // 7 — the founder band.
+    // 8 — the founder band, which is also the pricing band's "Talk to us" destination.
+    await expect(page.locator("#contact")).toHaveCount(1);
     await expect(
       page.getByRole("heading", { name: "Setting this up for a team? Email me." }),
     ).toBeVisible();
 
-    // 8 — the footer: the browser-path button leads its link row; no security link, no address.
+    // 9 — the footer: the browser-path button leads its link row; no security link, no address.
     const footer = page.locator("footer");
     // Two matches are legitimate in single tenancy: the primary button (/login) plus the plain
     // "Sign in" link (/app). The button is the first — assert it specifically.
@@ -120,6 +137,7 @@ test.describe("the public landing page", () => {
     await expect(page.locator("#agent")).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Why Topos" })).toHaveCount(0);
     await expect(page.getByRole("link", { name: "FAQ" })).toHaveAttribute("href", "#faq");
+    await expect(page.getByRole("link", { name: "Pricing" })).toHaveAttribute("href", "#pricing");
   });
 
   test("the founder's address is never in the served bytes, and never a mailto", async ({

--- a/web/tests/e2e/landing.spec.ts
+++ b/web/tests/e2e/landing.spec.ts
@@ -100,17 +100,29 @@ test.describe("the public landing page", () => {
       "#contact",
     );
 
-    // 7 — the FAQ, fully visible text (no accordion): six questions, six answers on the page.
+    // 7 — the founder band, the pricing band's "Talk to us" destination. It sits directly under
+    // pricing and ahead of the FAQ, and opens on its heading: no micro-label above it.
+    const contact = page.locator("#contact");
+    await expect(contact).toHaveCount(1);
+    await expect(
+      page.getByRole("heading", { name: "Setting this up for a team? Email me." }),
+    ).toBeVisible();
+    await expect(contact.getByText("Design partners")).toHaveCount(0);
+    // The order is the contract, not an accident of authoring: the band that answers the pricing
+    // CTA has to come before the FAQ, or the button jumps the reader past it.
+    const contactPrecedesFaq = await page.evaluate(() => {
+      const c = document.querySelector("#contact");
+      const f = document.querySelector("#faq");
+      if (!c || !f) return false;
+      return Boolean(c.compareDocumentPosition(f) & Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+    expect(contactPrecedesFaq).toBe(true);
+
+    // 8 — the FAQ, fully visible text (no accordion): six questions, six answers on the page.
     const faq = page.locator("#faq");
     await expect(faq.locator("dt")).toHaveCount(6);
     await expect(faq.locator("dd")).toHaveCount(6);
     await expect(faq.locator("dd").first()).toBeVisible();
-
-    // 8 — the founder band, which is also the pricing band's "Talk to us" destination.
-    await expect(page.locator("#contact")).toHaveCount(1);
-    await expect(
-      page.getByRole("heading", { name: "Setting this up for a team? Email me." }),
-    ).toBeVisible();
 
     // 9 — the footer: the browser-path button leads its link row; no security link, no address.
     const footer = page.locator("footer");


### PR DESCRIPTION
The landing page carried no price and there was no `/pricing` surface, so a visitor had no way to tell whether the hosted product costs anything. This adds the pricing band, and reorders the two bands beneath it so the band that answers the pricing CTA comes before the FAQ.

## What's here

- **`PricingBand`** — three tiers (Self-hosted `$0`, Team `$20/seat/mo`, Enterprise `$40/seat/mo`), the seat definition as the band's lede, and one accent CTA.
- **Nav** gains `Pricing` → `#pricing`, between How it works and FAQ.
- **The founder band moves above the FAQ** and gains `id="contact"` — it is the Enterprise arm's destination, and with the FAQ in between, "Talk to us" jumped the reader past six questions to reach what they had just asked for.
- **The founder band loses its "Design partners" micro-label** and opens on its heading. Every other band wears a label because each is one entry in a catalogue of what the product does; this one is a person offering to help, and labelling it filed it alongside the rest.
- The founder address is unchanged — still assembled client-side, never a `mailto`, never in the served bytes.

Band order is now: loop → **pricing** → **contact** → FAQ → footer.

## The design call

Hierarchy inside the band is carried by the neutral ramp, not by colour, so it stays quiet next to the loop above it:

| Tier | Surface | Border | Padding | Shadow |
|---|---|---|---|---|
| Self-hosted | `ground` — the page itself | `line-soft` | 24px | none |
| Enterprise | `panel` | `line-soft` | 24px | none |
| Team | `panel` | `line` | 28px | `shadow-card` |

The free tier is an outline on the paper rather than a card raised off it, so it stays present and honest without competing with the tier the page is asking for. Klein blue appears exactly twice in the band — the chip and the button — both on the raised card.

The tier CTAs resolve through the same `ctaTo`/`ctaLabel` the rest of the page already computes, so a single-tenant install renders "Sign in" where a multi-tenant one renders "Create a workspace".

## Checks

- `bun run check` green — biome, design tokens in sync (19), boundary, email-authorization, contract types, docs in sync (12 pages), typecheck.
- `bun run test:e2e -- landing.spec.ts` — **8 passed**. The spec walks the new band as its own numbered step, asserts the nav link resolves to `#pricing`, asserts the retired label is gone, and asserts the ordering itself via `compareDocumentPosition` — contact before FAQ is a contract, not an accident of authoring.
- Verified in the browser: the three cards resolve to distinct computed backgrounds (`rgb(241,241,238)` / `rgb(248,248,245)` / `rgb(248,248,245)` with the stronger border and shadow) and equal height at 432.29px; band order reads `demo` → `pricing` → `contact` → `faq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)