### PR TITLE
One planning seam: plans carry demand, records carry custody

### DIFF
--- a/bins/topos/CLAUDE.md
+++ b/bins/topos/CLAUDE.md
@@ -84,9 +84,15 @@ generated `docs/cli.md` (`cargo xtask gen-cli-ref`).
   preserved as `.topos-kept-*` siblings) plus the park journal + recovery; the contracts live in
   the module docs. The rule everywhere: **no byte differing from its recorded baseline is
   destroyed unless a snapshot taken after the last revalidation holds it.**
-- `placement` — where a bundle's bytes land per scope (shared-dir-first over the home;
-  project-rooted with containment proven at the write boundary), composing
-  `topos-harness::{coverage,registry}`.
+- `placement` — where a bundle's bytes land per scope, in the TWO target shapes one plan carries:
+  a DIRECTORY the bundle owns (shared-dir-first over the home; project-rooted with containment
+  proven at the write boundary), or ENTRIES it owns inside a config file shared with the whole
+  machine (`entries_plan` — the harness table's MCP surfaces joined onto detection, narrowed by
+  the reach the caller resolved, with the surfaces it withheld and their reasons). A kind picks
+  which arm plans and which mechanic applies; a plan says what SHOULD stand and never what does
+  (that is the bundle record's custody). Composes `topos-harness::{coverage,registry,mcp}`. `Drift`
+  is the ONE payload-free vocabulary both shapes project onto (Absent/Clean/Modified/Foreign/
+  Unscannable) for the words receipts and the wire choose; `ScanStatus` keeps its scanned bytes.
 - `mcp_validate` + `ops/add_mcp` — the `kind = "mcp"` bundle's AUTHORING half. `mcp_validate` is
   the server-document gate, mirroring the web tier rule for rule over the shared vectors at
   `tests/fixtures/mcp/` (six typed refusal codes; the credential scan runs FIRST, over the whole
@@ -105,11 +111,16 @@ generated `docs/cli.md` (`cargo xtask gen-cli-ref`).
   re-runs the gate BEFORE the op WAL, and threads it onto the wire.
 - `mcp_engine` + `config_custody` — the `kind = "mcp"` bundle's delivery half: a store-only sync
   (lock custody, no dir placement) feeds a per-scope config CONVERGE over
-  `topos-harness::mcp`'s pure drivers — server.json parsed fail-closed, per-harness surfaces
-  joined onto detection (project surfaces containment-proven) and narrowed by ONE shared
-  resolution (the row's `dest` config-file entries mapped to the harnesses that claim them;
-  no dest = every MCP-capable agent) so an add never places where the next sweep would claw it
-  back, removal via prior-matched keys with drift left in place. ONE converge path serves every
+  `topos-harness::mcp`'s pure drivers — server.json parsed fail-closed, and the converge itself
+  is DEMAND (each bundle's entries plan) plus CUSTODY (its own recorded rows). Reach resolves at
+  PLANNING and nowhere else: a row's `dest` config-file entries map to the harnesses that claim
+  them (no dest = every MCP-capable agent), a targeted verb plans only the harnesses whose
+  recorded rows prove the bundle already stands there (`recorded_entries_plan`), and the plan
+  carries the surfaces it withheld so a receipt still says what reach cost. An `McpDemand` is
+  built only by `DemandedBundle::planned`, so no caller can hand the converge a reach the planner
+  did not compute, and an add never places where the next sweep would claw it back. Removal and
+  key retirement resolve their surfaces from the descriptor table and their reach from the
+  recorded rows — prior-matched keys, with drift left in place. ONE converge path serves every
   surface, the wholly-topos-owned Claude plugin dir included (its `.mcp.json` is an ordinary
   driver surface; content topos did not write backs the whole surface off), and every entry
   point — the sweep, add's inline converge, a targeted accept/go-back, `remove` — serializes on

--- a/bins/topos/CLAUDE.md
+++ b/bins/topos/CLAUDE.md
@@ -115,10 +115,13 @@ generated `docs/cli.md` (`cargo xtask gen-cli-ref`).
   is DEMAND (each bundle's entries plan) plus CUSTODY (its own recorded rows). Reach resolves at
   PLANNING and nowhere else: a row's `dest` config-file entries map to the harnesses that claim
   them (no dest = every MCP-capable agent), a targeted verb plans only the harnesses whose
-  recorded rows prove the bundle already stands there (`recorded_entries_plan`), and the plan
-  carries the surfaces it withheld so a receipt still says what reach cost. An `McpDemand` is
-  built only by `DemandedBundle::planned`, so no caller can hand the converge a reach the planner
-  did not compute, and an add never places where the next sweep would claw it back. Removal and
+  recorded rows prove the bundle already stands there (`recorded_reach`), and the plan carries the
+  surfaces it withheld so a receipt still says what reach cost. Every demand the sweep and `add`
+  converge is built by `DemandedBundle::planned`, so a caller cannot hand the converge a reach the
+  planner did not compute; the targeted converge builds its own demand from a reach it re-derives
+  from the record immediately before the lock, because a verb plans at its top and converges after
+  a materialize — a stale reach would claw back an entry a sweep placed in that window. An add
+  never places where the next sweep would claw it back. Removal and
   key retirement resolve their surfaces from the descriptor table and their reach from the
   recorded rows — prior-matched keys, with drift left in place. ONE converge path serves every
   surface, the wholly-topos-owned Claude plugin dir included (its `.mcp.json` is an ordinary

--- a/bins/topos/src/mcp_engine.rs
+++ b/bins/topos/src/mcp_engine.rs
@@ -184,8 +184,13 @@ pub(crate) struct RemovedEntry {
 pub(crate) struct ConvergeOutcome {
     pub bundles: Vec<BundleStates>,
     pub removed: Vec<RemovedEntry>,
-    /// Honest per-bundle / per-surface failure lines (the sweep's warning channel).
+    /// Honest per-bundle / per-surface FAILURE lines (the sweep's warning channel — the one that
+    /// makes a run exit non-zero).
     pub warnings: Vec<String>,
+    /// Facts about work that SUCCEEDED and is worth stating (a wholly-owned config file deleted
+    /// when its last entry left). A line describing something that worked belongs here: routed
+    /// into the warning channel it would make a clean run report itself broken.
+    pub notices: Vec<String>,
 }
 
 // =================================================================================================
@@ -512,6 +517,7 @@ pub(crate) fn converge(
             &provenance,
         );
         out.warnings.extend(surface_out.warnings);
+        out.notices.extend(surface_out.notices);
         for key in &surface_out.wrote {
             if let Some(i) = desired_bundles.get(key) {
                 wrote.insert(*i);
@@ -646,6 +652,7 @@ pub(crate) fn remove_bundle(
             &provenance,
         );
         out.warnings.extend(surface_out.warnings);
+        out.notices.extend(surface_out.notices);
         for (state_key, state) in surface_out.states {
             if state_key == key && (state.state == "removed" || state.state == "drifted") {
                 out.removed.push(RemovedEntry {
@@ -764,6 +771,8 @@ struct SurfaceOutcome {
     /// left byte-identical, which is what makes it an answer rather than a guess.
     wrote: BTreeSet<String>,
     warnings: Vec<String>,
+    /// Success NOTICES — things that WORKED and are worth stating (see [`ConvergeOutcome::notices`]).
+    notices: Vec<String>,
 }
 
 impl SurfaceOutcome {
@@ -772,6 +781,31 @@ impl SurfaceOutcome {
             states: Vec::new(),
             wrote: BTreeSet::new(),
             warnings: Vec::new(),
+            notices: Vec::new(),
+        }
+    }
+
+    /// The WRITE-BOUNDARY containment refusal: every desired key reads `unprovable` with the same
+    /// note the planner's withheld line carries, nothing is written, and the escape is disclosed.
+    fn escaped(desired: &[McpEntry], h: &KnownHarness, escape: &Path) -> Self {
+        Self {
+            states: desired
+                .iter()
+                .map(|e| {
+                    (
+                        e.key.clone(),
+                        agent_state(
+                            h.slug,
+                            "unprovable",
+                            Some("the config path does not resolve inside this checkout"),
+                            None,
+                        ),
+                    )
+                })
+                .collect(),
+            wrote: BTreeSet::new(),
+            warnings: vec![crate::placement::escape_line(h.slug, escape)],
+            notices: Vec::new(),
         }
     }
     fn unprovable(desired: &[McpEntry], h: &KnownHarness, path: &Path, reason: &str) -> Self {
@@ -787,8 +821,24 @@ impl SurfaceOutcome {
                 .collect(),
             wrote: BTreeSet::new(),
             warnings: vec![format!("MCP_SURFACE_UNPROVABLE {}: {reason}", h.slug)],
+            notices: Vec::new(),
         }
     }
+}
+
+/// **The containment rail, re-run at the WRITE boundary.** A project surface was proven inside the
+/// checkout when the plan was made — and a plan is a memory, not a permission. Any component of
+/// the path can be swapped for an outward symlink between planning and this write, and
+/// `replace_config` follows symlinks, so the proof is re-run HERE, immediately before any byte
+/// moves, over every path this surface is about to touch (the config file, and the plugin manifest
+/// beside it). `None` at the person scope — there is no checkout to be inside of — and when every
+/// path still proves.
+fn write_escape(io: &ScopeIo<'_>, paths: &[&Path]) -> Option<PathBuf> {
+    let root = io.project_root.as_deref()?;
+    paths
+        .iter()
+        .find(|p| !crate::placement::within_project(root, p))
+        .map(|p| (*p).to_path_buf())
 }
 
 /// The intent-journal protocol around ONE config write: (a) the custody persists the pending
@@ -959,6 +1009,8 @@ fn converge_surface(
                 && !outcome.fingerprints.is_empty()
                 && let Some(manifest) = plugin_manifest_path(path)
                 && !io.fs.exists(&manifest)
+                // Healing the manifest is a WRITE — it passes the same write-boundary proof.
+                && write_escape(io, &[&manifest]).is_none()
                 && crate::config_io::replace_config(io.fs, &manifest, &plugin_dir::manifest_bytes())
                     .is_ok()
             {
@@ -998,6 +1050,25 @@ fn converge_surface(
             let owns_file =
                 outcome.created_file || (owned_before && all_ours && kept.is_empty() && !unmanaged);
 
+            // The plugin surface writes its constant manifest beside the entries file — before
+            // it, so a crash never leaves entries without the manifest that makes them load. The
+            // manifest rides the same foreign-occupant rule as every other byte: (re)written
+            // only when absent or still byte-identical to what topos renders; a hand-edited one
+            // is left standing, disclosed.
+            let (manifest, mut manifest_kept) = if is_plugin {
+                plugin_manifest_verdict(io.fs, h.slug, path)
+            } else {
+                (None, None)
+            };
+            // THE WRITE-BOUNDARY CONTAINMENT PROOF — before the journal, before a byte moves, so
+            // a refusal costs nothing and leaves nothing behind.
+            let mut to_write: Vec<&Path> = vec![path];
+            if let Some(m) = &manifest {
+                to_write.push(m);
+            }
+            if let Some(escape) = write_escape(io, &to_write) {
+                return SurfaceOutcome::escaped(desired, h, &escape);
+            }
             let intents = write_intents(
                 custody,
                 h.slug,
@@ -1009,16 +1080,6 @@ fn converge_surface(
             );
             let path_owned = path.to_path_buf();
             let fs = io.fs;
-            // The plugin surface writes its constant manifest beside the entries file — before
-            // it, so a crash never leaves entries without the manifest that makes them load. The
-            // manifest rides the same foreign-occupant rule as every other byte: (re)written
-            // only when absent or still byte-identical to what topos renders; a hand-edited one
-            // is left standing, disclosed.
-            let (manifest, mut manifest_kept) = if is_plugin {
-                plugin_manifest_verdict(io.fs, h.slug, path)
-            } else {
-                (None, None)
-            };
             let write = move || -> std::io::Result<()> {
                 if let Some(m) = &manifest {
                     crate::config_io::replace_config(fs, m, &plugin_dir::manifest_bytes())?;
@@ -1045,7 +1106,10 @@ fn converge_surface(
                             // — its disclosure (kept, dir stays) supersedes the write-time one.
                             manifest_kept = prune_plugin_dir(io.fs, h.slug, path);
                         }
-                        surface.warnings.push(format!(
+                        // A SUCCESS notice, not a fault: the file went because the last entry
+                        // topos owned left it, which is the removal working. Pushed into the
+                        // warning channel it would make a clean sweep count itself failed.
+                        surface.notices.push(format!(
                             "MCP_FILE_REMOVED {}: {} held only topos entries and was deleted",
                             h.slug,
                             path.display()
@@ -1335,14 +1399,20 @@ fn prune_plugin_dir(fs: &dyn FsOps, slug: &str, mcp_path: &Path) -> Option<Strin
 ///   no ownership record to reuse, and minting fresh here would land a DUPLICATE `topos-local-*`
 ///   entry beside the original (now-foreign, unremovable) one. Skip with an honest warning; the
 ///   next sweep re-mints under the full scope plan and heals this scope;
-/// - `plan` — built by [`recorded_entries_plan`] — reaches only the harnesses that ALREADY hold a
-///   custody entry for this bundle in this scope. A harness the narrowing excluded never gained an
-///   entry, so it stays untouched; a narrowing CHANGE is the sweep's job, not a go-back's.
+/// - the reach is the harnesses that ALREADY hold a custody entry for this bundle in this scope. A
+///   harness the narrowing excluded never gained an entry, so it stays untouched; a narrowing
+///   CHANGE is the sweep's job, not a go-back's.
+///
+/// **The reach is derived HERE, not handed in.** A verb plans at its top and converges after a
+/// snapshot, a fetch and a materialize; a sweep landing in that window can widen this bundle's
+/// entries, and converging with the older set would CLAW BACK the entry the sweep just placed (a
+/// demanded bundle's standing rows are never `preserved`, so a surface an out-of-date reach omits
+/// gets prior-matched and removed). So the reach comes from the custody read immediately before
+/// the lock — the verb's own plan decides only THAT the entries mechanic runs, never how far.
 pub(crate) fn converge_bundle_now(
     ctx: &crate::ctx::Ctx<'_>,
     sid: &crate::id::SkillId,
     name: &str,
-    plan: &PlacementPlan,
 ) -> (Vec<McpAgentState>, Vec<String>) {
     let Some(roots) = ctx.roots.clone() else {
         return (Vec::new(), Vec::new());
@@ -1350,8 +1420,9 @@ pub(crate) fn converge_bundle_now(
     let Ok(Some((version_id, server_json))) = stored_server_json(ctx, sid) else {
         return (Vec::new(), Vec::new());
     };
-    // An ADVISORY (unlocked) read: it only answers whether an ownership record exists to reuse.
-    // The authoritative read-modify-write happens inside `converge`, under the per-scope lock.
+    // An ADVISORY (unlocked) read: it answers whether an ownership record exists to reuse, and
+    // supplies the reach below. The authoritative read-modify-write happens inside `converge`,
+    // under the per-scope lock.
     let custody = match ScopeEntries::load(ctx.fs, &ctx.layout) {
         Ok(l) => l,
         Err(e) => {
@@ -1366,7 +1437,7 @@ pub(crate) fn converge_bundle_now(
             );
         }
     };
-    if custody.key_of(sid.as_str()).is_none() {
+    let Some(reach) = recorded_reach(&custody, sid.as_str()) else {
         return (
             Vec::new(),
             vec![format!(
@@ -1374,13 +1445,17 @@ pub(crate) fn converge_bundle_now(
                  heals this scope"
             )],
         );
-    }
-    // Nothing planned ⇒ nothing placed here, nothing stale, nothing to do.
-    if plan.entries().next().is_none() {
+    };
+    let project_root = ctx.layout.project_root().map(Path::to_path_buf);
+    // The demand's plan, from the reach as it stands NOW.
+    let fresh = crate::placement::entries_plan(ctx, project_root.as_deref(), Some(&reach));
+    // Nothing to place AND nothing to say. A plan with only WITHHELD surfaces still enters: it
+    // writes nothing, but it speaks the per-agent states a receipt owes, and the converge it
+    // enters is also where the intent journal's crash recovery runs.
+    if fresh.entries().next().is_none() && fresh.withheld.is_empty() {
         return (Vec::new(), Vec::new());
     }
     let descriptors = mcp::descriptor::mcp_harnesses();
-    let project_root = ctx.layout.project_root().map(Path::to_path_buf);
     let cwd = project_root.clone().or_else(|| roots.cwd.clone());
     let detected: BTreeSet<String> =
         topos_harness::registry::detected_harnesses(&roots.home, cwd.as_deref())
@@ -1401,7 +1476,7 @@ pub(crate) fn converge_bundle_now(
         workspace_slug: None,
         version_id,
         server_json,
-        plan: plan.clone(),
+        plan: fresh,
     };
     let outcome = converge(
         &io,
@@ -1430,20 +1505,26 @@ pub(crate) fn recorded_entries_plan(
     ctx: &crate::ctx::Ctx<'_>,
     skill_id: &str,
 ) -> crate::placement::PlacementPlan {
-    let owned: Vec<String> = ScopeEntries::load(ctx.fs, &ctx.layout)
+    let reach = ScopeEntries::load(ctx.fs, &ctx.layout)
         .ok()
-        .and_then(|custody| {
-            let key = custody.key_of(skill_id)?.to_owned();
-            Some(
-                mcp::descriptor::mcp_harnesses()
-                    .iter()
-                    .filter(|h| custody.holds(&placement_key(h.slug, &key)))
-                    .map(|h| h.slug.to_owned())
-                    .collect(),
-            )
-        })
+        .and_then(|custody| recorded_reach(&custody, skill_id))
         .unwrap_or_default();
-    crate::placement::entries_plan(ctx, ctx.layout.project_root(), Some(&owned))
+    crate::placement::entries_plan(ctx, ctx.layout.project_root(), Some(&reach))
+}
+
+/// The harnesses whose RECORDED rows hold this bundle's minted key in one scope — the row-derived
+/// reach itself, shared by the verb's plan and by the converge's late re-derivation so the two can
+/// never answer differently. `None` = no minted key here at all, which is not an empty reach but
+/// an absent ownership record, and the caller says so.
+fn recorded_reach(custody: &ScopeEntries, skill_id: &str) -> Option<Vec<String>> {
+    let key = custody.key_of(skill_id)?.to_owned();
+    Some(
+        mcp::descriptor::mcp_harnesses()
+            .iter()
+            .filter(|h| custody.holds(&placement_key(h.slug, &key)))
+            .map(|h| h.slug.to_owned())
+            .collect(),
+    )
 }
 
 // =================================================================================================

--- a/bins/topos/src/mcp_engine.rs
+++ b/bins/topos/src/mcp_engine.rs
@@ -4,7 +4,12 @@
 //! The pure placement math lives in `topos_harness::mcp` (bytes in → an [`EditPlan`] out, one
 //! driver per dialect); THIS module owns everything stateful around it, per scope:
 //!
-//! - the demand set (what the reconcile resolved this run — see [`McpDemand`]),
+//! - the demand set — what the reconcile resolved this run, PLANNED onto this scope's config
+//!   surfaces ([`McpDemand`], built only by [`DemandedBundle::planned`]). Reach is the plan's
+//!   answer: the converge places a bundle exactly where its plan carries an entries target, and
+//!   states the surfaces the plan withheld. Removal and key retirement read the RECORDED rows
+//!   instead — a bundle being removed has no demand left to plan from, and custody is the only
+//!   thing that knows where its entries went,
 //! - `server.json` parsing with a fail-closed re-check of the publish gate (a secret /
 //!   templated / value-less header the gate should have refused is never placed, only warned
 //!   about),
@@ -55,11 +60,14 @@ use crate::config_custody::EntryPlacement;
 use crate::config_custody::{self, PendingIntent, ScopeEntries, placement_key};
 use crate::error::ClientError;
 use crate::fs_seam::FsOps;
+use crate::placement::PlacementPlan;
 use crate::sidecar::Layout;
 
-/// One demanded MCP bundle in one scope — everything the engine needs, resolved by the reconcile.
+/// What a caller RESOLVED about one demanded MCP bundle, before its placement is planned: the
+/// identity, the bytes, and the reach its row asked for. Turned into an [`McpDemand`] — the only
+/// way one is ever built — by [`DemandedBundle::planned`].
 #[derive(Debug, Clone)]
-pub(crate) struct McpDemand {
+pub(crate) struct DemandedBundle {
     /// The bundle identity the custody keys on (the workspace skill id; `local:<name>` for an
     /// untracked local row).
     pub bundle_id: String,
@@ -73,10 +81,60 @@ pub(crate) struct McpDemand {
     /// The bundle's `server.json` bytes, read from the scope store's current tree (or the local
     /// row's dir).
     pub server_json: Vec<u8>,
-    /// Registry slugs this demand is narrowed to — the harnesses whose config files the row's
-    /// `dest` names. `None` = no dest (every MCP-capable harness); `Some` = exactly these,
-    /// possibly none at all (a dest row is frozen to what it names).
-    pub harness_filter: Option<Vec<String>>,
+    /// The harness narrowing the caller resolved — the slugs whose config files the row's `dest`
+    /// names, or (for a targeted verb) the harnesses whose recorded rows prove the bundle already
+    /// stands there. `None` = every MCP-capable harness. It is a PLANNER INPUT and nothing else:
+    /// the plan turns it into targets, and no downstream step re-derives reach.
+    pub reach: Option<Vec<String>>,
+}
+
+impl DemandedBundle {
+    /// Plan this row onto ONE scope's config surfaces — the ONE construction of an [`McpDemand`].
+    /// The scope (its fs, home and project root) comes from `io`, and `detected` is the SAME set
+    /// the converge this feeds engages against.
+    pub(crate) fn planned(
+        self,
+        io: &ScopeIo<'_>,
+        descriptors: &[&'static KnownHarness],
+        detected: &BTreeSet<String>,
+    ) -> McpDemand {
+        let plan = crate::placement::entries_plan_at(
+            io.fs,
+            descriptors,
+            &io.home,
+            detected,
+            io.project_root.as_deref(),
+            self.reach.as_deref(),
+        );
+        McpDemand {
+            bundle_id: self.bundle_id,
+            name: self.name,
+            workspace_slug: self.workspace_slug,
+            version_id: self.version_id,
+            server_json: self.server_json,
+            plan,
+        }
+    }
+}
+
+/// One demanded MCP bundle PLANNED onto one scope — the identity + bytes the caller resolved, and
+/// the plan that says WHERE its entries belong here. The converge is demand (these plans) plus
+/// custody (each bundle's own recorded rows); it never re-decides reach.
+#[derive(Debug, Clone)]
+pub(crate) struct McpDemand {
+    /// See [`DemandedBundle::bundle_id`].
+    pub bundle_id: String,
+    /// See [`DemandedBundle::name`].
+    pub name: String,
+    /// See [`DemandedBundle::workspace_slug`].
+    pub workspace_slug: Option<String>,
+    /// See [`DemandedBundle::version_id`].
+    pub version_id: String,
+    /// See [`DemandedBundle::server_json`].
+    pub server_json: Vec<u8>,
+    /// The ENTRIES half of this bundle's placement plan at this scope: one target per config file
+    /// its entries belong in, plus the surfaces the plan withheld with their reasons.
+    pub plan: PlacementPlan,
 }
 
 /// The scope's I/O: the fs seam, the scope store (where the custody document and every bundle's own
@@ -339,80 +397,65 @@ pub(crate) fn converge(
     let mut wrote: BTreeSet<usize> = BTreeSet::new();
 
     for h in descriptors {
-        // The scope surface. A PROJECT scope never falls back to the user surface.
-        let surface: Option<(PathBuf, McpDialect)> = match &io.project_root {
-            Some(root) => match h.mcp().and_then(|m| m.project) {
-                Some((rel, dialect)) => {
-                    let path = root.join(rel);
-                    // THE CONTAINMENT RAIL, before ANY read or write: the resolved path (symlinks
-                    // followed for the check) must stay inside the checkout — refused and
-                    // disclosed, never redirected.
-                    if crate::placement::within_project(root, &path) {
-                        Some((path, dialect))
-                    } else {
+        // WHAT THE PLANS WITHHELD from this surface — one line per placeable demand that asked for
+        // this harness and did not get it (no surface at this scope, a project path the containment
+        // rail refused). The reach decision is the plan's, so the disclosure of what it cost is the
+        // plan's too; the converge only speaks it in the descriptor order the receipt reads in.
+        for (i, _) in &parsed {
+            if let Some(w) = demands[*i].plan.withheld_for(h.slug) {
+                push_state(
+                    &mut states,
+                    *i,
+                    agent_state(h.slug, w.state, Some(w.note.as_str()), None),
+                );
+            }
+        }
+        // WHERE this surface's file is. A harness some plan REACHES answers with the plan's own
+        // target — the file the demand named, and engagement already proven when it was planned.
+        // A harness only CUSTODY names (an undemanded bundle's standing entry, a narrowing change,
+        // a removal-only run) has no plan to read, so it resolves through the same shared
+        // resolution the planner used — because a removal must still reach the files it wrote.
+        let planned = parsed
+            .iter()
+            .find_map(|(i, _)| demands[*i].plan.entries_for(h.slug));
+        let (file, dialect) = match planned {
+            Some(t) => (t.file.clone(), t.dialect),
+            None => {
+                let surface =
+                    crate::placement::config_surface(h, &io.home, io.project_root.as_deref());
+                let crate::placement::ConfigSurface::Ready {
+                    root,
+                    file,
+                    dialect,
+                } = surface
+                else {
+                    // A project surface the containment rail refused earns ONE scope-level
+                    // disclosure (the per-bundle states rode the plans above); a harness with no
+                    // surface at this scope is simply not here.
+                    if let crate::placement::ConfigSurface::Escaped { path } = surface {
                         let line = crate::placement::escape_line(h.slug, &path);
                         if !out.warnings.contains(&line) {
                             out.warnings.push(line);
                         }
-                        for (i, _) in &parsed {
-                            if filter_admits(&demands[*i], h.slug) {
-                                push_state(
-                                    &mut states,
-                                    *i,
-                                    agent_state(
-                                        h.slug,
-                                        "unprovable",
-                                        Some(
-                                            "the config path does not resolve inside this checkout",
-                                        ),
-                                        None,
-                                    ),
-                                );
-                            }
-                        }
-                        continue;
                     }
+                    continue;
+                };
+                // Engagement: the harness is detected on this machine, OR its config surface
+                // already exists (entries were placed while it was detected — removal must still
+                // reach them).
+                if !(detected.contains(h.slug) || io.fs.exists(&root)) {
+                    continue;
                 }
-                None => None,
-            },
-            None => h
-                .mcp()
-                .and_then(|m| m.user)
-                .and_then(|s| h.mcp_user_path(&io.home).map(|p| (p, s.dialect))),
-        };
-        let Some((path, dialect)) = surface else {
-            // No surface AT THIS SCOPE: withheld, honestly, per demanded bundle.
-            let note = if io.project_root.is_some() {
-                "no project-level config"
-            } else {
-                "no user-level config"
-            };
-            for (i, _) in &parsed {
-                if filter_admits(&demands[*i], h.slug) {
-                    push_state(
-                        &mut states,
-                        *i,
-                        agent_state(h.slug, "not-supported", Some(note), None),
-                    );
-                }
+                (file, dialect)
             }
-            continue;
         };
 
-        // Engagement: the harness is detected on this machine, OR its config surface already
-        // exists (entries were placed while it was detected — removal/update must still reach
-        // them).
-        let engaged = detected.contains(h.slug) || io.fs.exists(&path);
-        if !engaged {
-            continue;
-        }
-
-        // The desired set for this harness: the placeable demands that pass the row narrowing.
+        // The desired set for this harness: the placeable demands whose PLAN puts an entries
+        // target here. Nothing is re-narrowed — the plan already answered.
         let mut desired: Vec<McpEntry> = Vec::new();
         let mut desired_bundles: BTreeMap<String, usize> = BTreeMap::new();
         for (i, p) in &parsed {
-            let d = &demands[*i];
-            if !filter_admits(d, h.slug) {
+            if demands[*i].plan.entries_for(h.slug).is_none() {
                 continue;
             }
             let key = minted[i].clone();
@@ -426,7 +469,7 @@ pub(crate) fn converge(
         }
         // Parse-failed demands report per engaged harness (their entries are held above).
         for (i, reason) in &failed {
-            if filter_admits(&demands[*i], h.slug) {
+            if demands[*i].plan.entries_for(h.slug).is_some() {
                 push_state(
                     &mut states,
                     *i,
@@ -456,14 +499,13 @@ pub(crate) fn converge(
                 (key.clone(), (d.bundle_id.clone(), d.version_id.clone()))
             })
             .collect();
-        // The plugin dir's driver surface is its `.mcp.json`; the manifest beside it and the
-        // dir prune are `converge_file`'s dialect-specific I/O.
-        let path = surface_file(&path, dialect);
+        // The plugin dir's driver surface is its `.mcp.json` (resolved with the surface); the
+        // manifest beside it and the dir prune are `converge_file`'s dialect-specific I/O.
         let surface_out = converge_file(
             io,
             &mut custody,
             h,
-            &path,
+            &file,
             dialect,
             &desired,
             &preserved,
@@ -572,20 +614,18 @@ pub(crate) fn remove_bundle(
     };
 
     for h in descriptors {
-        let surface: Option<(PathBuf, McpDialect)> = match &io.project_root {
-            Some(root) => h.mcp().and_then(|m| m.project).and_then(|(rel, dialect)| {
-                let path = root.join(rel);
-                crate::placement::within_project(root, &path).then_some((path, dialect))
-            }),
-            None => h
-                .mcp()
-                .and_then(|m| m.user)
-                .and_then(|s| h.mcp_user_path(&io.home).map(|p| (p, s.dialect))),
-        };
-        let Some((path, dialect)) = surface else {
+        // A removal resolves its surfaces from the DESCRIPTOR table and its reach from the
+        // RECORDED rows — never from a plan. A bundle being removed has no demand left to plan
+        // from, and custody is the only thing that knows where its entries actually went.
+        let crate::placement::ConfigSurface::Ready {
+            root,
+            file,
+            dialect,
+        } = crate::placement::config_surface(h, &io.home, io.project_root.as_deref())
+        else {
             continue;
         };
-        if !(detected.contains(h.slug) || io.fs.exists(&path)) {
+        if !(detected.contains(h.slug) || io.fs.exists(&root)) {
             continue;
         }
         if !custody.holds(&placement_key(h.slug, &key)) {
@@ -595,12 +635,11 @@ pub(crate) fn remove_bundle(
         // keys, and every other entry — ours or not — reads foreign and stays byte-identical.
         let only_this = |_l: &ScopeEntries, entry_key: &str| entry_key != key;
         let provenance = BTreeMap::new();
-        let path = surface_file(&path, dialect);
         let surface_out = converge_file(
             io,
             &mut custody,
             h,
-            &path,
+            &file,
             dialect,
             &[],
             &only_this,
@@ -683,14 +722,6 @@ fn converge_lock(io: &ScopeIo<'_>) -> Result<crate::fs_seam::LockGuard, String> 
     io.fs.lock_exclusive(&locks.join("mcp.lock")).map_err(|e| {
         format!("MCP_LOCK_UNAVAILABLE: {e} — no MCP config is read or written this run")
     })
-}
-
-/// Whether a demand's dest narrowing admits `slug` (`None` = every MCP-capable harness; a dest
-/// row admits exactly the harnesses its config files name — possibly none).
-fn filter_admits(d: &McpDemand, slug: &str) -> bool {
-    d.harness_filter
-        .as_ref()
-        .is_none_or(|f| f.iter().any(|s| s == slug))
 }
 
 fn agent_state(slug: &str, state: &str, note: Option<&str>, file: Option<&Path>) -> McpAgentState {
@@ -956,10 +987,14 @@ fn converge_surface(
                 let mine = custody.rows_at(h.slug, path);
                 !mine.is_empty() && mine.iter().all(|(_, e)| e.owns_file)
             };
-            let all_ours = outcome
-                .states
-                .iter()
-                .all(|(_, s)| !matches!(s, EntryState::Drifted | EntryState::Foreign));
+            // The same drift question the dir side asks of a folder, asked of the entries —
+            // through the one vocabulary both project onto.
+            let all_ours = outcome.states.iter().all(|(_, s)| {
+                !matches!(
+                    crate::placement::Drift::of_entry(*s),
+                    crate::placement::Drift::Modified | crate::placement::Drift::Foreign
+                )
+            });
             let owns_file =
                 outcome.created_file || (owned_before && all_ours && kept.is_empty() && !unmanaged);
 
@@ -1215,16 +1250,6 @@ fn fold_states(
 // manifest beside it, the dir prune when the last entry leaves).
 // =================================================================================================
 
-/// The driver surface FILE for a resolved descriptor surface: the plugin DIR's `.mcp.json` for
-/// [`McpDialect::ClaudePluginDir`], the path itself for every file dialect.
-fn surface_file(path: &Path, dialect: McpDialect) -> PathBuf {
-    if dialect == McpDialect::ClaudePluginDir {
-        path.join(plugin_dir::PLUGIN_MCP_PATH)
-    } else {
-        path.to_path_buf()
-    }
-}
-
 /// The constant manifest's path beside a plugin `.mcp.json`.
 fn plugin_manifest_path(mcp_path: &Path) -> Option<PathBuf> {
     mcp_path
@@ -1310,13 +1335,14 @@ fn prune_plugin_dir(fs: &dyn FsOps, slug: &str, mcp_path: &Path) -> Option<Strin
 ///   no ownership record to reuse, and minting fresh here would land a DUPLICATE `topos-local-*`
 ///   entry beside the original (now-foreign, unremovable) one. Skip with an honest warning; the
 ///   next sweep re-mints under the full scope plan and heals this scope;
-/// - it converges only the harnesses that ALREADY hold a custody entry for this bundle in this
-///   scope. A harness the narrowing excluded never gained an entry, so it stays untouched; a
-///   narrowing CHANGE is the sweep's job, not a go-back's.
+/// - `plan` — built by [`recorded_entries_plan`] — reaches only the harnesses that ALREADY hold a
+///   custody entry for this bundle in this scope. A harness the narrowing excluded never gained an
+///   entry, so it stays untouched; a narrowing CHANGE is the sweep's job, not a go-back's.
 pub(crate) fn converge_bundle_now(
     ctx: &crate::ctx::Ctx<'_>,
     sid: &crate::id::SkillId,
     name: &str,
+    plan: &PlacementPlan,
 ) -> (Vec<McpAgentState>, Vec<String>) {
     let Some(roots) = ctx.roots.clone() else {
         return (Vec::new(), Vec::new());
@@ -1324,8 +1350,8 @@ pub(crate) fn converge_bundle_now(
     let Ok(Some((version_id, server_json))) = stored_server_json(ctx, sid) else {
         return (Vec::new(), Vec::new());
     };
-    // An ADVISORY (unlocked) read: it only derives the targeted reach below. The authoritative
-    // read-modify-write happens inside `converge`, under the per-scope converge lock.
+    // An ADVISORY (unlocked) read: it only answers whether an ownership record exists to reuse.
+    // The authoritative read-modify-write happens inside `converge`, under the per-scope lock.
     let custody = match ScopeEntries::load(ctx.fs, &ctx.layout) {
         Ok(l) => l,
         Err(e) => {
@@ -1340,7 +1366,7 @@ pub(crate) fn converge_bundle_now(
             );
         }
     };
-    let Some(key) = custody.key_of(sid.as_str()).map(str::to_owned) else {
+    if custody.key_of(sid.as_str()).is_none() {
         return (
             Vec::new(),
             vec![format!(
@@ -1348,18 +1374,12 @@ pub(crate) fn converge_bundle_now(
                  heals this scope"
             )],
         );
-    };
-    let descriptors = mcp::descriptor::mcp_harnesses();
-    // The harnesses that provably hold this bundle's entry here — the whole reach of a targeted
-    // converge. None ⇒ nothing placed, nothing stale, nothing to do.
-    let owned: Vec<String> = descriptors
-        .iter()
-        .filter(|h| custody.holds(&placement_key(h.slug, &key)))
-        .map(|h| h.slug.to_owned())
-        .collect();
-    if owned.is_empty() {
+    }
+    // Nothing planned ⇒ nothing placed here, nothing stale, nothing to do.
+    if plan.entries().next().is_none() {
         return (Vec::new(), Vec::new());
     }
+    let descriptors = mcp::descriptor::mcp_harnesses();
     let project_root = ctx.layout.project_root().map(Path::to_path_buf);
     let cwd = project_root.clone().or_else(|| roots.cwd.clone());
     let detected: BTreeSet<String> =
@@ -1381,7 +1401,7 @@ pub(crate) fn converge_bundle_now(
         workspace_slug: None,
         version_id,
         server_json,
-        harness_filter: Some(owned),
+        plan: plan.clone(),
     };
     let outcome = converge(
         &io,
@@ -1398,6 +1418,32 @@ pub(crate) fn converge_bundle_now(
         .map(|b| b.states)
         .unwrap_or_default();
     (states, outcome.warnings)
+}
+
+/// **The targeted verbs' ENTRIES plan** — the row-derived reach A2 keeps: a bundle's plan here is
+/// exactly the harnesses whose RECORDED rows prove it already stands there, planned onto this
+/// scope's surfaces through the one planner. A targeted accept, go-back or reset must never fan a
+/// bundle out past what the sweep's narrowing last admitted, and the record is the only local
+/// evidence of what that was. An unreadable custody, or a bundle with no minted key, plans nothing
+/// — `converge_bundle_now` then says so with its own honest warning.
+pub(crate) fn recorded_entries_plan(
+    ctx: &crate::ctx::Ctx<'_>,
+    skill_id: &str,
+) -> crate::placement::PlacementPlan {
+    let owned: Vec<String> = ScopeEntries::load(ctx.fs, &ctx.layout)
+        .ok()
+        .and_then(|custody| {
+            let key = custody.key_of(skill_id)?.to_owned();
+            Some(
+                mcp::descriptor::mcp_harnesses()
+                    .iter()
+                    .filter(|h| custody.holds(&placement_key(h.slug, &key)))
+                    .map(|h| h.slug.to_owned())
+                    .collect(),
+            )
+        })
+        .unwrap_or_default();
+    crate::placement::entries_plan(ctx, ctx.layout.project_root(), Some(&owned))
 }
 
 // =================================================================================================

--- a/bins/topos/src/ops/add_mcp.rs
+++ b/bins/topos/src/ops/add_mcp.rs
@@ -853,28 +853,31 @@ fn converge_one(ctx: &Ctx<'_>, target: &EditTarget, bundle_id: &str, name: &str)
     .iter()
     .map(|h| h.slug.to_owned())
     .collect();
+    // The SAME narrowing the sweep resolves for this row (its `dest` entries mapped to the
+    // config files they name) — one shared resolution, so the add can never place into a
+    // harness the next sweep would claw back. It is a PLANNER input: the plan turns it into the
+    // config files this bundle's entries belong in.
+    let (reach, filter_warnings) = row_narrowing(ctx, target, name);
     let io = crate::mcp_engine::ScopeIo {
         fs: ctx.fs,
         layout: &layout,
         home: roots.home.clone(),
         project_root,
     };
-    // The SAME narrowing the sweep resolves for this row (its `dest` entries mapped to the
-    // config files they name) — one shared resolution, so the add can never place into a
-    // harness the next sweep would claw back.
-    let (filter, filter_warnings) = row_narrowing(ctx, target, name);
-    let demand = crate::mcp_engine::McpDemand {
+    let descriptors = topos_harness::mcp::descriptor::mcp_harnesses();
+    let demand = crate::mcp_engine::DemandedBundle {
         bundle_id: bundle_id.to_owned(),
         name: name.to_owned(),
         workspace_slug: None,
         version_id: String::new(),
         server_json,
-        harness_filter: filter,
-    };
+        reach,
+    }
+    .planned(&io, &descriptors, &detected);
     let outcome = crate::mcp_engine::converge(
         &io,
         std::slice::from_ref(&demand),
-        &topos_harness::mcp::descriptor::mcp_harnesses(),
+        &descriptors,
         &detected,
         &HashSet::new(),
         false,

--- a/bins/topos/src/ops/add_mcp.rs
+++ b/bins/topos/src/ops/add_mcp.rs
@@ -888,6 +888,7 @@ fn converge_one(ctx: &Ctx<'_>, target: &EditTarget, bundle_id: &str, name: &str)
         super::sync_engine::prettify_state_files(ctx, &mut states);
         lines.extend(states.iter().map(agent_line));
     }
+    lines.extend(outcome.notices.iter().cloned());
     lines.extend(outcome.warnings.iter().cloned());
     lines
 }

--- a/bins/topos/src/ops/dest_select.rs
+++ b/bins/topos/src/ops/dest_select.rs
@@ -336,15 +336,17 @@ fn norm(raw: &str) -> String {
 /// written for — naming it would otherwise publish nothing, or reset nothing, and report success;
 /// the other three states say what is actually in the way instead of pretending it is emptiness.
 fn unusable_copy(display: &str, status: &ScanStatus) -> ClientError {
-    ClientError::SelectionRefused(match status {
-        ScanStatus::Clean { .. } => {
+    use crate::placement::Drift;
+    // The words come from the ONE drift vocabulary — the classification, never the bytes.
+    ClientError::SelectionRefused(match status.drift() {
+        Drift::Clean => {
             format!("that copy has no edits — {display} holds the version topos placed there")
         }
-        ScanStatus::Absent => format!("that copy is not there — nothing is placed at {display}"),
-        ScanStatus::Foreign => {
+        Drift::Absent => format!("that copy is not there — nothing is placed at {display}"),
+        Drift::Foreign => {
             format!("{display} holds files topos did not write — it is not a copy of this bundle")
         }
-        ScanStatus::Modified { .. } | ScanStatus::Unscannable => {
+        Drift::Modified | Drift::Unscannable => {
             format!("{display} cannot be read safely — nothing was touched")
         }
     })

--- a/bins/topos/src/ops/manifest_edit.rs
+++ b/bins/topos/src/ops/manifest_edit.rs
@@ -3083,7 +3083,7 @@ fn converge_removed_mcp(
                 _ => format!("{file}: server entry removed"),
             });
         }
-        for w in &outcome.warnings {
+        for w in outcome.notices.iter().chain(&outcome.warnings) {
             lines.push(w.clone());
         }
         if lines.is_empty() {

--- a/bins/topos/src/ops/reconcile.rs
+++ b/bins/topos/src/ops/reconcile.rs
@@ -4821,6 +4821,14 @@ fn run_mcp_converge(
             allow_removals,
         );
         sweep.warnings.extend(outcome.warnings);
+        // Work that SUCCEEDED belongs in disclosures: a wholly-owned config file deleted when its
+        // last entry left is the removal working, and counted as a fault it makes a clean sweep
+        // report itself failed and exit non-zero.
+        for notice in outcome.notices {
+            if !sweep.disclosures.contains(&notice) {
+                sweep.disclosures.push(notice);
+            }
+        }
         // Config entries that LEFT this run ride the receipt as `removed` rows — one per bundle,
         // counted in the config files the entries lived in; a hand-edited entry stays in place
         // and rides the same row's `kept` list. Named from the delivery cache (the entry's
@@ -4880,14 +4888,25 @@ fn run_mcp_converge(
             });
             let (name, ws_id, display) = match named {
                 Some((n, w, d)) => (n, Some(w), d),
-                None => (
-                    bundle_id
-                        .strip_prefix("local:")
-                        .unwrap_or(&bundle_id)
-                        .to_owned(),
-                    None,
-                    None,
-                ),
+                // No delivery cache row describes this bundle (a local row, a workspace whose
+                // cache entry is gone). Its OWN record still holds the name it was placed under —
+                // ask that before falling back to the opaque id, or a receipt announces the
+                // removal of something nobody can recognise.
+                None => {
+                    let recorded = SkillId::parse(&bundle_id).ok().and_then(|sid| {
+                        doc::read_doc::<Lock>(env.ctx.fs, &layout.published(&sid).lock)
+                            .ok()
+                            .flatten()
+                            .map(|l| l.name)
+                    });
+                    let name = recorded.unwrap_or_else(|| {
+                        bundle_id
+                            .strip_prefix("local:")
+                            .unwrap_or(&bundle_id)
+                            .to_owned()
+                    });
+                    (name, None, None)
+                }
             };
             let mut row = plain_row(&name, PullAction::Removed, ws_id, &label);
             row.kind = BundleKind::Mcp.tag();

--- a/bins/topos/src/ops/reconcile.rs
+++ b/bins/topos/src/ops/reconcile.rs
@@ -439,9 +439,11 @@ struct Sweep {
     /// Per scope label, every NAME its rows MENTION — delivered or not. A name a row still names is
     /// never cleaned, so a transient failure can not read as a drop.
     mentioned: BTreeMap<String, HashSet<String>>,
-    /// Per scope label: the MCP demands this sweep resolved (`kind = "mcp"` rows and feed items,
-    /// with the stored `server.json` bytes) — what [`crate::mcp_engine::converge`] runs on.
-    mcp_demands: BTreeMap<String, Vec<crate::mcp_engine::McpDemand>>,
+    /// Per scope label: the MCP bundles this sweep resolved (`kind = "mcp"` rows and feed items,
+    /// with the stored `server.json` bytes and the reach their rows asked for). Planned onto the
+    /// scope's config surfaces — once, in [`run_mcp_converge`] — into what
+    /// [`crate::mcp_engine::converge`] runs on.
+    mcp_demands: BTreeMap<String, Vec<crate::mcp_engine::DemandedBundle>>,
     /// Per scope label: mcp bundle ids whose demand state is UNKNOWABLE this run (a row whose
     /// resolution failed, a store not yet holding bytes) — the engine holds their config entries.
     mcp_hold: BTreeMap<String, HashSet<String>>,
@@ -2247,13 +2249,13 @@ fn local_mcp_demand(
                 narrowing.unreachable.as_deref(),
             );
             sweep.mcp_demands.entry(sc.label.clone()).or_default().push(
-                crate::mcp_engine::McpDemand {
+                crate::mcp_engine::DemandedBundle {
                     bundle_id,
                     name: display.to_owned(),
                     workspace_slug: None,
                     version_id: String::new(),
                     server_json: bytes,
-                    harness_filter: narrowing.filter,
+                    reach: narrowing.filter,
                 },
             );
         }
@@ -2580,9 +2582,17 @@ fn reconcile_feed<'a>(
                 // The marker back-fills offline too: a store synced before the marker existed
                 // gains it from the cache's word, so the cache row's loss stops mattering.
                 crate::bundle_kind::write_kind_marker(&run_ctx, &sid, kind);
+                // The ENTRIES plan: the config files this scope's surfaces put the bundle's
+                // entries in. The offline arm resolves no row `dest`, so it plans the full reach
+                // — the scope converge below re-plans from the same seam with whatever the row
+                // narrowed to.
+                let scope_root = match &sc.scope {
+                    ResolvedScope::Project { dir } => Some(dir.clone()),
+                    ResolvedScope::Person => None,
+                };
                 let plan_fn: Option<&sync_engine::PlanFn<'_>> = if mcp {
-                    Some(&|_: &Ctx<'_>, _: &str, _: &Lock, _: &PlacementMap| {
-                        crate::placement::PlacementPlan::default()
+                    Some(&|ctx: &Ctx<'_>, _: &str, _: &Lock, _: &PlacementMap| {
+                        crate::placement::entries_plan(ctx, scope_root.as_deref(), None)
                     })
                 } else {
                     None
@@ -2815,9 +2825,17 @@ fn sync_workspace_skill<'a>(
     // from wherever the engine computes the plan, so the receipt says so instead of the bundle
     // quietly landing nowhere.
     let escapes: std::cell::RefCell<Vec<String>> = std::cell::RefCell::new(Vec::new());
+    let mcp_reach = st.mcp_dest_filter.clone();
     let plan_fn = |ctx: &Ctx<'_>, skill_id: &str, lock: &Lock, map: &PlacementMap| {
         if mcp {
-            return crate::placement::PlacementPlan::default();
+            // A config-placed bundle plans ENTRIES, not dirs: the config files its row's `dest`
+            // narrowing leaves standing at this scope. The dir half of the engine sees no target
+            // and the store sync degenerates to pure lock/sync advancement, exactly as before.
+            return crate::placement::entries_plan(
+                ctx,
+                project_dir.as_deref(),
+                mcp_reach.as_deref(),
+            );
         }
         // The row's `name` is what the directory is called; everything else about the bundle keeps
         // its catalog identity.
@@ -3290,7 +3308,7 @@ fn push_stored_mcp_demand(
     sid: &SkillId,
     name: &str,
     workspace_slug: Option<&str>,
-    harness_filter: Option<Vec<String>>,
+    reach: Option<Vec<String>>,
     unreachable: Option<&str>,
     row_index: Option<usize>,
     sweep: &mut Sweep,
@@ -3299,13 +3317,13 @@ fn push_stored_mcp_demand(
         Ok(Some((version_id, server_json))) => {
             sweep.note_mcp_row(&sc.label, sid.as_str(), row_index, unreachable);
             sweep.mcp_demands.entry(sc.label.clone()).or_default().push(
-                crate::mcp_engine::McpDemand {
+                crate::mcp_engine::DemandedBundle {
                     bundle_id: sid.as_str().to_owned(),
                     name: name.to_owned(),
                     workspace_slug: workspace_slug.map(str::to_owned),
                     version_id,
                     server_json,
-                    harness_filter,
+                    reach,
                 },
             );
         }
@@ -4751,19 +4769,20 @@ fn run_mcp_converge(
     }
 
     for (label, layout, project_root, person_scope) in scopes_to_run {
-        let demands = sweep.mcp_demands.remove(&label).unwrap_or_default();
+        let rows = sweep.mcp_demands.remove(&label).unwrap_or_default();
         // The common non-mcp machine: no demands and no custody document — nothing to converge,
         // read.
-        if demands.is_empty() && !env.ctx.fs.exists(&layout.config_custody_path()) {
+        if rows.is_empty() && !env.ctx.fs.exists(&layout.config_custody_path()) {
             continue;
         }
+
         let mut hold = machine_hold.clone();
         hold.extend(sweep.mcp_hold.remove(&label).unwrap_or_default());
         // A name a row still MENTIONS whose demand did not land this run (a catalog fetch
         // failure, a refused resolution) must hold its entries too — matched through the cache's
         // name → id rows.
         if let Some(mentioned) = sweep.mentioned.get(&label) {
-            let demanded: HashSet<&str> = demands.iter().map(|d| d.bundle_id.as_str()).collect();
+            let demanded: HashSet<&str> = rows.iter().map(|d| d.bundle_id.as_str()).collect();
             for entry in env.prior.workspaces.values() {
                 for (skill_id, ds) in &entry.delivered {
                     if mentioned.contains(&ds.name) && !demanded.contains(skill_id.as_str()) {
@@ -4785,10 +4804,18 @@ fn run_mcp_converge(
             home: roots.home.clone(),
             project_root: project_root.clone(),
         };
+        let descriptors = topos_harness::mcp::descriptor::mcp_harnesses();
+        // THE ONE PLANNING CALL for this scope: every resolved row's reach becomes the config
+        // files its entries belong in. The converge past this point reads demand from these
+        // plans and custody from each bundle's own record — it decides no reach of its own.
+        let demands: Vec<crate::mcp_engine::McpDemand> = rows
+            .into_iter()
+            .map(|row| row.planned(&io, &descriptors, &detected))
+            .collect();
         let outcome = crate::mcp_engine::converge(
             &io,
             &demands,
-            &topos_harness::mcp::descriptor::mcp_harnesses(),
+            &descriptors,
             &detected,
             &hold,
             allow_removals,

--- a/bins/topos/src/ops/remove.rs
+++ b/bins/topos/src/ops/remove.rs
@@ -337,6 +337,7 @@ fn retire_mcp_entries(ctx: &Ctx<'_>, skill_id: &str, item: &mut RemoveItem) {
             }
         })
         .collect();
+    lines.extend(outcome.notices.iter().cloned());
     lines.extend(outcome.warnings.iter().cloned());
     // A detach that could not take the lock or write the scope document has LOST custody of a
     // drifted row the record is about to take with it. That is the person's business, not a silent

--- a/bins/topos/src/ops/sync_engine.rs
+++ b/bins/topos/src/ops/sync_engine.rs
@@ -310,12 +310,13 @@ pub(crate) fn sync_one_planned(
     // map carries every recorded placement — appended targets are never-materialized until an apply.
     let applied_eq_observed = sync.applied == sync.observed;
     // A CONFIG-PLACED (mcp) record reached without an injected planner (a targeted accept, a
-    // resume) keeps its EMPTY plan: skill-dir placement must never engage for it — its bytes
-    // reach agents through the config converge alone.
+    // resume) plans ENTRIES targets, never dirs: skill-dir placement must never engage for it —
+    // its bytes reach agents through the config files the plan names, and the apply below
+    // dispatches on the target arm.
     let mcp_record = plan_fn.is_none() && planning_kind(ctx, skill_id, &map, &name)?.is_mcp();
     let make_plan = |map: &PlacementMap| match plan_fn {
         Some(f) => f(ctx, skill_id, &lock, map),
-        None if mcp_record => crate::placement::PlacementPlan::default(),
+        None if mcp_record => crate::mcp_engine::recorded_entries_plan(ctx, skill_id),
         None => placement::plan_for_skill(ctx, skill_id, &lock, map),
     };
     let plan = make_plan(&map);
@@ -494,7 +495,8 @@ pub(crate) fn sync_one_planned(
             // advance `applied` with NO swap, never a false DIVERGED — and no spurious draft snapshot.
             heal_forward(ctx, &sp, &map, &managed, &lock, &sync, &t)?;
             let mut row = applied_row(&name, &sync, target_commit);
-            row.harnesses = converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name);
+            row.harnesses =
+                converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name, &plan);
             row.kind = mcp_record.then(|| BundleKind::Mcp.as_str().to_owned());
             mark_installed(ctx, &mut row, first_receive, &map, &managed);
             Ok(row)
@@ -516,7 +518,8 @@ pub(crate) fn sync_one_planned(
             }
             apply_forward(ctx, &sp, &map, &managed, &lock, &sync, skill_id, &t)?;
             let mut row = applied_row(&name, &sync, target_commit);
-            row.harnesses = converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name);
+            row.harnesses =
+                converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name, &plan);
             row.kind = mcp_record.then(|| BundleKind::Mcp.as_str().to_owned());
             mark_installed(ctx, &mut row, first_receive, &map, &managed);
             Ok(row)
@@ -563,6 +566,7 @@ fn converge_explicit_mcp(
     run: bool,
     skill_id: &str,
     name: &str,
+    plan: &crate::placement::PlacementPlan,
 ) -> Vec<topos_types::results::McpAgentState> {
     if !run {
         return Vec::new();
@@ -570,7 +574,7 @@ fn converge_explicit_mcp(
     let Ok(sid) = crate::id::SkillId::parse(skill_id) else {
         return Vec::new();
     };
-    let (mut states, warnings) = crate::mcp_engine::converge_bundle_now(ctx, &sid, name);
+    let (mut states, warnings) = crate::mcp_engine::converge_bundle_now(ctx, &sid, name, plan);
     for w in warnings {
         eprintln!("topos update: {w}");
     }
@@ -647,7 +651,7 @@ pub(crate) fn go_back(
     // for it (the converge below re-renders configs from the restored version's server.json).
     let mcp_record = planning_kind(ctx, skill_id, &map, &name)?.is_mcp();
     let plan = if mcp_record {
-        crate::placement::PlacementPlan::default()
+        crate::mcp_engine::recorded_entries_plan(ctx, skill_id)
     } else {
         placement::plan_for_skill(ctx, skill_id, &lock, &map)
     };
@@ -738,7 +742,8 @@ pub(crate) fn go_back(
     // best-effort sweep fact uses.
     let harnesses = if mcp_record {
         let sid = crate::id::SkillId::parse(skill_id)?;
-        let (mut states, warnings) = crate::mcp_engine::converge_bundle_now(ctx, &sid, &name);
+        let (mut states, warnings) =
+            crate::mcp_engine::converge_bundle_now(ctx, &sid, &name, &plan);
         for w in warnings {
             eprintln!("topos update: {w}");
         }
@@ -810,7 +815,10 @@ pub(crate) fn reset_to_base(
     // Same rule as the go-back: an mcp record never gets skill-dir placements planned, and an
     // empty-map record with no kind evidence fails CLOSED rather than materializing on a guess.
     let plan = if planning_kind(ctx, sid, &map, &lock.name)?.is_mcp() {
-        crate::placement::PlacementPlan::default()
+        // An mcp record plans ENTRIES, so this reset touches no folder. Restoring the store is
+        // where a reset's authority ends here: the config files reconverge on the next sweep (or
+        // on a targeted `update <name>`), which is also where a narrowing change would land.
+        crate::mcp_engine::recorded_entries_plan(ctx, sid)
     } else {
         placement::plan_for_skill(ctx, sid, &lock, &map)
     };
@@ -976,8 +984,8 @@ fn every_copy_settled(ctx: &Ctx<'_>, sp: &sidecar::SkillPaths) -> bool {
     };
     !scans.iter().any(|s| {
         matches!(
-            s.status,
-            ScanStatus::Modified { .. } | ScanStatus::Unscannable
+            s.status.drift(),
+            placement::Drift::Modified | placement::Drift::Unscannable
         )
     })
 }

--- a/bins/topos/src/ops/sync_engine.rs
+++ b/bins/topos/src/ops/sync_engine.rs
@@ -495,8 +495,7 @@ pub(crate) fn sync_one_planned(
             // advance `applied` with NO swap, never a false DIVERGED — and no spurious draft snapshot.
             heal_forward(ctx, &sp, &map, &managed, &lock, &sync, &t)?;
             let mut row = applied_row(&name, &sync, target_commit);
-            row.harnesses =
-                converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name, &plan);
+            row.harnesses = converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name);
             row.kind = mcp_record.then(|| BundleKind::Mcp.as_str().to_owned());
             mark_installed(ctx, &mut row, first_receive, &map, &managed);
             Ok(row)
@@ -518,8 +517,7 @@ pub(crate) fn sync_one_planned(
             }
             apply_forward(ctx, &sp, &map, &managed, &lock, &sync, skill_id, &t)?;
             let mut row = applied_row(&name, &sync, target_commit);
-            row.harnesses =
-                converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name, &plan);
+            row.harnesses = converge_explicit_mcp(ctx, mcp_record && explicit, skill_id, &name);
             row.kind = mcp_record.then(|| BundleKind::Mcp.as_str().to_owned());
             mark_installed(ctx, &mut row, first_receive, &map, &managed);
             Ok(row)
@@ -566,7 +564,6 @@ fn converge_explicit_mcp(
     run: bool,
     skill_id: &str,
     name: &str,
-    plan: &crate::placement::PlacementPlan,
 ) -> Vec<topos_types::results::McpAgentState> {
     if !run {
         return Vec::new();
@@ -574,7 +571,7 @@ fn converge_explicit_mcp(
     let Ok(sid) = crate::id::SkillId::parse(skill_id) else {
         return Vec::new();
     };
-    let (mut states, warnings) = crate::mcp_engine::converge_bundle_now(ctx, &sid, name, plan);
+    let (mut states, warnings) = crate::mcp_engine::converge_bundle_now(ctx, &sid, name);
     for w in warnings {
         eprintln!("topos update: {w}");
     }
@@ -742,8 +739,7 @@ pub(crate) fn go_back(
     // best-effort sweep fact uses.
     let harnesses = if mcp_record {
         let sid = crate::id::SkillId::parse(skill_id)?;
-        let (mut states, warnings) =
-            crate::mcp_engine::converge_bundle_now(ctx, &sid, &name, &plan);
+        let (mut states, warnings) = crate::mcp_engine::converge_bundle_now(ctx, &sid, &name);
         for w in warnings {
             eprintln!("topos update: {w}");
         }

--- a/bins/topos/src/placement.rs
+++ b/bins/topos/src/placement.rs
@@ -1,7 +1,17 @@
-//! The **placement engine** — WHERE a followed skill's bytes land on this machine, computed from the
-//! machine alone: which agents are detected, and which of them read the shared `~/.agents/skills`
-//! convention dir. A row that names its own destinations bypasses detection entirely
-//! ([`dest_plan`]).
+//! The **placement engine** — WHERE a followed bundle's bytes land on this machine, computed from
+//! the machine alone: which agents are detected, and which of them read the shared
+//! `~/.agents/skills` convention dir. A row that names its own destinations bypasses detection
+//! entirely ([`dest_plan`]).
+//!
+//! ## Two target shapes, one plan
+//!
+//! A [`PlacementPlan`] carries [`PlannedTarget`]s of two shapes, and a bundle's kind picks which
+//! arm plans: a **DIRECTORY** this bundle owns ([`DirTarget`] — the dir planners below, written by
+//! [`crate::materialize`]), or **ENTRIES** it owns inside a config file shared with everything else
+//! on the machine ([`EntriesTarget`] — [`entries_plan`], applied by [`crate::mcp_engine`]'s
+//! per-scope converge, one write per file carrying every bundle's entries at once). Nothing forces
+//! one writer; what the two shapes share is the plan, and what the plan means: **WHAT SHOULD
+//! STAND**. What topos actually put there is CUSTODY, and it lives in the bundle's own record.
 //!
 //! ## The policy: shared-dir-first
 //!
@@ -29,9 +39,11 @@
 //! and that no OTHER tracked skill's record owns — is ADOPTED in place (the caller arms the choice
 //! with the incoming bundle digest), never duplicated under a namespaced sibling.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use topos_harness::coverage;
+use topos_harness::mcp::{EntryState, McpDialect, plugin_dir};
 use topos_harness::{PlacementNaming, registry};
 use topos_types::persisted::{Lock, PlacementKind, PlacementMap, PlacementState, SwapCapability};
 
@@ -40,24 +52,82 @@ use crate::error::ClientError;
 use crate::scan::{self, ScannedBundle};
 use crate::stat_cache;
 
-/// One planned placement target — where one copy of the bundle's bytes belongs on this machine.
+/// One planned DIRECTORY target — a folder this bundle owns, written by [`crate::materialize`].
 #[derive(Debug, Clone)]
-pub(crate) struct PlannedTarget {
+pub(crate) struct DirTarget {
     pub dir: PathBuf,
     pub kind: PlacementKind,
     /// The registry slug a `Native` target serves (`None` for the shared dir).
     pub agent: Option<String>,
 }
 
+/// One planned ENTRIES target — the shared config FILE a bundle's entries belong in, and the
+/// dialect that file speaks. Written by the scope's config converge (`crate::mcp_engine`), never
+/// by the materializer: one write per file carries every bundle's entries at once.
+#[derive(Debug, Clone)]
+pub(crate) struct EntriesTarget {
+    /// The DRIVER surface file the entries land in — the plugin dir's own `.mcp.json` under that
+    /// dialect, the descriptor's path everywhere else.
+    pub file: PathBuf,
+    /// The registry slug whose config this is.
+    pub agent: String,
+    pub dialect: McpDialect,
+}
+
+/// One planned target — the two shapes a bundle's bytes reach an agent through: a DIRECTORY this
+/// bundle owns, or ENTRIES it owns inside a config file shared with everything else on the
+/// machine. A kind picks a mechanic; nothing forces one writer.
+#[derive(Debug, Clone)]
+pub(crate) enum PlannedTarget {
+    Dir(DirTarget),
+    Entries(EntriesTarget),
+}
+
+/// A surface this plan deliberately does NOT reach, with the reason the receipt states. Reach is
+/// the plan's answer, so what reach COST is the plan's answer too — without it a bundle that lands
+/// nowhere on some agent would simply go unmentioned.
+#[derive(Debug, Clone)]
+pub(crate) struct WithheldSurface {
+    /// The registry slug that was withheld.
+    pub agent: String,
+    /// The wire state token (`not-supported` — no surface at this scope; `unprovable` — the
+    /// surface cannot be safely edited).
+    pub state: &'static str,
+    /// The note a person reads beside it.
+    pub note: String,
+}
+
 impl PlacementPlan {
-    /// The plan's targets, in plan order — the apply set [`crate::materialize`] writes.
-    pub(crate) fn dirs(&self) -> impl Iterator<Item = &PlannedTarget> {
-        self.targets.iter()
+    /// The plan's DIR targets, in plan order — the apply set [`crate::materialize`] writes.
+    pub(crate) fn dirs(&self) -> impl Iterator<Item = &DirTarget> {
+        self.targets.iter().filter_map(|t| match t {
+            PlannedTarget::Dir(d) => Some(d),
+            PlannedTarget::Entries(_) => None,
+        })
     }
 
-    /// Record one target.
+    /// The plan's ENTRIES targets, in plan order — the demand the scope's config converge applies.
+    pub(crate) fn entries(&self) -> impl Iterator<Item = &EntriesTarget> {
+        self.targets.iter().filter_map(|t| match t {
+            PlannedTarget::Entries(e) => Some(e),
+            PlannedTarget::Dir(_) => None,
+        })
+    }
+
+    /// The planned entries target for one registry slug, if the plan reaches it.
+    pub(crate) fn entries_for(&self, agent: &str) -> Option<&EntriesTarget> {
+        self.entries().find(|e| e.agent == agent)
+    }
+
+    /// What this plan withheld from one registry slug, if anything.
+    pub(crate) fn withheld_for(&self, agent: &str) -> Option<&WithheldSurface> {
+        self.withheld.iter().find(|w| w.agent == agent)
+    }
+
+    /// Record one dir target.
     fn push_dir(&mut self, dir: PathBuf, kind: PlacementKind, agent: Option<String>) {
-        self.targets.push(PlannedTarget { dir, kind, agent });
+        self.targets
+            .push(PlannedTarget::Dir(DirTarget { dir, kind, agent }));
     }
 
     /// Whether a dir is already planned — one dir, one copy, one record.
@@ -82,7 +152,9 @@ pub(crate) struct CoveredAgent {
     pub docs_level: bool,
 }
 
-/// The full placement plan for one skill on this machine.
+/// The full placement plan for one bundle at one scope — WHAT SHOULD STAND. Its targets are the
+/// demand; what topos actually put there is CUSTODY, and that lives in the bundle's own record
+/// (`map.json` for dirs, `entries.json` for config entries), never here.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PlacementPlan {
     pub targets: Vec<PlannedTarget>,
@@ -92,6 +164,9 @@ pub(crate) struct PlacementPlan {
     /// as its disclosure line ([`escape_line`]). The placement is skipped, never redirected; the
     /// caller surfaces the lines so a silent non-delivery is impossible.
     pub refused: Vec<String>,
+    /// ENTRIES plans only: the surfaces this plan does not reach, and why (see
+    /// [`WithheldSurface`]).
+    pub withheld: Vec<WithheldSurface>,
 }
 
 /// Compute the placement plan for one skill. `naming` carries the untrusted display name + workspace
@@ -483,6 +558,165 @@ pub(crate) fn dest_plan(
     plan
 }
 
+// ---------------------------------------------------------------------------------------------
+// The ENTRIES half of the planner — where a bundle's entries belong inside SHARED config files.
+// ---------------------------------------------------------------------------------------------
+
+/// What one harness's MCP config surface resolves to at one scope — the ONE resolution both the
+/// planner (which decides reach) and the converge (which must find the files custody names) ask.
+#[derive(Debug, Clone)]
+pub(crate) enum ConfigSurface {
+    /// A usable surface: the driver file, the path engagement is probed at, and the dialect.
+    Ready {
+        root: PathBuf,
+        file: PathBuf,
+        dialect: McpDialect,
+    },
+    /// The harness has no config surface AT THIS SCOPE (a project scope never falls back to the
+    /// user surface). `note` is the phrase the receipt states.
+    NotSupported { note: &'static str },
+    /// PROJECT scope: the surface does not resolve inside the checkout — refused and disclosed,
+    /// never redirected (the same rail every project path passes, see [`within_project`]).
+    Escaped { path: PathBuf },
+}
+
+/// Resolve one harness's MCP config surface at one scope. `project_root` `Some` = the PROJECT
+/// scope, whose surfaces are the checkout-relative ones, containment-proven.
+pub(crate) fn config_surface(
+    h: &registry::KnownHarness,
+    home: &Path,
+    project_root: Option<&Path>,
+) -> ConfigSurface {
+    let resolved = match project_root {
+        Some(root) => match h.mcp().and_then(|m| m.project) {
+            Some((rel, dialect)) => {
+                let path = root.join(rel);
+                // THE CONTAINMENT RAIL, before ANY read or write: the resolved path (symlinks
+                // followed for the check) must stay inside the checkout.
+                if !within_project(root, &path) {
+                    return ConfigSurface::Escaped { path };
+                }
+                Some((path, dialect))
+            }
+            None => None,
+        },
+        None => h
+            .mcp()
+            .and_then(|m| m.user)
+            .and_then(|s| h.mcp_user_path(home).map(|p| (p, s.dialect))),
+    };
+    match resolved {
+        Some((root, dialect)) => ConfigSurface::Ready {
+            file: surface_file(&root, dialect),
+            root,
+            dialect,
+        },
+        None => ConfigSurface::NotSupported {
+            note: if project_root.is_some() {
+                "no project-level config"
+            } else {
+                "no user-level config"
+            },
+        },
+    }
+}
+
+/// The DRIVER surface file for a resolved descriptor surface: the plugin DIR's `.mcp.json` for
+/// [`McpDialect::ClaudePluginDir`], the path itself for every file dialect.
+pub(crate) fn surface_file(path: &Path, dialect: McpDialect) -> PathBuf {
+    if dialect == McpDialect::ClaudePluginDir {
+        path.join(plugin_dir::PLUGIN_MCP_PATH)
+    } else {
+        path.to_path_buf()
+    }
+}
+
+/// **The ENTRIES plan for one bundle at one scope** — the config files its entries belong in, plus
+/// the surfaces the scope WITHHELD and why. The mirror of the dir planners: it says what SHOULD
+/// stand, and nothing about what already does (that is the bundle's custody record's answer).
+///
+/// `reach` is the harness narrowing the caller resolved — a row's `dest` entries mapped to the
+/// config files they name, or (for a targeted verb) the harnesses whose recorded rows prove the
+/// bundle already stands there. `None` = every MCP-capable harness. Narrowing resolves HERE, once:
+/// a harness outside it earns no target and no withheld line, because the row never asked for it.
+///
+/// The three outcomes, in the order the surface decides them: no surface at this scope, or one the
+/// containment rail refuses ⇒ WITHHELD, disclosed; a surface the machine does not engage (the
+/// harness is neither detected nor does its config already exist) ⇒ nothing at all, because there
+/// is no agent here to reach; else an ENTRIES target.
+pub(crate) fn entries_plan(
+    ctx: &Ctx<'_>,
+    project_root: Option<&Path>,
+    reach: Option<&[String]>,
+) -> PlacementPlan {
+    let Some(roots) = &ctx.roots else {
+        return PlacementPlan::default(); // no machine roots: no config surface is resolvable
+    };
+    // A PROJECT scope detects against the checkout; the person scope against the machine's cwd.
+    let detected: BTreeSet<String> =
+        registry::detected_harnesses(&roots.home, project_root.or(roots.cwd.as_deref()))
+            .iter()
+            .map(|h| h.slug.to_owned())
+            .collect();
+    entries_plan_at(
+        ctx.fs,
+        &topos_harness::mcp::descriptor::mcp_harnesses(),
+        &roots.home,
+        &detected,
+        project_root,
+        reach,
+    )
+}
+
+/// [`entries_plan`] over the primitives — the machine home, the harness table, and the DETECTED
+/// set as arguments (the callers that already probed detection for their converge pass the same
+/// one, so a plan and the converge it feeds can never disagree about which agents are here).
+pub(crate) fn entries_plan_at(
+    fs: &dyn crate::fs_seam::FsOps,
+    descriptors: &[&'static registry::KnownHarness],
+    home: &Path,
+    detected: &BTreeSet<String>,
+    project_root: Option<&Path>,
+    reach: Option<&[String]>,
+) -> PlacementPlan {
+    let mut plan = PlacementPlan::default();
+    for h in descriptors {
+        if reach.is_some_and(|r| !r.iter().any(|s| s == h.slug)) {
+            continue;
+        }
+        match config_surface(h, home, project_root) {
+            ConfigSurface::NotSupported { note } => plan.withheld.push(WithheldSurface {
+                agent: h.slug.to_owned(),
+                state: "not-supported",
+                note: note.to_owned(),
+            }),
+            ConfigSurface::Escaped { .. } => plan.withheld.push(WithheldSurface {
+                agent: h.slug.to_owned(),
+                state: "unprovable",
+                note: "the config path does not resolve inside this checkout".to_owned(),
+            }),
+            ConfigSurface::Ready {
+                root,
+                file,
+                dialect,
+            } => {
+                // Engagement: the harness is detected on this machine, OR its config surface
+                // already exists (entries were placed while it was detected — an update or a
+                // removal must still reach them).
+                if !(detected.contains(h.slug) || fs.exists(&root)) {
+                    continue;
+                }
+                plan.targets.push(PlannedTarget::Entries(EntriesTarget {
+                    file,
+                    agent: h.slug.to_owned(),
+                    dialect,
+                }));
+            }
+        }
+    }
+    plan
+}
+
 /// The classic single-placement plan (no detection): the prior record's targets as-is — except a
 /// STALE adoption reservation (never materialized, dir occupied, the occupant no longer matching
 /// its recorded digest), which is re-chosen fresh so [`reconcile_map`] can replace it (mirroring
@@ -501,14 +735,14 @@ fn classic_plan(
     if let Some(map) = prior
         && !map.placements.is_empty()
     {
-        let mut targets: Vec<PlannedTarget> = Vec::new();
+        let mut targets: Vec<DirTarget> = Vec::new();
         let mut invalid: Vec<(PlacementKind, Option<String>)> = Vec::new();
         for (dir, st) in map.placements.iter().zip(&map.placement_state) {
             let reusable = st.materialized_sha.is_some()
                 || !topos_harness::dir_taken(Path::new(dir))
                 || adoption_reservation_holds(dir, st, adopt);
             if reusable {
-                targets.push(PlannedTarget {
+                targets.push(DirTarget {
                     dir: PathBuf::from(dir),
                     kind: st.kind,
                     agent: st.agent.clone(),
@@ -524,22 +758,20 @@ fn classic_plan(
             if targets.iter().any(|t| t.dir == dir) {
                 continue;
             }
-            targets.push(PlannedTarget { dir, kind, agent });
+            targets.push(DirTarget { dir, kind, agent });
         }
         return PlacementPlan {
-            targets,
-            shared_covers: Vec::new(),
-            refused: Vec::new(),
+            targets: targets.into_iter().map(PlannedTarget::Dir).collect(),
+            ..PlacementPlan::default()
         };
     }
     PlacementPlan {
-        targets: vec![PlannedTarget {
+        targets: vec![PlannedTarget::Dir(DirTarget {
             dir: adapter_choice(ctx, skill_id, naming, &taken, &owned, adopt),
             kind: PlacementKind::Native,
             agent: Some(ctx.harness.id().slug().to_owned()),
-        }],
-        shared_covers: Vec::new(),
-        refused: Vec::new(),
+        })],
+        ..PlacementPlan::default()
     }
 }
 
@@ -916,6 +1148,42 @@ pub(crate) fn managed_indices(map: &PlacementMap, plan: &PlacementPlan) -> Vec<u
 // The multi-placement work-tree scan — draft-anywhere classification.
 // ---------------------------------------------------------------------------------------------
 
+/// **The ONE drift vocabulary** — what a managed target LOOKS LIKE against what the record says
+/// topos put there. Both target shapes project onto these five: a placement DIR through
+/// [`ScanStatus::drift`], a config ENTRY through [`Drift::of_entry`].
+///
+/// It is deliberately PAYLOAD-FREE, and a projection rather than a replacement: the payload stays
+/// where it is load-bearing ([`ScanStatus::Modified`] carries the scanned bytes every consumer
+/// commits), and this is what the words a person reads — and the wire states — are chosen from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Drift {
+    /// Nothing is there: an absent dir, or an entry gone from its config file.
+    Absent,
+    /// Byte-for-byte what the record says topos wrote.
+    Clean,
+    /// Changed since topos wrote it — a local edit, never clobbered.
+    Modified,
+    /// Content topos holds no record of writing: not ours, never overwritten.
+    Foreign,
+    /// It cannot be read safely — fail closed.
+    Unscannable,
+}
+
+impl Drift {
+    /// One config ENTRY's apply outcome projected onto the vocabulary: what the converge FOUND
+    /// before it wrote. A first placement was absent; an update sat at our own recorded
+    /// fingerprint; a hand edit is drift; a `topos-` key we hold no record of is foreign; and an
+    /// entry the removal took out is absent once the write lands.
+    pub(crate) fn of_entry(state: EntryState) -> Self {
+        match state {
+            EntryState::PlacedNew | EntryState::Removed => Self::Absent,
+            EntryState::Current | EntryState::Updated => Self::Clean,
+            EntryState::Drifted => Self::Modified,
+            EntryState::Foreign => Self::Foreign,
+        }
+    }
+}
+
 /// One placement's scan outcome, against ITS OWN recorded materialized sha.
 pub(crate) enum ScanStatus {
     /// The dir does not exist (or is a dangling symlink).
@@ -933,6 +1201,20 @@ pub(crate) enum ScanStatus {
     Foreign,
     /// The dir exists but cannot be scanned safely — fail closed, never overwrite it.
     Unscannable,
+}
+
+impl ScanStatus {
+    /// This dir's projection onto the [one drift vocabulary](Drift) — the classification without
+    /// the bytes, for every consumer that asks WHAT it is rather than WHICH bytes it holds.
+    pub(crate) fn drift(&self) -> Drift {
+        match self {
+            Self::Absent => Drift::Absent,
+            Self::Clean { .. } => Drift::Clean,
+            Self::Modified { .. } => Drift::Modified,
+            Self::Foreign => Drift::Foreign,
+            Self::Unscannable => Drift::Unscannable,
+        }
+    }
 }
 
 /// One placement's scan row.
@@ -1528,13 +1810,12 @@ mod tests {
     fn a_replaced_stale_reservation_resets_the_slot_state() {
         let prior = reservation_map("/skills/deploy", Some(&"a".repeat(64)));
         let plan = PlacementPlan {
-            targets: vec![PlannedTarget {
+            targets: vec![PlannedTarget::Dir(DirTarget {
                 dir: PathBuf::from("/skills/deploy-acme"),
                 kind: PlacementKind::Native,
                 agent: Some("claude-code".to_owned()),
-            }],
-            shared_covers: Vec::new(),
-            refused: Vec::new(),
+            })],
+            ..PlacementPlan::default()
         };
         let next = reconcile_map(&prior, &plan);
         assert_eq!(next.placements, vec!["/skills/deploy-acme".to_owned()]);
@@ -1633,13 +1914,12 @@ mod tests {
     fn an_unchanged_reservation_keeps_its_recorded_state() {
         let prior = reservation_map("/skills/deploy", Some(&"a".repeat(64)));
         let plan = PlacementPlan {
-            targets: vec![PlannedTarget {
+            targets: vec![PlannedTarget::Dir(DirTarget {
                 dir: PathBuf::from("/skills/deploy"),
                 kind: PlacementKind::Native,
                 agent: Some("claude-code".to_owned()),
-            }],
-            shared_covers: Vec::new(),
-            refused: Vec::new(),
+            })],
+            ..PlacementPlan::default()
         };
         let next = reconcile_map(&prior, &plan);
         assert_eq!(next.placements, vec!["/skills/deploy".to_owned()]);

--- a/bins/topos/src/tests/mcp_engine.rs
+++ b/bins/topos/src/tests/mcp_engine.rs
@@ -31,7 +31,7 @@ use crate::ctx::Ctx;
 use crate::error::ClientError;
 use crate::fs_seam::{FaultFs, FsOps as _, RealFs};
 use crate::ids::test_sources::{FixedClock, SeqIds};
-use crate::mcp_engine::{self, McpDemand, ScopeIo};
+use crate::mcp_engine::{self, DemandedBundle, McpDemand, ScopeIo};
 use crate::plane::{
     AppliedSkillReport, DeliverySkill, DeliverySnapshot, DeliverySource, DirectorySource,
     FetchedFile, FetchedVersion, InertFollow, InertPlane, KnownCurrent, LinkStatus, PlaneError,
@@ -516,6 +516,80 @@ static SYNTHETIC: &[KnownHarness] = &[
     ),
 ];
 
+/// **The entries plan is what decides reach — and what says what reach COST.** Four facts, over
+/// the one planner every demand is built through:
+///
+/// - no narrowing ⇒ every engaged harness with a surface at this scope gets a target;
+/// - a narrowing admits exactly what it names, and stays SILENT about the rest — a row that never
+///   asked for a harness is owed no disclosure about it;
+/// - a harness with no surface AT THIS SCOPE is WITHHELD, carrying the phrase the receipt prints
+///   (this is what keeps the per-agent `not-supported` lines alive now that the converge no longer
+///   derives them);
+/// - a harness that is neither detected nor already configured earns neither a target nor a line:
+///   there is no agent here to reach, and nothing was withheld from anyone.
+#[test]
+fn the_entries_plan_carries_reach_and_names_what_it_withheld() {
+    let home = Scratch::new("entries-plan");
+    let fs = RealFs;
+    let plan_at =
+        |detected: &BTreeSet<String>, project: Option<&Path>, reach: Option<&[String]>| {
+            crate::placement::entries_plan_at(&fs, &synthetic(), &home.0, detected, project, reach)
+        };
+    let slugs = |p: &crate::placement::PlacementPlan| -> Vec<String> {
+        p.entries().map(|e| e.agent.clone()).collect()
+    };
+    let withheld = |p: &crate::placement::PlacementPlan| -> Vec<(String, String)> {
+        p.withheld
+            .iter()
+            .map(|w| (w.agent.clone(), w.state.to_owned()))
+            .collect()
+    };
+
+    // Every engaged harness, person scope: six targets, nothing withheld.
+    let all = plan_at(&all_slugs(), None, None);
+    assert_eq!(slugs(&all).len(), synthetic().len(), "{:?}", slugs(&all));
+    assert!(withheld(&all).is_empty(), "{:?}", withheld(&all));
+    // The target names the DRIVER file — the plugin dialect's own `.mcp.json`, not its dir.
+    let plugin = all.entries_for("claude-code").expect("claude-code planned");
+    assert!(
+        plugin.file.ends_with(".mcp.json"),
+        "{}",
+        plugin.file.display()
+    );
+
+    // A narrowing admits exactly what it names — and says nothing about the rest.
+    let narrowed = plan_at(&all_slugs(), None, Some(&["cursor".to_owned()]));
+    assert_eq!(slugs(&narrowed), vec!["cursor".to_owned()]);
+    assert!(withheld(&narrowed).is_empty(), "{:?}", withheld(&narrowed));
+
+    // PROJECT scope: the two harnesses with no project surface are withheld, by name and phrase.
+    let project = Scratch::new("entries-plan-co");
+    let proj = plan_at(&all_slugs(), Some(&project.0), None);
+    for slug in ["openclaw", "hermes-agent"] {
+        assert!(
+            proj.entries_for(slug).is_none(),
+            "{slug} must not be planned"
+        );
+        let w = proj.withheld_for(slug).unwrap_or_else(|| panic!("{slug}"));
+        assert_eq!(
+            (w.state, w.note.as_str()),
+            ("not-supported", "no project-level config")
+        );
+    }
+    assert!(proj.entries_for("cursor").is_some());
+
+    // Nothing detected and no config on disk: no target, and nothing withheld from anyone.
+    let cold = Scratch::new("entries-plan-cold");
+    let cold_plan =
+        crate::placement::entries_plan_at(&fs, &synthetic(), &cold.0, &BTreeSet::new(), None, None);
+    assert!(slugs(&cold_plan).is_empty(), "{:?}", slugs(&cold_plan));
+    assert!(
+        withheld(&cold_plan).is_empty(),
+        "{:?}",
+        withheld(&cold_plan)
+    );
+}
+
 /// The synthetic table as the engine takes it — the same `&[&KnownHarness]` view the real
 /// [`mcp_harnesses`](topos_harness::mcp::descriptor::mcp_harnesses) hands production.
 fn synthetic() -> Vec<&'static KnownHarness> {
@@ -535,15 +609,24 @@ fn person_io<'a>(fs: &'a RealFs, layout: &'a Layout, home: &Path) -> ScopeIo<'a>
     }
 }
 
-fn demand(bundle_id: &str, name: &str, ws: Option<&str>, server: &str) -> McpDemand {
-    McpDemand {
+fn demand(bundle_id: &str, name: &str, ws: Option<&str>, server: &str) -> DemandedBundle {
+    DemandedBundle {
         bundle_id: bundle_id.to_owned(),
         name: name.to_owned(),
         workspace_slug: ws.map(str::to_owned),
         version_id: "v1".to_owned(),
         server_json: server.as_bytes().to_vec(),
-        harness_filter: None,
+        reach: None,
     }
+}
+
+/// Plan a scope's demanded rows onto the SYNTHETIC harness table — the production seam
+/// ([`DemandedBundle::planned`]) with the tests' own rows, so a converge here reads its demand
+/// off plans exactly as the sweep does.
+fn plan(io: &ScopeIo<'_>, rows: Vec<DemandedBundle>) -> Vec<McpDemand> {
+    rows.into_iter()
+        .map(|r| r.planned(io, &synthetic(), &all_slugs()))
+        .collect()
 }
 
 fn no_hold() -> HashSet<String> {
@@ -581,9 +664,10 @@ fn converge_places_into_all_six_dialects_byte_identical_to_the_drivers() {
         Some("eng"),
         &server_json("https://mcp.example/linear"),
     );
+    let io = person_io(&fs, &layout, &home.0);
     let out = mcp_engine::converge(
-        &person_io(&fs, &layout, &home.0),
-        std::slice::from_ref(&d),
+        &io,
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -669,8 +753,8 @@ fn converge_places_into_all_six_dialects_byte_identical_to_the_drivers() {
         .map(Option::unwrap_or_default)
         .collect();
     let out2 = mcp_engine::converge(
-        &person_io(&fs, &layout, &home.0),
-        std::slice::from_ref(&d),
+        &io,
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -713,9 +797,10 @@ fn removal_converges_everywhere_and_deletes_only_wholly_owned_files() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
+    let io = person_io(&fs, &layout, &home.0);
     let out = mcp_engine::converge(
-        &person_io(&fs, &layout, &home.0),
-        std::slice::from_ref(&d),
+        &io,
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -772,15 +857,15 @@ fn a_hand_edited_entry_is_drift_never_clobbered_and_survives_removal_disclosed()
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    let cursor_only = |d: &McpDemand| {
+    let cursor_only = |d: &DemandedBundle| {
         let mut d = d.clone();
-        d.harness_filter = Some(vec!["cursor".into()]);
+        d.reach = Some(vec!["cursor".into()]);
         d
     };
     let io = person_io(&fs, &layout, &home.0);
     mcp_engine::converge(
         &io,
-        &[cursor_only(&d)],
+        &plan(&io, vec![cursor_only(&d)]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -797,7 +882,7 @@ fn a_hand_edited_entry_is_drift_never_clobbered_and_survives_removal_disclosed()
     // fingerprint so drift survives re-runs.
     let out = mcp_engine::converge(
         &io,
-        &[cursor_only(&d)],
+        &plan(&io, vec![cursor_only(&d)]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -839,9 +924,16 @@ fn a_foreign_topos_prefixed_entry_is_never_touched_or_claimed() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["cursor".into()]);
+    d.reach = Some(vec!["cursor".into()]);
     let io = person_io(&fs, &layout, &home.0);
-    let out = mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+    let out = mcp_engine::converge(
+        &io,
+        &plan(&io, vec![d.clone()]),
+        &synthetic(),
+        &all_slugs(),
+        &no_hold(),
+        true,
+    );
     assert_eq!(state_of(&out, "s_a", "cursor").state, "conflicting");
     assert_eq!(
         std::fs::read_to_string(&cursor).unwrap(),
@@ -863,8 +955,15 @@ fn a_suspect_header_fails_the_demand_closed_with_a_warning() {
     let io = person_io(&fs, &layout, &home.0);
     let mut d = demand("s_a", "alpha", Some("eng"), "");
     d.server_json = br#"{"name":"io.test/a","description":"A.","version":"1.0.0","remotes":[{"type":"streamable-http","url":"https://a.example","headers":[{"name":"Authorization","isSecret":true}]}]}"#.to_vec();
-    d.harness_filter = Some(vec!["cursor".into()]);
-    let out = mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+    d.reach = Some(vec!["cursor".into()]);
+    let out = mcp_engine::converge(
+        &io,
+        &plan(&io, vec![d.clone()]),
+        &synthetic(),
+        &all_slugs(),
+        &no_hold(),
+        true,
+    );
     assert!(
         out.warnings
             .iter()
@@ -888,9 +987,9 @@ fn a_sibling_key_in_the_plugin_mcp_json_backs_the_surface_off_and_survives() {
     let fs = RealFs;
     let layout = Layout::new(&home.0.join(".topos"));
     let io = person_io(&fs, &layout, &home.0);
-    let claude_only = |d: &McpDemand| {
+    let claude_only = |d: &DemandedBundle| {
         let mut d = d.clone();
-        d.harness_filter = Some(vec!["claude-code".into()]);
+        d.reach = Some(vec!["claude-code".into()]);
         d
     };
     let v1 = demand(
@@ -901,7 +1000,7 @@ fn a_sibling_key_in_the_plugin_mcp_json_backs_the_surface_off_and_survives() {
     );
     mcp_engine::converge(
         &io,
-        &[claude_only(&v1)],
+        &plan(&io, vec![claude_only(&v1)]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -926,7 +1025,7 @@ fn a_sibling_key_in_the_plugin_mcp_json_backs_the_surface_off_and_survives() {
     );
     let out = mcp_engine::converge(
         &io,
-        &[claude_only(&v2)],
+        &plan(&io, vec![claude_only(&v2)]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -957,9 +1056,9 @@ fn a_hand_edited_plugin_manifest_survives_update_and_removal_disclosed() {
     let fs = RealFs;
     let layout = Layout::new(&home.0.join(".topos"));
     let io = person_io(&fs, &layout, &home.0);
-    let claude_only = |d: &McpDemand| {
+    let claude_only = |d: &DemandedBundle| {
         let mut d = d.clone();
-        d.harness_filter = Some(vec!["claude-code".into()]);
+        d.reach = Some(vec!["claude-code".into()]);
         d
     };
     let v1 = demand(
@@ -970,7 +1069,7 @@ fn a_hand_edited_plugin_manifest_survives_update_and_removal_disclosed() {
     );
     mcp_engine::converge(
         &io,
-        &[claude_only(&v1)],
+        &plan(&io, vec![claude_only(&v1)]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -994,7 +1093,7 @@ fn a_hand_edited_plugin_manifest_survives_update_and_removal_disclosed() {
     );
     let out = mcp_engine::converge(
         &io,
-        &[claude_only(&v2)],
+        &plan(&io, vec![claude_only(&v2)]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1056,10 +1155,10 @@ fn a_hand_deleted_plugin_manifest_heals_back_beside_remaining_entries() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["claude-code".into()]);
+    d.reach = Some(vec!["claude-code".into()]);
     mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1071,7 +1170,14 @@ fn a_hand_deleted_plugin_manifest_heals_back_beside_remaining_entries() {
     std::fs::remove_file(&manifest).unwrap();
 
     // The next converge (nothing changed — a Leave) re-heals the constant file.
-    mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+    mcp_engine::converge(
+        &io,
+        &plan(&io, vec![d.clone()]),
+        &synthetic(),
+        &all_slugs(),
+        &no_hold(),
+        true,
+    );
     assert_eq!(
         std::fs::read(&manifest).unwrap_or_else(|e| panic!("the manifest was not healed: {e}")),
         plugin_dir::manifest_bytes()
@@ -1109,8 +1215,15 @@ fn converges_serialize_on_the_per_scope_mcp_lock() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec!["cursor".into()]);
-        let out = mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+        d.reach = Some(vec!["cursor".into()]);
+        let out = mcp_engine::converge(
+            &io,
+            &plan(&io, vec![d.clone()]),
+            &synthetic(),
+            &all_slugs(),
+            &no_hold(),
+            true,
+        );
         tx.send(out).unwrap();
     });
 
@@ -1149,10 +1262,10 @@ fn a_moved_surface_path_discloses_the_stale_row_and_never_drops_it() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["cursor".into()]);
+    d.reach = Some(vec!["cursor".into()]);
     mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1224,10 +1337,10 @@ fn a_hand_deleted_plugin_dir_sheds_its_ledger_entries_on_the_next_converge() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["claude-code".into()]);
+    d.reach = Some(vec!["claude-code".into()]);
     mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1326,10 +1439,10 @@ fn a_user_entry_added_to_a_topos_created_file_survives_last_entry_removal() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec![slug.to_owned()]);
+        d.reach = Some(vec![slug.to_owned()]);
         mcp_engine::converge(
             &io,
-            std::slice::from_ref(&d),
+            &plan(&io, vec![d.clone()]),
             &synthetic(),
             &all_slugs(),
             &no_hold(),
@@ -1373,10 +1486,10 @@ fn a_converge_that_sees_user_content_flips_owns_file_false() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["cursor".into()]);
+    d.reach = Some(vec!["cursor".into()]);
     mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1403,7 +1516,7 @@ fn a_converge_that_sees_user_content_flips_owns_file_false() {
     std::fs::write(&cursor, serde_json::to_string_pretty(&root).unwrap() + "\n").unwrap();
     let out = mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1431,8 +1544,15 @@ fn the_engine_places_the_remote_the_gate_approved_not_the_first_typed_one() {
     let io = person_io(&fs, &layout, &home.0);
     let mut d = demand("s_two", "two", Some("eng"), "");
     d.server_json = br#"{"name":"io.test/two","description":"Two remotes.","version":"1.0.0","remotes":[{"type":"streamable-http"},{"type":"streamable-http","url":"https://second.example/mcp"}]}"#.to_vec();
-    d.harness_filter = Some(vec!["cursor".into()]);
-    let out = mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+    d.reach = Some(vec!["cursor".into()]);
+    let out = mcp_engine::converge(
+        &io,
+        &plan(&io, vec![d.clone()]),
+        &synthetic(),
+        &all_slugs(),
+        &no_hold(),
+        true,
+    );
     assert!(out.warnings.is_empty(), "{:?}", out.warnings);
     assert_eq!(state_of(&out, "s_two", "cursor").state, "placed");
     let text = std::fs::read_to_string(home.0.join(".cursor/mcp.json")).unwrap();
@@ -1451,10 +1571,10 @@ fn holds_and_targeted_runs_never_remove_standing_entries() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["cursor".into()]);
+    d.reach = Some(vec!["cursor".into()]);
     mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1495,10 +1615,10 @@ fn intent_journal_recovery_heals_both_crash_orders_through_the_engine() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["cursor".into()]);
+    d.reach = Some(vec!["cursor".into()]);
     mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1538,7 +1658,7 @@ fn intent_journal_recovery_heals_both_crash_orders_through_the_engine() {
     assert!(custody.flush(&fs, &layout).is_empty());
     let out = mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1583,7 +1703,7 @@ fn intent_journal_recovery_heals_both_crash_orders_through_the_engine() {
         .unwrap();
     let out = mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -1621,7 +1741,7 @@ fn a_later_surface_never_journals_over_intents_an_earlier_one_left_standing() {
         };
         mcp_engine::converge(
             &io,
-            &two_bundle_demands(),
+            &plan(&io, two_bundle_demands()),
             &synthetic(),
             &all_slugs(),
             &no_hold(),
@@ -1652,7 +1772,7 @@ fn a_later_surface_never_journals_over_intents_an_earlier_one_left_standing() {
             };
             let _ = mcp_engine::converge(
                 &io,
-                &two_bundle_demands(),
+                &plan(&io, two_bundle_demands()),
                 &synthetic(),
                 &all_slugs(),
                 &no_hold(),
@@ -1686,7 +1806,7 @@ fn a_later_surface_never_journals_over_intents_an_earlier_one_left_standing() {
             };
             mcp_engine::converge(
                 &io,
-                &two_bundle_demands(),
+                &plan(&io, two_bundle_demands()),
                 &synthetic(),
                 &all_slugs(),
                 &no_hold(),
@@ -1712,7 +1832,7 @@ fn a_later_surface_never_journals_over_intents_an_earlier_one_left_standing() {
 }
 
 /// Two bundles that converge on DIFFERENT surfaces in one run — the cross-surface fixture.
-fn two_bundle_demands() -> Vec<McpDemand> {
+fn two_bundle_demands() -> Vec<DemandedBundle> {
     // X rides the EARLIER surface in table order (codex) and Y the later one (cursor), so Y's
     // journal write genuinely comes after X has left intents standing — the ordering the guard is
     // about. Reversed, X is the last surface and nothing follows it to overwrite anything.
@@ -1722,14 +1842,14 @@ fn two_bundle_demands() -> Vec<McpDemand> {
         Some("eng"),
         &server_json("https://mcp.example/x"),
     );
-    x.harness_filter = Some(vec!["codex".into()]);
+    x.reach = Some(vec!["codex".into()]);
     let mut y = demand(
         "s_y",
         "why",
         Some("eng"),
         &server_json("https://mcp.example/y"),
     );
-    y.harness_filter = Some(vec!["cursor".into()]);
+    y.reach = Some(vec!["cursor".into()]);
     vec![x, y]
 }
 
@@ -1765,8 +1885,15 @@ fn a_removal_never_swallows_a_crash_left_intent_before_it_is_durable() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec!["cursor".into()]);
-        mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+        d.reach = Some(vec!["cursor".into()]);
+        mcp_engine::converge(
+            &io,
+            &plan(&io, vec![d.clone()]),
+            &synthetic(),
+            &all_slugs(),
+            &no_hold(),
+            true,
+        );
         fault.ops_attempted()
     };
 
@@ -1781,7 +1908,7 @@ fn a_removal_never_swallows_a_crash_left_intent_before_it_is_durable() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec!["cursor".into()]);
+        d.reach = Some(vec!["cursor".into()]);
         // A clean placement first.
         {
             let io = ScopeIo {
@@ -1792,7 +1919,7 @@ fn a_removal_never_swallows_a_crash_left_intent_before_it_is_durable() {
             };
             mcp_engine::converge(
                 &io,
-                std::slice::from_ref(&d),
+                &plan(&io, vec![d.clone()]),
                 &synthetic(),
                 &all_slugs(),
                 &no_hold(),
@@ -1901,10 +2028,10 @@ fn a_drifted_entry_outlives_the_record_and_is_still_cleaned_up_later() {
         Some("eng"),
         &server_json("https://mcp.example/a"),
     );
-    d.harness_filter = Some(vec!["cursor".into()]);
+    d.reach = Some(vec!["cursor".into()]);
     mcp_engine::converge(
         &io,
-        std::slice::from_ref(&d),
+        &plan(&io, vec![d.clone()]),
         &synthetic(),
         &all_slugs(),
         &no_hold(),
@@ -2030,8 +2157,15 @@ fn a_failed_record_write_keeps_its_intents_in_the_durable_journal() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec!["cursor".into()]);
-        mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+        d.reach = Some(vec!["cursor".into()]);
+        mcp_engine::converge(
+            &io,
+            &plan(&io, vec![d.clone()]),
+            &synthetic(),
+            &all_slugs(),
+            &no_hold(),
+            true,
+        );
         fault.ops_attempted()
     };
     assert!(probe > 0);
@@ -2047,7 +2181,7 @@ fn a_failed_record_write_keeps_its_intents_in_the_durable_journal() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec!["cursor".into()]);
+        d.reach = Some(vec!["cursor".into()]);
         {
             let fault = FaultFs::new(fail_at);
             let io = ScopeIo {
@@ -2058,7 +2192,7 @@ fn a_failed_record_write_keeps_its_intents_in_the_durable_journal() {
             };
             let _ = mcp_engine::converge(
                 &io,
-                std::slice::from_ref(&d),
+                &plan(&io, vec![d.clone()]),
                 &synthetic(),
                 &all_slugs(),
                 &no_hold(),
@@ -2093,7 +2227,7 @@ fn a_failed_record_write_keeps_its_intents_in_the_durable_journal() {
             };
             mcp_engine::converge(
                 &io,
-                std::slice::from_ref(&d),
+                &plan(&io, vec![d.clone()]),
                 &synthetic(),
                 &all_slugs(),
                 &no_hold(),
@@ -2139,8 +2273,15 @@ fn a_fault_at_any_write_never_tears_state_and_the_next_converge_heals() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec!["cursor".into()]);
-        mcp_engine::converge(&io, &[d], &synthetic(), &all_slugs(), &no_hold(), true);
+        d.reach = Some(vec!["cursor".into()]);
+        mcp_engine::converge(
+            &io,
+            &plan(&io, vec![d.clone()]),
+            &synthetic(),
+            &all_slugs(),
+            &no_hold(),
+            true,
+        );
         fault.ops_attempted()
     };
     assert!(probe > 0);
@@ -2153,7 +2294,7 @@ fn a_fault_at_any_write_never_tears_state_and_the_next_converge_heals() {
             Some("eng"),
             &server_json("https://mcp.example/a"),
         );
-        d.harness_filter = Some(vec!["cursor".into()]);
+        d.reach = Some(vec!["cursor".into()]);
         {
             let fault = FaultFs::new(fail_at);
             let io = ScopeIo {
@@ -2164,7 +2305,7 @@ fn a_fault_at_any_write_never_tears_state_and_the_next_converge_heals() {
             };
             let _ = mcp_engine::converge(
                 &io,
-                std::slice::from_ref(&d),
+                &plan(&io, vec![d.clone()]),
                 &synthetic(),
                 &all_slugs(),
                 &no_hold(),
@@ -2176,7 +2317,7 @@ fn a_fault_at_any_write_never_tears_state_and_the_next_converge_heals() {
         let io = person_io(&fs, &layout, &home.0);
         let out = mcp_engine::converge(
             &io,
-            std::slice::from_ref(&d),
+            &plan(&io, vec![d.clone()]),
             &synthetic(),
             &all_slugs(),
             &no_hold(),
@@ -3906,7 +4047,8 @@ fn a_deleted_ledger_makes_the_targeted_go_back_skip_with_a_warning() {
 
     // The converge the go-back hand-runs: zero writes, one honest warning.
     let sid = crate::id::SkillId::parse("s_linear").unwrap();
-    let (states, warnings) = crate::mcp_engine::converge_bundle_now(&ctx, &sid, "linear");
+    let plan = crate::mcp_engine::recorded_entries_plan(&ctx, sid.as_str());
+    let (states, warnings) = crate::mcp_engine::converge_bundle_now(&ctx, &sid, "linear", &plan);
     assert!(states.is_empty(), "{states:?}");
     assert!(
         warnings

--- a/bins/topos/src/tests/mcp_engine.rs
+++ b/bins/topos/src/tests/mcp_engine.rs
@@ -516,6 +516,243 @@ static SYNTHETIC: &[KnownHarness] = &[
     ),
 ];
 
+/// **Z1 — the containment rail is re-run at the WRITE boundary.** A plan resolves a project
+/// surface once and the converge writes it later; `replace_config` follows symlinks, so a path
+/// component swapped for an outward symlink in that window would put managed bytes outside the
+/// checkout. The proof therefore re-runs immediately before any byte moves: ZERO writes outside,
+/// the `unprovable` state spoken with the same note the planner's withheld line carries, and the
+/// escape disclosed.
+#[test]
+fn a_surface_symlinked_out_between_plan_and_write_is_refused_with_zero_writes() {
+    let fs = RealFs;
+    let project = Scratch::new("wb-project");
+    let outside = Scratch::new("wb-outside");
+    std::fs::create_dir_all(project.0.join(".cursor")).unwrap();
+    let layout = Layout::new(&project.0.join(".topos"));
+    let io = ScopeIo {
+        fs: &fs,
+        layout: &layout,
+        home: project.0.clone(),
+        project_root: Some(project.0.clone()),
+    };
+    let mut d = demand(
+        "s_a",
+        "alpha",
+        Some("eng"),
+        &server_json("https://mcp.example/a"),
+    );
+    d.reach = Some(vec!["cursor".into()]);
+    // The plan proves containment HERE, while `.cursor` is an ordinary dir inside the checkout.
+    let demands = plan(&io, vec![d]);
+    assert!(
+        demands[0].plan.entries_for("cursor").is_some(),
+        "the surface planned clean: {:?}",
+        demands[0].plan
+    );
+
+    // ...and the checkout is rewritten under it before the write lands.
+    std::fs::remove_dir_all(project.0.join(".cursor")).unwrap();
+    std::os::unix::fs::symlink(&outside.0, project.0.join(".cursor")).unwrap();
+
+    let out = mcp_engine::converge(&io, &demands, &synthetic(), &all_slugs(), &no_hold(), true);
+
+    assert!(
+        !outside.0.join("mcp.json").exists(),
+        "no managed byte may land outside the checkout"
+    );
+    let st = state_of(&out, "s_a", "cursor");
+    assert_eq!(st.state, "unprovable", "{st:?}");
+    assert_eq!(
+        st.note.as_deref(),
+        Some("the config path does not resolve inside this checkout")
+    );
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.starts_with("PLACEMENT_ESCAPES_PROJECT")),
+        "{:?}",
+        out.warnings
+    );
+}
+
+/// **Z2 — a targeted converge whose whole reach is WITHHELD still speaks, and still recovers.**
+/// The reach resolves to one harness whose surface no longer proves inside the checkout, so there
+/// is nothing to write anywhere. Returning early there would drop the per-agent line the receipt
+/// owes AND skip the intent journal's crash recovery, which runs inside the converge — so a crash
+/// left by an earlier run would survive every targeted verb.
+#[test]
+fn a_targeted_converge_with_only_withheld_surfaces_reports_and_still_recovers() {
+    let rig = Rig::new("withheld-targeted");
+    rig.seed_session();
+    seed_harness_dirs(&rig.home.0);
+    let proj = Scratch::new("withheld-co");
+    std::fs::create_dir_all(proj.0.join(".git")).unwrap();
+    std::fs::create_dir_all(proj.0.join(".cursor")).unwrap();
+    std::fs::write(
+        proj.0.join(crate::manifest::MANIFEST_FILE),
+        format!("[bundles]\n\"{HOST}/{WS_NAME}/linear\" = {{ dest = [\"./.cursor/mcp.json\"] }}\n"),
+    )
+    .unwrap();
+    let v = mk_version(&[(
+        "server.json",
+        server_json("https://mcp.example/linear").as_bytes(),
+    )]);
+    let plane = FakePlane::new().with_version("s_linear", &v);
+    plane.serves(vec![delivered_mcp("s_linear", "linear", &v)]);
+    let dir = FakeDirectory {
+        skills: vec![mcp_catalog_entry("s_linear", "linear", &v)],
+        channels: Vec::new(),
+    };
+    let ctx = rig.ctx_at(Some(&proj.0));
+    sweep(&ctx, &plane, &dir);
+    assert!(
+        proj.0.join(".cursor/mcp.json").exists(),
+        "the sweep placed the one narrowed surface"
+    );
+
+    // The checkout is rewritten: the ONLY harness the record reaches no longer proves inside it.
+    let outside = Scratch::new("withheld-outside");
+    std::fs::remove_dir_all(proj.0.join(".cursor")).unwrap();
+    std::os::unix::fs::symlink(&outside.0, proj.0.join(".cursor")).unwrap();
+
+    // A crash-left intent standing in the scope journal — only a run that ENTERS the converge
+    // resolves it.
+    let playout = crate::sidecar::existing_project_store(&rig.fs, &proj.0).unwrap();
+    let mut custody = crate::config_custody::ScopeEntries::load(&rig.fs, &playout).unwrap();
+    let mut intents = std::collections::BTreeMap::new();
+    intents.insert(
+        crate::config_custody::placement_key("codex", "topos-eng-ghost"),
+        crate::config_custody::PendingIntent {
+            bundle_id: "s_ghost".to_owned(),
+            version_id: "v1".to_owned(),
+            file: proj.0.join(".codex/config.toml").display().to_string(),
+            fingerprint: "deadbeef".to_owned(),
+            owns_file: false,
+        },
+    );
+    custody.journal(&rig.fs, &playout, intents).unwrap();
+    assert!(
+        crate::config_custody::ScopeEntries::load(&rig.fs, &playout)
+            .unwrap()
+            .has_pending(),
+        "the crash-left intent stands before the verb"
+    );
+
+    let out = ops::pull(
+        &ctx,
+        ops::PullScope::One {
+            name: "linear".into(),
+            workspace: None,
+            mode: ops::TargetMode::GoBack(ops::VersionRef::Full(v.id)),
+            store: ops::StoreScope::Here,
+        },
+    )
+    .expect("the go-back applies");
+
+    // It SPOKE: the per-agent line survives a run that wrote nothing.
+    let row = &out.data.skills[0];
+    let st = row
+        .harnesses
+        .iter()
+        .find(|h| h.agent == "cursor")
+        .unwrap_or_else(|| panic!("cursor state: {row:?}"));
+    assert_eq!(st.state, "unprovable", "{st:?}");
+    assert!(
+        !outside.0.join("mcp.json").exists(),
+        "nothing lands outside the checkout"
+    );
+    // And it RECOVERED: the journal the crash left is resolved by observation, not carried.
+    assert!(
+        !crate::config_custody::ScopeEntries::load(&rig.fs, &playout)
+            .unwrap()
+            .has_pending(),
+        "the converge ran its crash recovery"
+    );
+}
+
+/// **Z5 — a `dest` move is a wholly successful sweep, and it says so.** Moving a bundle's config
+/// destination from one agent to another removes its entry from the old surface and deletes the
+/// file topos wholly owned there. Both are work that WORKED: routed through the warning channel
+/// the deletion made a clean run count itself FAILED and exit non-zero while `--json` still said
+/// `ok: true`. It rides disclosures now — and the row reporting the surfaces the bundle left names
+/// it the way a person knows it. For a LOCALLY ADOPTED bundle no delivery cache describes, that
+/// name comes from the bundle's own record; the opaque store id is the last resort, not the first
+/// answer.
+#[test]
+fn a_dest_move_is_a_clean_sweep_that_names_the_bundle_it_moved() {
+    let rig = Rig::new("dest-move");
+    seed_harness_dirs(&rig.home.0);
+    rig.write_global("[bundles]\n");
+    let dir = rig.home.0.join("demo");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("server.json"),
+        "{\"name\":\"io.test/demo\",\"description\":\"D.\",\"version\":\"1.0.0\",\
+         \"remotes\":[{\"type\":\"streamable-http\",\"url\":\"https://demo.example/mcp\"}]}",
+    )
+    .unwrap();
+    let ctx = rig.ctx_at(Some(&rig.work.0));
+    let never = |_s: &Session| -> ops::SessionTransports {
+        unreachable!("the path door never dials a session")
+    };
+    // Adopted in place: the store tracks the folder under an opaque id, and no delivery cache
+    // will ever describe it — the shape whose receipt used to print that id at a person.
+    ops::add_mcp(
+        &ctx,
+        &never,
+        None,
+        dir.to_str().unwrap(),
+        true,
+        None,
+        &Default::default(),
+    )
+    .expect("the local mcp folder adopts");
+    let plane = FakePlane::new();
+    let fdir = FakeDirectory {
+        skills: Vec::new(),
+        channels: Vec::new(),
+    };
+    rig.write_global(&format!(
+        "[bundles]\n\"{}\" = {{ kind = \"mcp\", dest = [\"~/.cursor/mcp.json\"] }}\n",
+        dir.display()
+    ));
+    sweep(&ctx, &plane, &fdir);
+    let cursor = rig.home.0.join(".cursor/mcp.json");
+    assert!(cursor.exists(), "the first sweep placed cursor");
+
+    // The row's destination MOVES. The old surface loses the entry, and the file topos created
+    // there goes with it.
+    rig.write_global(&format!(
+        "[bundles]\n\"{}\" = {{ kind = \"mcp\", dest = [\"~/.openclaw/openclaw.json\"] }}\n",
+        dir.display()
+    ));
+    let out = sweep(&ctx, &plane, &fdir);
+
+    assert!(
+        rig.home.0.join(".openclaw/openclaw.json").exists(),
+        "the new destination gained the entry"
+    );
+    assert!(!cursor.exists(), "the wholly-owned old file was deleted");
+    // NOTHING failed — the whole point: a successful move exits 0.
+    assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    // The deletion is a DISCLOSURE, and it still names the file it deleted.
+    assert!(
+        out.disclosures
+            .iter()
+            .any(|d| d.starts_with("MCP_FILE_REMOVED") && d.contains("mcp.json")),
+        "{:?}",
+        out.disclosures
+    );
+    // The row for the surfaces the bundle left names `demo` — never the store's id for it.
+    let left = out
+        .data
+        .skills
+        .iter()
+        .find(|r| r.action == topos_types::results::PullAction::Removed)
+        .unwrap_or_else(|| panic!("{:?}", out.data.skills));
+    assert_eq!(left.skill, "demo", "{left:?}");
+}
+
 /// **The entries plan is what decides reach — and what says what reach COST.** Four facts, over
 /// the one planner every demand is built through:
 ///
@@ -3857,9 +4094,9 @@ fn a_targeted_go_back_converges_the_configs_to_the_restored_document() {
 /// ITEM PAIR (targeted go-back honors narrowing): a bundle narrowed to ONE harness must stay in
 /// that one harness through a targeted `update <mcp>@<version>` — the go-back's converge reaches
 /// only the harnesses that already hold a custody entry here, so a harness the narrowing excluded
-/// never gains one. Before the fix the targeted demand carried an EMPTY filter, which
-/// `filter_admits` reads as ALL harnesses: openclaw (detected, engaged, excluded by the row)
-/// gained an entry the sweep then had to claw back.
+/// never gains one. Before the fix the targeted demand carried an EMPTY narrowing, read as ALL
+/// harnesses: openclaw (detected, engaged, excluded by the row) gained an entry the sweep then had
+/// to claw back.
 #[test]
 fn a_targeted_go_back_never_reaches_a_narrowing_excluded_harness() {
     let rig = Rig::new("goback-narrow");
@@ -4047,8 +4284,7 @@ fn a_deleted_ledger_makes_the_targeted_go_back_skip_with_a_warning() {
 
     // The converge the go-back hand-runs: zero writes, one honest warning.
     let sid = crate::id::SkillId::parse("s_linear").unwrap();
-    let plan = crate::mcp_engine::recorded_entries_plan(&ctx, sid.as_str());
-    let (states, warnings) = crate::mcp_engine::converge_bundle_now(&ctx, &sid, "linear", &plan);
+    let (states, warnings) = crate::mcp_engine::converge_bundle_now(&ctx, &sid, "linear");
     assert!(states.is_empty(), "{states:?}");
     assert!(
         warnings


### PR DESCRIPTION
The demand half of the pipeline unification: MCP delivery rides the same planning seam as skill placement. Together with the custody half (#46), the second delivery engine is gone as a separate structure — a bundle's plan carries typed targets, and the kind decides which write mechanic applies.

## What changes

- **One planning seam.** A plan's target is a directory the bundle owns *or* the config files its entries land in, resolved at planning time from the one harness table and the row's dest narrowing — plus the surfaces the plan withholds and why, so the per-agent receipt lines derive from the plan that declined them. All five empty-plan divert sites, all four hand-built demand constructions, and the per-row harness filter are deleted; surface resolution exists once.
- **Demand rides plans; custody stays in records.** Removal and retire read recorded rows (custody names its own file); a targeted converge derives its reach from custody at the last read before the lock — the verb doesn't supply it, so it cannot go stale across a snapshot — and a targeted accept never fans out.
- **Belts at the write boundary.** Project containment is re-proven immediately before any config write; a symlink swapped in after planning yields the unprovable state and the escape warning with zero bytes moved. A targeted converge whose surfaces are all withheld speaks its states and still runs intent-journal recovery instead of returning silently.
- **The claw-back tells the truth.** Moving a bundle's `dest` from one agent's config to another now sweeps cleanly: entry placed, old entry removed, the emptied file's deletion disclosed (not counted as a failure), exit 0 with the JSON envelope agreeing, and every line naming the bundle rather than an internal id.
- **Drift is a projection.** One payload-free five-state drift vocabulary both custody shapes answer to; the scan status keeps carrying the exact bytes its consumers commit.

## Verification

Full workspace suite green (CLI lib 1050; the six-dialect MCP e2e byte-unchanged since before the series); all drift gates green; web suite untouched and green. Two independent reviews plus a regression-focused by-hand session: dest narrowing end-to-end with the claw-back verified on disk, targeted verbs proven not to fan out, six-dialect placement shapes checked file-by-file, and drift preservation through update and remove. Review findings (a write-boundary containment gap, a silent all-withheld return, a widened race window, and the claw-back receipt) all fixed with red-before/green-after tests; one receipt-shape residual is documented for the verb-surface pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
