### PR TITLE
list <name> answers about the one skill: its own source, one placement per line

### DIFF
--- a/bins/topos/src/ops/list.rs
+++ b/bins/topos/src/ops/list.rs
@@ -34,6 +34,7 @@ use topos_types::results::{
 use crate::ctx::Ctx;
 use crate::doc;
 use crate::error::ClientError;
+use crate::manifest::keys::{self, KeyShape};
 use crate::plane::DirectorySource;
 use crate::sessions::Session;
 use crate::sidecar;
@@ -142,10 +143,10 @@ pub(crate) fn list_with(
     };
 
     // The external sources' health, over the sections THIS INVOCATION SHOWS — computed BEFORE any
-    // of the focused views, every one of which returns early. `--agent`, `--remote` and the
-    // one-skill deep dive all answer about machines that track external sources too, and the
-    // shared tail renders this block for all of them; leaving it empty there would make the
-    // contract true only of the view that happens to fall through.
+    // of the focused views, every one of which returns early. `--agent` and `--remote` answer
+    // about machines that track external sources too, and the shared tail renders this block for
+    // them; leaving it empty there would make the contract true only of the view that happens to
+    // fall through. The one-skill deep dive is the exception, and narrows it below.
     data.forge = inventory::forge_sources(ctx, &sections);
 
     if req.footprint {
@@ -229,11 +230,23 @@ pub(crate) fn list_with(
     // way — "nothing manages it" is the whole answer, never an error.
     if let Some(name) = &req.name {
         let dive = dive_sections(&resolved, req.view);
-        data.detail = Some(match inventory::detail_for(&dive, &all, name) {
+        let detail = match inventory::detail_for(&dive, &all, name) {
             Ok(detail) => detail,
             Err(_) => builtin_detail(ctx, name)
                 .unwrap_or_else(|| unmanaged_detail(ctx, name, discover.as_ref())),
-        });
+        };
+        // A one-skill answer names THIS skill's external source and NO other. Every line above it
+        // is about the skill on screen, so an unrelated repository's last check reads as one more
+        // fact about that skill — the listing's "what is my machine tracking?" block answering a
+        // question nobody asked here. Recomputed over the DIVE's sections (which can exceed the
+        // listing's — a bare dive inside a project answers from the machine scope too) and then
+        // narrowed to the source the answering row itself names: the repository that delivers it,
+        // or nothing at all.
+        data.forge = inventory::forge_sources(ctx, &dive);
+        let origin = detail_forge_origin(&detail);
+        data.forge
+            .retain(|f| origin.as_deref() == Some(f.source.as_str()));
+        data.detail = Some(detail);
         return Ok(ListOutcome {
             data,
             warnings,
@@ -398,6 +411,21 @@ fn dive_sections(resolved: &Resolved, view: ScopeView) -> Vec<&ScopeResolution> 
     match view {
         ScopeView::Machine => vec![resolved.machine()],
         ScopeView::Here | ScopeView::All => resolved.scopes.iter().collect(),
+    }
+}
+
+/// The external repository a deep dive's answer comes from, as the check log spells it
+/// (`<host>/<owner>/<repo>`) — `None` when no row answered, or the row that did is not a forge
+/// row. The key the answering row is spelled with IS the reference, so classifying it is the same
+/// derivation the check log's own key gets: a repo-SET row and every member it delivers carry the
+/// set's key, a single import carries its own, and both resolve to the one repository.
+fn detail_forge_origin(detail: &ListDetail) -> Option<String> {
+    match keys::classify_key(detail.source_key.as_deref()?).ok()? {
+        KeyShape::RepoSet { host, owner, repo }
+        | KeyShape::RepoSkill {
+            host, owner, repo, ..
+        } => Some(format!("{host}/{owner}/{repo}")),
+        _ => None,
     }
 }
 

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -1908,8 +1908,15 @@ fn list_detail_tty(detail: &topos_types::results::ListDetail) -> String {
         (None, Some(p)) => s.push_str(&format!("\n  pinned {} (not applied here)", short(p))),
         (None, None) => {}
     }
+    // ONE folder per line. A comma-joined run of absolute paths wraps into a wall the eye cannot
+    // find a path's start in, and the count of copies — the thing this line exists to report — is
+    // unreadable at a glance. Same shape whatever the count, so a second copy never changes how
+    // the answer is read.
     if !detail.placements.is_empty() {
-        s.push_str(&format!("\n  placed in {}", detail.placements.join(", ")));
+        s.push_str("\n  placed in:");
+        for p in &detail.placements {
+            s.push_str(&format!("\n    {p}"));
+        }
     }
     // An mcp bundle's "where": per-agent config entries (placed file + state), instead of
     // placement dirs.
@@ -4592,7 +4599,10 @@ mod tests {
                     attribution: Some("assigned by Dana".to_owned()),
                     version: Some("a".repeat(64)),
                     pin: None,
-                    placements: vec!["/home/dev/.claude/skills/deploy".to_owned()],
+                    placements: vec![
+                        "/home/dev/.claude/skills/deploy".to_owned(),
+                        "/home/dev/.codex/skills/deploy".to_owned(),
+                    ],
                     state: S::Applied,
                     kind: None,
                     harnesses: Vec::new(),
@@ -4613,10 +4623,14 @@ mod tests {
         );
         assert!(text.contains("— assigned by Dana"), "{text}");
         assert!(text.contains("version aaaaaaaaaaaa"), "{text}");
+        // Every placement on its OWN line — never a comma-joined run of absolute paths.
         assert!(
-            text.contains("placed in /home/dev/.claude/skills/deploy"),
+            text.contains(
+                "placed in:\n    /home/dev/.claude/skills/deploy\n    /home/dev/.codex/skills/deploy"
+            ),
             "{text}"
         );
+        assert!(!text.contains("deploy, "), "{text}");
         assert!(text.ends_with("applied"), "{text}");
 
         // The agent-eye view: per-dir entries marked managed or untracked.

--- a/bins/topos/src/tests/manifest_reconcile.rs
+++ b/bins/topos/src/tests/manifest_reconcile.rs
@@ -3333,9 +3333,13 @@ fn scoped_forge_health_answers_about_the_scopes_own_pin() {
 }
 
 #[test]
-fn every_focused_list_view_carries_the_forge_health() {
-    // The focused views return early. Each of them is just as likely to be run on a machine that
-    // tracks external sources, and the shared tail renders this block for all of them.
+fn the_deep_dive_names_only_its_own_external_source() {
+    // The focused views return early, and the shared tail renders this block for them: `--agent`
+    // is just as likely to be run on a machine that tracks external sources. The ONE-SKILL dive is
+    // the exception. Every line it prints is a fact about the skill on screen, so an unrelated
+    // repository's last check would read as one more of them — the listing's "what is this machine
+    // tracking?" answering a question nobody asked here. It shows the repository that DELIVERS
+    // this skill, or nothing.
     let rig = Rig::new("repo-focused-views");
     rig.write_global("[bundles]\n\"github.com/o/r\" = \"*\"\n");
     let log: CallLog = Arc::new(Mutex::new(Vec::new()));
@@ -3348,27 +3352,49 @@ fn every_focused_list_view_carries_the_forge_health() {
     ));
     update_now(&ctx, &plane, &dir, &git);
 
-    for req in [
-        ops::ListRequest {
-            name: Some("alpha".to_owned()),
-            ..ops::ListRequest::default()
-        },
-        ops::ListRequest::default(),
-    ] {
-        let named = req.name.clone();
-        let listed =
-            crate::ops::list_with(&ctx, &req, None, None, crate::ops::RowPage::unlimited())
-                .unwrap();
-        assert!(
-            listed
-                .data
-                .forge
-                .iter()
-                .any(|f| f.source == "github.com/o/r"),
-            "the {named:?} view carries it too: {:?}",
-            listed.data.forge
-        );
-    }
+    let dive = |name: &str| {
+        crate::ops::list_with(
+            &ctx,
+            &ops::ListRequest {
+                name: Some(name.to_owned()),
+                ..ops::ListRequest::default()
+            },
+            None,
+            None,
+            crate::ops::RowPage::unlimited(),
+        )
+        .unwrap()
+        .data
+        .forge
+    };
+
+    // The repo delivers `alpha`, so `alpha`'s own answer names it.
+    let mine = dive("alpha");
+    assert_eq!(mine.len(), 1, "{mine:?}");
+    assert_eq!(mine[0].source, "github.com/o/r");
+
+    // Nothing external delivers the built-in — and the machine's unrelated GitHub row is not news
+    // about it. THE reported bug: this block used to ride every dive on the machine.
+    assert!(dive("topos").is_empty(), "{:?}", dive("topos"));
+
+    // The LISTING is the view the block belongs to, and still carries it in full.
+    let listed = crate::ops::list_with(
+        &ctx,
+        &ops::ListRequest::default(),
+        None,
+        None,
+        crate::ops::RowPage::unlimited(),
+    )
+    .unwrap();
+    assert!(
+        listed
+            .data
+            .forge
+            .iter()
+            .any(|f| f.source == "github.com/o/r"),
+        "{:?}",
+        listed.data.forge
+    );
 }
 
 #[test]


### PR DESCRIPTION
Two defects in `topos list <name>`, both reported against 0.1.24 from a project that tracks a GitHub repo:

```
$ topos list topos
topos
  from this machine
  version a44bb9a03654
  placed in /Users/rk/.agents/skills/topos, /Users/rk/.gemini/antigravity/skills/topos, /Users/rk/.claude/skills/topos, /Users/rk/.codex/skills/topos, /Users/rk/.cursor/skills/topos, /Users/rk/.hermes/skills/topos
  local edits ahead of the applied version
external sources:
  github.com/leonardomso/rust-skills — fd2a861ab040 (checked 2026-08-04 21:41)
```

**1. The external-sources block did not belong to this command.** `topos` comes from the machine; the repo delivers nothing to it. Every line above that block is a fact about the skill on screen, so an unrelated repository's last check reads as one more of them.

The dive now narrows the block to the source its OWN answering row names — a repo set and every member it delivers resolve to the one repository, a single import to its own, everything else (a workspace reference, a local folder, the built-in, a name nothing manages) to nothing. It is recomputed over the dive's sections rather than the listing's, which can be narrower: a bare dive inside a project answers from the machine scope too.

`--agent` and `--remote` keep the block, and the listing is unchanged — those are inventory questions.

**2. Placements were comma-joined.** Six absolute paths wrapped into a wall; the count of copies stopped being readable. `placed in:` now heads one indented folder per line, the same shape the mcp entries below it already use, whatever the count.

## After

```
$ topos list topos
topos
  from this machine
  version 583739b070de
  placed in:
    /Users/rk/.agents/skills/topos
    /Users/rk/.gemini/antigravity/skills/topos
    /Users/rk/.claude/skills/topos
    /Users/rk/.codex/skills/topos
    /Users/rk/.cursor/skills/topos
    /Users/rk/.hermes/skills/topos
  local edits ahead of the applied version

$ topos list rust-skills          # the repo's own member — the source IS its news
rust-skills
  from …/topos.toml, line key github.com/leonardomso/rust-skills
  version 3dd367302fc5
  placed in:
    …/.claude/skills/rust-skills
  applied
external sources:
  github.com/leonardomso/rust-skills — fd2a861ab040 (checked 2026-08-07 01:36)

$ topos list                      # the listing keeps the block, unchanged
…
external sources:
  github.com/leonardomso/rust-skills — fd2a861ab040 (checked 2026-08-07 01:36)
```

## Verification

- `cargo test -p topos` — 931 passed, 0 failed.
- `cargo xtask ci` — all 7 gates green (fmt, clippy, doc, schema/fixture/cli-ref drift, layering).
- Reproduced live against a copy of the reporting machine's sidecar, from a project holding the GitHub row: the three shapes above are real output from this branch.
- `the_deep_dive_names_only_its_own_external_source` replaces the test that pinned the old blanket behavior — it now asserts all three: the member names its repo, the built-in names nothing, the listing keeps it.

No version bump here; the workspace stays at 0.1.24 for the release step to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
