### PR TITLE
Docs page takes the site's width, and opens on its own markdown

### DIFF
--- a/web/app/components/docs/docs-shell.tsx
+++ b/web/app/components/docs/docs-shell.tsx
@@ -1,5 +1,7 @@
-import type { MouseEvent } from "react";
+import { CheckIcon, CopyIcon, FileTextIcon } from "lucide-react";
+import { type MouseEvent, useRef, useState } from "react";
 import { Link, NavLink } from "react-router";
+import { useCopied } from "@/components/use-copied";
 import type { DocsPageView } from "@/lib/docs/model";
 
 /**
@@ -47,6 +49,67 @@ function copyFromCodeBlock(event: MouseEvent<HTMLElement>) {
   });
 }
 
+/**
+ * Both page actions are SECONDARY — nobody arrives at a docs page to press them — so they wear no
+ * border and no field: faint mono text that inks on hover, the annotation voice the rest of the
+ * system uses for an aside. One shape for the two, so they read as a pair rather than a control
+ * and a link that happen to sit together.
+ */
+const ACTION =
+  "inline-flex shrink-0 items-center gap-1.5 rounded-sm font-mono text-[11px] text-faint transition-colors hover:text-ink focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
+
+/**
+ * The machine-readable exits, at the top of every page: COPY the markdown this page was written
+ * in, or OPEN it. Both name the same twin (`<this path>.md`), and the copy FETCHES it rather than
+ * the page shipping a second copy of its own prose — the same rule the code-block copy follows.
+ *
+ * A failed fetch or a denied clipboard leaves the button untouched rather than inventing an error
+ * surface: the link sitting beside it is the honest fallback, and it needs no script to work.
+ */
+function PageActions({ markdownPath }: { markdownPath: string }) {
+  const { copied, copy } = useCopied();
+  const [busy, setBusy] = useState(false);
+  // One flight at a time — a second click while the twin is still in the air is a no-op, not a
+  // second request.
+  const inFlight = useRef(false);
+
+  async function copyPage() {
+    if (inFlight.current) {
+      return;
+    }
+    inFlight.current = true;
+    setBusy(true);
+    try {
+      const response = await fetch(markdownPath, { headers: { accept: "text/markdown" } });
+      if (response.ok) {
+        copy(await response.text());
+      }
+    } catch {
+      // Offline or blocked: the "View as markdown" link beside this button still resolves.
+    } finally {
+      inFlight.current = false;
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1">
+      <button type="button" onClick={copyPage} className={ACTION}>
+        {copied ? (
+          <CheckIcon aria-hidden className="h-3 w-3" />
+        ) : (
+          <CopyIcon aria-hidden className="h-3 w-3" />
+        )}
+        {copied ? "copied" : busy ? "copying…" : "copy page as markdown"}
+      </button>
+      <a href={markdownPath} className={ACTION}>
+        <FileTextIcon aria-hidden className="h-3 w-3" />
+        view page as markdown
+      </a>
+    </div>
+  );
+}
+
 function DocsNav() {
   return (
     <nav className="sticky top-0 z-20 border-line-soft border-b bg-ground/95 backdrop-blur">
@@ -87,16 +150,12 @@ function DocsNav() {
   );
 }
 
-function DocsFooter({ markdownPath }: { markdownPath: string }) {
+function DocsFooter() {
   return (
     <footer className="mt-20 border-line-soft border-t py-10">
       <div className={`${WRAP} flex flex-wrap items-center justify-between gap-4 text-[13px]`}>
         <p className="text-faint">Apache-2.0 {"·"} © 2026 Topos</p>
         <div className="flex flex-wrap gap-6 text-faint">
-          {/* The same page an agent should fetch — stated on the page, not hidden in a header. */}
-          <a href={markdownPath} className="transition-colors hover:text-ink">
-            This page as markdown
-          </a>
           <a href="/docs/llms.txt" className="transition-colors hover:text-ink">
             llms.txt
           </a>
@@ -229,6 +288,9 @@ export function DocsShell({ page }: { page: DocsPageView }) {
             <h1 className="font-display font-semibold text-[clamp(19px,2.4vw,25px)] text-ink leading-[1.45] tracking-[-0.03em]">
               {page.title}
             </h1>
+            {/* Between the title and its description, on the reading column's own left edge —
+                the pair is quiet enough to sit in the text's line without competing with it. */}
+            <PageActions markdownPath={page.markdownPath} />
             <p className="mt-2 text-[15px] text-dim">{page.description}</p>
           </header>
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: pure event delegation — the real controls are the generated <button data-copy> elements, and their keyboard activation dispatches a native click this same handler receives. */}
@@ -242,7 +304,7 @@ export function DocsShell({ page }: { page: DocsPageView }) {
         </main>
         <TableOfContents headings={page.headings} />
       </div>
-      <DocsFooter markdownPath={page.markdownPath} />
+      <DocsFooter />
     </div>
   );
 }

--- a/web/app/components/docs/docs-shell.tsx
+++ b/web/app/components/docs/docs-shell.tsx
@@ -18,7 +18,12 @@ import type { DocsPageView } from "@/lib/docs/model";
  * every code block, so the browser downloads no highlighter.
  */
 
-const WRAP = "mx-auto max-w-[1180px] px-6";
+/**
+ * The same measure the landing and every other public page uses (DESIGN.md's layout rule): the
+ * wordmark has to sit on one vertical line as a reader crosses from the landing into the docs,
+ * so this wrap is not the docs' own decision to make.
+ */
+const WRAP = "mx-auto max-w-[1080px] px-6";
 const GITHUB = "https://github.com/topos-sh/topos";
 
 /**

--- a/web/app/components/landing/landing-page.tsx
+++ b/web/app/components/landing/landing-page.tsx
@@ -36,7 +36,6 @@ const FLEET_RAIL = false;
 const INSTALL = "curl -fsSL https://topos.sh/install | sh";
 const AGENT_SETUP_PROMPT = "Set up Topos for us: fetch https://topos.sh/agent and follow it.";
 const GITHUB = "https://github.com/topos-sh/topos";
-const SECURITY = `${GITHUB}/blob/main/SECURITY.md`;
 /** The documentation site — a subpath of this origin, so it rides the deployment's own domain. */
 const DOCS = "/docs";
 
@@ -245,70 +244,6 @@ const TEAMS: {
   },
 ];
 
-/** Six answers in full view — no accordion, because a hidden answer is an unanswered question. */
-const FAQ: { q: string; a: ReactNode }[] = [
-  {
-    q: "What does my team actually install?",
-    a: (
-      <>
-        Plain files, in your agent’s own folders: the same skill bundles and reference docs someone
-        would write by hand. The open-source <code className="font-mono text-[13px]">topos</code>{" "}
-        command keeps them current in the background; nothing about how your agent works changes.
-      </>
-    ),
-  },
-  {
-    q: "Which agents does it work with?",
-    a: (
-      <>
-        Topos delivers to Claude Code, OpenClaw, and Hermes today. What it writes is the ordinary
-        skill format, so Codex, Cursor, and the wider skills ecosystem read the same files.
-      </>
-    ),
-  },
-  {
-    q: "What happens to someone’s local edits?",
-    a: (
-      <>
-        They are never overwritten. A local change is kept as a draft beside the team’s version, and
-        your agent offers it back as a proposal when it is worth sharing.
-      </>
-    ),
-  },
-  {
-    q: "Where do our skills live, and is there lock-in?",
-    a: (
-      <>
-        In a plain git repo. Self-host the whole thing or use our cloud, and take it with you if you
-        ever leave.{" "}
-        <a
-          href={SECURITY}
-          target="_blank"
-          rel="noreferrer"
-          className="border-hairline border-b transition-colors hover:border-ink"
-        >
-          The security model
-          <span className="sr-only"> (opens in a new tab)</span>
-        </a>{" "}
-        spells out exactly what the server holds.
-      </>
-    ),
-  },
-  {
-    q: "What does it cost?",
-    a: (
-      <>
-        Nothing while we are in closed beta, and self-hosting is free forever. We will publish
-        pricing before that changes.
-      </>
-    ),
-  },
-  {
-    q: "We’re early. Will you set it up with us?",
-    a: <>Yes. Email me below and I’ll get your team’s first shared skills flowing with you.</>,
-  },
-];
-
 /**
  * The unclaimed-install band: shown ONLY while a single-tenant install still awaits its first
  * owner. The claim rides the one-time link the server printed at boot — machine control is the
@@ -367,9 +302,6 @@ export function LandingPage({
             </a>
             <a href="#pricing" className="transition-colors hover:text-ink max-sm:hidden">
               Pricing
-            </a>
-            <a href="#faq" className="transition-colors hover:text-ink max-sm:hidden">
-              FAQ
             </a>
             <a href={DOCS} className="transition-colors hover:text-ink max-sm:hidden">
               Docs
@@ -497,9 +429,9 @@ export function LandingPage({
 
       <PricingBand ctaTo={ctaTo} ctaLabel={ctaLabel} docsHref={DOCS} />
 
-      {/* Directly under pricing, so the Enterprise arm's "Talk to us" lands on the next screen
-          rather than past the FAQ. It opens on its heading — no micro-label — which is what marks
-          it as the page's one personal address rather than another catalogued band. */}
+      {/* Directly under pricing, so the Enterprise arm's "Talk to us" lands on the next screen.
+          It opens on its heading — no micro-label — which is what marks it as the page's one
+          personal address rather than another catalogued band, and it is the page's last word. */}
       <section id="contact" className="pt-[84px] lg:pt-[116px]">
         <div className={WRAP}>
           <SectionHeading>Setting this up for a team? Email me.</SectionHeading>
@@ -512,23 +444,6 @@ export function LandingPage({
           <div className="mt-5">
             <FounderAddressBlock />
           </div>
-        </div>
-      </section>
-
-      <section id="faq" className="pt-[84px] lg:pt-[116px]">
-        <div className={WRAP}>
-          <MicroLabel>FAQ</MicroLabel>
-          <SectionHeading>Questions people ask first.</SectionHeading>
-          <dl className="mt-6 grid gap-x-12 gap-y-7 lg:grid-cols-2">
-            {FAQ.map((item) => (
-              <div key={item.q}>
-                <dt className="font-display font-semibold text-[13.5px] text-ink tracking-[-0.01em]">
-                  {item.q}
-                </dt>
-                <dd className="mt-2 max-w-[54ch] text-[14px] text-dim leading-[1.6]">{item.a}</dd>
-              </div>
-            ))}
-          </dl>
         </div>
       </section>
 

--- a/web/tests/e2e/docs.spec.ts
+++ b/web/tests/e2e/docs.spec.ts
@@ -155,6 +155,53 @@ test.describe("the documentation", () => {
     }
   });
 
+  test("every page opens on the two markdown actions, each naming that page's own twin", async ({
+    page,
+  }) => {
+    await page.goto("/docs");
+    for (const path of await sidebarPaths(page)) {
+      await page.goto(path);
+      const twin = path === "/docs" ? "/docs.md" : `${path}.md`;
+      // The exits sit in the header — above the article, not buried under it.
+      const header = page.locator("main header");
+      await expect(header.getByRole("button"), path).toHaveText(/copy page as markdown/i);
+      await expect(
+        header.getByRole("link", { name: /view page as markdown/i }),
+        path,
+      ).toHaveAttribute("href", twin);
+      // The footer's old duplicate of the same link is gone — one address, stated once.
+      await expect(
+        page.locator("footer").getByRole("link", { name: /markdown/i }),
+        path,
+      ).toHaveCount(0);
+    }
+  });
+
+  test("copy page puts the twin's own bytes on the clipboard", async ({
+    page,
+    request,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.goto("/docs/install");
+
+    // Located by POSITION, not by name: the label is the button's own accessible name, and it
+    // changes to "copied" on success — a name-based locator would stop matching the thing it
+    // just clicked.
+    const copyPage = page.locator("main header button");
+    await expect(copyPage).toHaveText(/copy page as markdown/i);
+    await copyPage.click();
+    // The button reports the write rather than staying silent about it.
+    await expect(copyPage).toHaveText(/copied/i);
+
+    // What landed is EXACTLY what the twin serves — the page copies the markdown, it does not
+    // re-derive a second rendering of its own prose.
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    const twin = await (await request.get("/docs/install.md", { maxRedirects: 0 })).text();
+    expect(clipboard).toBe(twin);
+    expect(clipboard.startsWith("# ")).toBe(true);
+  });
+
   test("/docs/llms.txt indexes every page by its markdown twin, and every link resolves", async ({
     page,
     request,

--- a/web/tests/e2e/landing.spec.ts
+++ b/web/tests/e2e/landing.spec.ts
@@ -101,7 +101,7 @@ test.describe("the public landing page", () => {
     );
 
     // 7 — the founder band, the pricing band's "Talk to us" destination. It sits directly under
-    // pricing and ahead of the FAQ, and opens on its heading: no micro-label above it.
+    // pricing and opens on its heading: no micro-label above it.
     const contact = page.locator("#contact");
     await expect(contact).toHaveCount(1);
     await expect(
@@ -109,22 +109,16 @@ test.describe("the public landing page", () => {
     ).toBeVisible();
     await expect(contact.getByText("Design partners")).toHaveCount(0);
     // The order is the contract, not an accident of authoring: the band that answers the pricing
-    // CTA has to come before the FAQ, or the button jumps the reader past it.
-    const contactPrecedesFaq = await page.evaluate(() => {
+    // CTA is the page's last word, so the button never jumps the reader past anything.
+    const contactIsLastBand = await page.evaluate(() => {
       const c = document.querySelector("#contact");
-      const f = document.querySelector("#faq");
+      const f = document.querySelector("footer");
       if (!c || !f) return false;
       return Boolean(c.compareDocumentPosition(f) & Node.DOCUMENT_POSITION_FOLLOWING);
     });
-    expect(contactPrecedesFaq).toBe(true);
+    expect(contactIsLastBand).toBe(true);
 
-    // 8 — the FAQ, fully visible text (no accordion): six questions, six answers on the page.
-    const faq = page.locator("#faq");
-    await expect(faq.locator("dt")).toHaveCount(6);
-    await expect(faq.locator("dd")).toHaveCount(6);
-    await expect(faq.locator("dd").first()).toBeVisible();
-
-    // 9 — the footer: the browser-path button leads its link row; no security link, no address.
+    // 8 — the footer: the browser-path button leads its link row; no security link, no address.
     const footer = page.locator("footer");
     // Two matches are legitimate in single tenancy: the primary button (/login) plus the plain
     // "Sign in" link (/app). The button is the first — assert it specifically.
@@ -144,12 +138,15 @@ test.describe("the public landing page", () => {
 
   test("the retired bands are gone", async ({ page }) => {
     await page.goto("/");
-    // The git-comparison band and the verb-card band both left; the nav points at the FAQ now.
+    // The git-comparison band, the verb-card band, and the FAQ all left; what the nav still points
+    // at has to resolve to a band that is actually on the page.
     await expect(page.locator("#vs")).toHaveCount(0);
     await expect(page.locator("#agent")).toHaveCount(0);
+    await expect(page.locator("#faq")).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Why Topos" })).toHaveCount(0);
-    await expect(page.getByRole("link", { name: "FAQ" })).toHaveAttribute("href", "#faq");
+    await expect(page.getByRole("link", { name: "FAQ" })).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Pricing" })).toHaveAttribute("href", "#pricing");
+    await expect(page.getByRole("link", { name: "How it works" })).toHaveAttribute("href", "#demo");
   });
 
   test("the founder's address is never in the served bytes, and never a mailto", async ({


### PR DESCRIPTION
Three changes to the public pages, all UI.

## The docs page stops jumping

`docs-shell.tsx` carried its own `max-w-[1180px]` wrap while every other public page uses `max-w-[1080px]`, so crossing from the landing into the docs shifted the wordmark and widened the page under the reader. The docs now take the same measure — `DESIGN.md` names 1080px as the site's one content wrap, so the docs were the deviation.

Measured in a browser: the wordmark sits at the same x on both pages, and the article column settles at 562px inside the three-column grid. The CLI reference — 19 code blocks and 19 tables, the heaviest page — keeps every block's own horizontal scroller, so nothing clips at the narrower measure and the page never scrolls sideways.

## The landing loses its FAQ

The six-item band, its nav entry, and the now-unused `SECURITY` constant that only an FAQ answer referenced. The founder band is the page's last word before the footer, which is where the pricing CTA already pointed.

## Every docs page opens on its own markdown

Each page already had a plain-markdown twin at its path plus `.md`, but the only pointer to it sat in the footer, below the whole article. Two actions now open the page instead:

- **`copy page as markdown`** — fetches the twin and puts its bytes on the clipboard
- **`view page as markdown`** — opens them

Both are secondary, so they wear no border and no field: faint mono text that inks on hover, the annotation voice the system already uses for an aside. They sit between the title and its description, on the reading column's left edge.

The copy *fetches* the twin rather than the page shipping a second rendering of its own prose — the rule the code-block copy already follows, so there is no page-weight cost. A failed fetch or a denied clipboard leaves the button untouched, because the link beside it is the honest fallback and needs no script to work. The footer's duplicate link is gone: one address, stated once.

**URL shape is unchanged.** Page paths carry no trailing slash, so the twin is the path plus `.md`. The directory-style `<path>/index.md` (Cloudflare's shape) belongs to docs whose pages are directory-shaped — `developers.cloudflare.com/workers.md` 404s for exactly that reason — and ours are not. Nothing about the twin routing, `llms.txt`, or published addresses moved.

## Tests

New e2e coverage in `docs.spec.ts`:

- one walks **every** sidebar page, asserting both actions are present and that the link names *that page's own* twin, and that the footer duplicate is gone
- one grants clipboard permissions, clicks copy, and asserts the clipboard contents are **byte-identical** to what the `.md` route serves

`landing.spec.ts` updated for the removed FAQ — the ordering assertion now anchors the founder band against the footer rather than against the FAQ.

Green: `bun run check` (biome, design tokens, boundary, email-authz, contract, docs drift, typecheck) · 666 unit tests · 146 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)