### PR TITLE
Bump the workspace to 0.1.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,7 +2440,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "getrandom 0.2.17",
  "sqlx",
@@ -3607,7 +3607,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "topos"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "base64",
  "clap",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "sha2",
  "unicode-normalization",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "axum",
  "plane-store",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "diffy",
  "gix",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "hex",
  "jsonc-parser",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "axum",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.25" # members inherit via `version.workspace = true`; bump to match the tag before tagging
+version = "0.1.26" # members inherit via `version.workspace = true`; bump to match the tag before tagging
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
   plane:
     # Pinned to one release (see the header). Override with TOPOS_VERSION, or build from source with
     # the docker-compose.build.yml override.
-    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.25}
+    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.26}
     restart: unless-stopped
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
     # compose network; nothing outside the network can. (The image already binds 0.0.0.0:8787.)
@@ -153,7 +153,7 @@ services:
   web:
     # The same release as the plane — one TOPOS_VERSION moves both, and they are only ever tested
     # together.
-    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.25}
+    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.26}
     restart: unless-stopped
     depends_on:
       db:

--- a/web/app/lib/plane/contract/version.ts
+++ b/web/app/lib/plane/contract/version.ts
@@ -4,4 +4,4 @@
  */
 
 /** The release version of the build serving this app — what the protocol card declares. */
-export const SERVER_RELEASE_VERSION = "0.1.25";
+export const SERVER_RELEASE_VERSION = "0.1.26";


### PR DESCRIPTION
Release prep for `v0.1.26` — the three pins `release.yml`'s `pins` job asserts against the tag before anything is built:

- `[workspace.package] version` in the root `Cargo.toml` (+ `Cargo.lock` refreshed; the release builds `--locked`)
- the image tag on **both** services in `docker-compose.yml` — the published deployment artifact, served at `/compose.yml`
- `SERVER_RELEASE_VERSION` in `web/app/lib/plane/contract/version.ts`, regenerated with `bun run gen:plane`

Additive on the wire: `MIN_SERVER_VERSION` and `MIN_CLI_VERSION` both stay at `0.1.15`. The shipped change (#38) altered the meaning of two display strings in the CLI's own `--json` envelope, not the client↔server protocol — the plane OpenAPI is byte-identical.

`cargo xtask ci` 7/7 green; `web: bun run check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)