### PR TITLE
A live manifest row outranks a stale retirement marker: remove can never again silently skip an uninstall

### DIFF
--- a/bins/topos/src/ops/add.rs
+++ b/bins/topos/src/ops/add.rs
@@ -2119,6 +2119,11 @@ pub(crate) fn extend_folder_dest(
     let Some(lock) = doc::read_doc::<Lock>(sctx.fs, &sctx.layout.published(&sid).lock)? else {
         return Ok(None);
     };
+    // Naming destinations for this folder is a re-demand exactly like naming the folder alone
+    // ([`unclaimed_record`]): a RETIRED record (released by the one-time orphan resolution) returns
+    // to every surface, so the row written below never stands over a record every store walker
+    // skips — a row asking for copies nothing would place, update, or ever take away again.
+    crate::sidecar::revive_record(sctx.fs, &sctx.layout, &sid);
     // WHAT the bundle is decides the vocabulary its destinations are spelled in. The row already
     // stands, so a folder that never placed anything is not a fail-closed case here: the same
     // classifier the row writers use, read as the ordinary skill when nothing answers.

--- a/bins/topos/src/ops/claim.rs
+++ b/bins/topos/src/ops/claim.rs
@@ -88,6 +88,11 @@ pub(crate) fn claim(
     let (state, twin, repaired, stamped) = {
         let sp = scope.layout.published(&target.id);
         let _guard = crate::sidecar::lock_skill(sctx.fs, &scope.layout, &target.id)?;
+        // A claim is a re-demand of the bundle it names: a RETIRED record (one the one-time
+        // orphan resolution released when nothing claimed it) returns to every surface as this
+        // folder joins its places, or the placement below would land in a record no walker reads.
+        // Best-effort, like every revive — a courtesy of the claim, never its gate.
+        crate::sidecar::revive_record(sctx.fs, &scope.layout, &target.id);
         let Some(mut map) = doc::read_map(sctx.fs, &sp.map)? else {
             return Err(ClientError::Corrupt(format!(
                 "'{}' has no placement map to record a copy in",

--- a/bins/topos/src/ops/manifest_edit.rs
+++ b/bins/topos/src/ops/manifest_edit.rs
@@ -1451,6 +1451,11 @@ pub(crate) fn remove_global(
     if !selection.is_empty() {
         resolved = narrow_arms(ctx, &target, resolved, selection)?;
     }
+    // A row still claims these records, so a retirement marker on one is stale — lifted before the
+    // plan below reads the store, and before the eager rails walk it (see [`revive_rowed_records`]).
+    if yes {
+        revive_rowed_records(ctx, &target, &resolved);
+    }
     let eager = eager_plan(ctx, &target, &resolved);
     let mut outcome = apply_arms(ctx, &target, tokens, resolved, via, selection, yes, true)?;
     // Row edits uninstall EAGERLY: with the row durably changed, the same machine-scope
@@ -1562,6 +1567,10 @@ pub(crate) fn remove_project(
     let mut resolved: Vec<Arm> = arms.into_iter().flatten().collect();
     if !selection.is_empty() {
         resolved = narrow_arms(ctx, &target, resolved, selection)?;
+    }
+    // The stale-marker lift — see [`remove_global`].
+    if yes {
+        revive_rowed_records(ctx, &target, &resolved);
     }
     let eager = eager_plan(ctx, &target, &resolved);
     let mut outcome = apply_arms(ctx, &target, tokens, resolved, via, selection, yes, false)?;
@@ -3443,6 +3452,44 @@ struct EagerBundle {
     /// second spelling its reconcile rows can arrive under when no store record answers for the
     /// folder. `None` for every other shape.
     local: Option<String>,
+}
+
+/// THE ROW IS THE DEMAND, so a record one of these arms still names is not retired — whatever
+/// marker it carries. A retirement marker records ONE conclusion, reached by the sweep's one-time
+/// resolution: that NOTHING claimed the record. A row claiming it now is the standing proof that
+/// conclusion has lapsed, and a stale marker must never outrank a live row — every store walker
+/// skips a marked record, so the eager uninstall below would enumerate nothing and this removal's
+/// receipt would claim copies left that are still sitting on disk.
+///
+/// Only a LOCAL-PATH row revives, and only through its OWN FOLDER: the record is identified by the
+/// directory the row is keyed on, which nothing else can answer to. A name lookup would be the
+/// wrong instrument here — a retired record and a later fresh one can share a name, and reviving
+/// the wrong one would put settled history back on every surface for the next sweep to resolve a
+/// second time, with a second closing statement for one record. Best-effort, like every revive.
+///
+/// Read (and applied) BEFORE the apply consumes the arms, and only where the removal APPLIES: a
+/// describe changes nothing on disk, marker included.
+fn revive_rowed_records(ctx: &Ctx<'_>, target: &EditTarget, arms: &[Arm]) {
+    let Some(sctx) = scope_store_ctx(ctx, target) else {
+        return;
+    };
+    for arm in arms {
+        let row = match arm {
+            Arm::RowDrop { row, .. } | Arm::DestNarrow { row: Some(row), .. } => row,
+            _ => continue,
+        };
+        let KeyShape::LocalPath { raw } = &row.shape else {
+            continue;
+        };
+        let dir = canonical_or(&row_dir(ctx, target, raw));
+        let Ok(Some(id)) = super::tracked_skill_at(&sctx, &dir) else {
+            continue;
+        };
+        let Ok(sid) = SkillId::parse(&id) else {
+            continue;
+        };
+        crate::sidecar::revive_record(sctx.fs, &sctx.layout, &sid);
+    }
 }
 
 fn eager_plan(ctx: &Ctx<'_>, target: &EditTarget, arms: &[Arm]) -> EagerPlan {

--- a/bins/topos/src/ops/reconcile.rs
+++ b/bins/topos/src/ops/reconcile.rs
@@ -5762,6 +5762,37 @@ fn revive_reclaimed(
     }
 }
 
+/// Whether anything this run CLAIMS a record — the demand half of [`resolve_orphans`]'s question,
+/// asked on its own so a record that ALREADY carries the retirement marker can be measured against
+/// it. The four claims, in the order they cost: the scope reconciled this identity, a workspace's
+/// fresh snapshot still delivers it, a manifest row of the scope mentions its name, or it earned a
+/// receipt row this run. Reading the lock is what turns an id into a name, so it comes last, and an
+/// unreadable one claims nothing (the marked record then simply stays as it is — nothing is
+/// deleted either way).
+fn record_claimed(
+    env: &Env<'_>,
+    layout: &sidecar::Layout,
+    sid: &SkillId,
+    mentioned: &HashSet<String>,
+    synced: &HashSet<String>,
+    reported: &HashSet<String>,
+) -> bool {
+    if synced.contains(sid.as_str()) {
+        return true;
+    }
+    if env.runs.iter().any(|r| {
+        r.snapshot
+            .as_ref()
+            .is_some_and(|s| s.skills.iter().any(|d| d.skill_id == sid.as_str()))
+    }) {
+        return true;
+    }
+    doc::read_doc::<Lock>(env.ctx.fs, &layout.published(sid).lock)
+        .ok()
+        .flatten()
+        .is_some_and(|lock| mentioned.contains(&lock.name) || reported.contains(&lock.name))
+}
+
 /// The ONE-TIME ORPHAN RESOLUTION — records may describe rows, never create them, so a store
 /// record that is claimed by NO row and delivered by NOTHING gets one closing statement on this
 /// receipt and then RETIRES: the marker written first (a crash between marker and line loses the
@@ -5778,6 +5809,13 @@ fn revive_reclaimed(
 /// resolves. Failed channel expansions and unexpanded project sets freeze theirs; an MCP record
 /// with live custody entries waits for the converge to conclude; a record that already earned a
 /// receipt row this run (the cleaner's removed/withdrawn) is fresh news, not a standing orphan.
+///
+/// AND THE INVERSE, in the same pass: a record ALREADY carrying the marker that this run finds
+/// demanded again is REVIVED — silently, and never a second statement. The marker is one
+/// conclusion about demand, this pass is where demand is read, and a claim outranks a conclusion
+/// drawn before it. Without it a machine that once reached the contradictory state (a live row over
+/// a marked record) would stay there forever: every walker skips the record, so the row's copies
+/// are never updated and never taken away, and nothing on any surface says why.
 fn resolve_orphans(
     env: &Env<'_>,
     driven: &Driven,
@@ -5827,12 +5865,26 @@ fn resolve_orphans(
             let Ok(sid) = SkillId::parse(id) else {
                 continue;
             };
-            if super::builtin::is_builtin(id)
-                || sidecar::record_retired(ctx.fs, &layout, &sid)
-                // A record still carrying config entries is placed, not orphaned — its own
-                // document says so.
-                || !crate::config_custody::entries_of(ctx.fs, &layout, id).is_empty()
-            {
+            if super::builtin::is_builtin(id) {
+                continue;
+            }
+            // A RETIRED record is settled history: it earns no second statement here and never
+            // retires twice. But the marker records ONE conclusion — that nothing demanded the
+            // record — and this pass owns the question of whether that still holds. So a marked
+            // record is measured against the same demand ([`record_claimed`]), and a live claim
+            // REVIVES it: the row is the demand, and a stale marker must never outrank one, or
+            // the machine keeps a record every walker skips while a row asks for its bytes.
+            // Silent, like everything else the sweep heals — the retirement had its one line, and
+            // a record returning to the surfaces its own row already names says nothing new.
+            if sidecar::record_retired(ctx.fs, &layout, &sid) {
+                if record_claimed(env, &layout, &sid, &mentioned, &synced, &reported) {
+                    sidecar::revive_record(ctx.fs, &layout, &sid);
+                }
+                continue;
+            }
+            // A record still carrying config entries is placed, not orphaned — its own document
+            // says so.
+            if !crate::config_custody::entries_of(ctx.fs, &layout, id).is_empty() {
                 continue;
             }
             let sp = layout.published(&sid);

--- a/bins/topos/src/tests/manifest_reconcile/dest.rs
+++ b/bins/topos/src/tests/manifest_reconcile/dest.rs
@@ -1253,3 +1253,149 @@ fn a_local_adopt_with_dest_places_a_copy_at_the_selected_folder() {
         out.data.skills
     );
 }
+
+// =================================================================================================
+// A retirement marker never outlives the row that claims the record.
+// =================================================================================================
+
+/// `topos remove -g <name> --yes` — the machine row drop, applied.
+fn remove_g(
+    ctx: &crate::ctx::Ctx<'_>,
+    plane: &FakePlane,
+    dir: &FakeDirectory,
+    name: &str,
+) -> topos_types::results::RemoveData {
+    match ops::remove_global(
+        ctx,
+        &connect(plane, dir),
+        &[name.to_owned()],
+        None,
+        true,
+        &Default::default(),
+    )
+    .unwrap()
+    {
+        ops::RemoveOutcome::Applied(data) => data,
+        other => panic!("--yes applies: {other:?}"),
+    }
+}
+
+/// THE RE-DEMAND, end to end. A folder adopted in place, then removed, then RETIRED by the sweep's
+/// one-time resolution, comes back through `add <path> --dest <folder>` — the destination-only door
+/// — and the marker goes with the row that claims it. Without that lift the row stood over a record
+/// every store walker skips: the copies landed, and the NEXT remove uninstalled nothing at all
+/// while its receipt said the row was gone — the person's dirs left holding files topos had
+/// stopped managing, with no line saying so.
+#[test]
+fn a_dest_re_add_revives_the_retired_record_so_the_next_remove_uninstalls_its_copies() {
+    let rig = Rig::new("dest-revive");
+    rig.seed_session();
+    let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+    let plane = FakePlane::new(log);
+    plane.serves(Vec::new());
+    let dir = FakeDirectory::new(Vec::new(), Vec::new());
+    rig.write_global("[bundles]\n");
+    let src = rig.home.0.join("tools/quaggamap");
+    skill_source(&src, b"# quaggamap\n");
+    let ctx = rig.ctx_at(Some(&rig.work.0));
+    let added = scoped_path_add(&ctx, &src, true).unwrap();
+    let record = sid(added.skill_id.as_deref().expect("an adopt records its id"));
+    let marker = rig.layout().published(&record).retired;
+
+    // The row goes; the sweep that follows resolves the leftover once and retires the record.
+    remove_g(&ctx, &plane, &dir, "quaggamap");
+    sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    assert!(
+        marker.exists(),
+        "the one-time resolution retired the record"
+    );
+
+    // THE DOOR: naming the same folder with a destination re-binds THAT record, and the claim
+    // lifts the marker then and there — before any sweep gets a turn.
+    let scope = ops::add_scope(&ctx, true).unwrap();
+    let data = ops::extend_folder_dest(&ctx, &scope, &src, &sel(&[], &["~/dest-a"]))
+        .unwrap()
+        .expect("the folder is still tracked here");
+    assert_eq!(
+        data.skill_id.as_deref(),
+        Some(record.as_str()),
+        "the re-add binds the record that is already there"
+    );
+    assert!(
+        !marker.exists(),
+        "a live row outranks a stale marker: the record is back on every surface"
+    );
+
+    // The copy lands where the row asks…
+    sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    let copy = rig.home.0.join("dest-a/quaggamap");
+    assert!(copy.join("SKILL.md").exists(), "the row's copy landed");
+
+    // …and the removal that follows really uninstalls it, naming the folder it emptied.
+    let data = remove_g(&ctx, &plane, &dir, "quaggamap");
+    assert!(!copy.exists(), "the managed copy left: {data:?}");
+    assert!(
+        data.uninstalled
+            .iter()
+            .any(|u| u.destinations.iter().any(|d| d.ends_with("quaggamap"))),
+        "the receipt names what it took away: {:?}",
+        data.uninstalled
+    );
+    assert!(
+        src.join("SKILL.md").exists(),
+        "the adopted source is the person's own — never deleted"
+    );
+}
+
+/// THE REMOVE DOOR alone, from the contradictory state and with NO sweep in between: a machine
+/// already carrying a marker under a live row (the state older builds could reach) still uninstalls
+/// what that row placed. The row is the demand — resolving the record through the marker instead
+/// would leave the copy on disk behind a receipt that says the row is gone.
+#[test]
+fn a_remove_uninstalls_the_copies_of_a_rowed_record_that_still_carries_the_marker() {
+    let rig = Rig::new("dest-revive-remove");
+    rig.seed_session();
+    let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+    let plane = FakePlane::new(log);
+    plane.serves(Vec::new());
+    let dir = FakeDirectory::new(Vec::new(), Vec::new());
+    rig.write_global("[bundles]\n");
+    let src = rig.home.0.join("tools/quaggamap");
+    skill_source(&src, b"# quaggamap\n");
+    let ctx = rig.ctx_at(Some(&rig.work.0));
+    let scope = ops::add_scope(&ctx, true).unwrap();
+    let mut added = ops::adopt_path(&ctx, &scope, &src, ops::KindDeclared::No).unwrap();
+    ops::note_added_path_dest_in(
+        &ctx,
+        &mut added,
+        &scope.target,
+        &src,
+        &["~/dest-a".to_owned()],
+    )
+    .unwrap();
+    sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    let copy = rig.home.0.join("dest-a/quaggamap");
+    assert!(copy.join("SKILL.md").exists());
+
+    // The contradiction, written directly: the marker under a row that still asks for the bundle.
+    let record = sid(added.skill_id.as_deref().expect("an adopt records its id"));
+    crate::sidecar::retire_record(&rig.fs, &rig.layout(), &record, rig_now(&rig)).unwrap();
+
+    let data = remove_g(&ctx, &plane, &dir, "quaggamap");
+    assert!(
+        !copy.exists(),
+        "the row's copy left with the row: {:?}",
+        data.uninstalled
+    );
+    assert!(
+        data.uninstalled
+            .iter()
+            .any(|u| u.destinations.iter().any(|d| d.ends_with("quaggamap"))),
+        "…and the receipt names it: {:?}",
+        data.uninstalled
+    );
+    assert!(
+        src.join("SKILL.md").exists(),
+        "the adopted source is the person's own — never deleted"
+    );
+}

--- a/bins/topos/src/tests/manifest_reconcile/sweep.rs
+++ b/bins/topos/src/tests/manifest_reconcile/sweep.rs
@@ -1279,3 +1279,130 @@ fn a_failed_member_install_leaves_the_row_and_the_next_update_converges() {
         out.warnings
     );
 }
+
+// =================================================================================================
+// The stale-marker self-heal.
+// =================================================================================================
+
+/// A retirement marker records ONE conclusion — that nothing demanded the record — and this pass
+/// owns whether that still holds. A machine already in the contradictory state (the marker under a
+/// row that names the bundle) heals on its very next update: the marker goes, silently, and every
+/// surface answers for the record again. Until it does, the row reads honestly never-applied — a
+/// listing states what it can prove, and a record no walker reads is not among those things.
+#[test]
+fn a_sweep_revives_a_retired_record_a_row_still_claims() {
+    let rig = Rig::new("stale-marker-heal");
+    rig.seed_session();
+    let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+    let plane = FakePlane::new(log);
+    plane.serves(Vec::new());
+    let dir = FakeDirectory::new(Vec::new(), Vec::new());
+    rig.write_global("[bundles]\n");
+    let src = rig.home.0.join("tools/quaggamap");
+    skill_source(&src, b"# quaggamap\n");
+    let ctx = rig.ctx_at(Some(&rig.work.0));
+    let scope = ops::add_scope(&ctx, true).unwrap();
+    let mut added = ops::adopt_path(&ctx, &scope, &src, ops::KindDeclared::No).unwrap();
+    ops::note_added_path_dest_in(
+        &ctx,
+        &mut added,
+        &scope.target,
+        &src,
+        &["~/dest-a".to_owned()],
+    )
+    .unwrap();
+    sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    assert!(rig.home.0.join("dest-a/quaggamap/SKILL.md").exists());
+    let record = sid(added.skill_id.as_deref().expect("an adopt records its id"));
+    let version = added.version_id.clone().expect("the adopt minted one");
+
+    // The contradiction, written directly: the marker under a row that still asks for the bundle.
+    crate::sidecar::retire_record(&rig.fs, &rig.layout(), &record, rig_now(&rig)).unwrap();
+    let item = machine_item(&ctx, "quaggamap").expect("the manifest row is still a line");
+    assert!(
+        item.version.is_none() && item.placements.is_empty(),
+        "a record no walker reads answers for nothing: {item:?}"
+    );
+
+    // ONE ordinary update heals it, and says nothing: the retirement had its line, and a record
+    // returning to the surfaces its own row already names is no news.
+    let out = sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    assert!(
+        !rig.layout().published(&record).retired.exists(),
+        "the live row lifted the stale marker"
+    );
+    assert!(
+        !out.data
+            .skills
+            .iter()
+            .any(|s| s.skill == "quaggamap" && s.action == PullAction::Released),
+        "a revival is silent — never a second closing statement: {:?}",
+        out.data.skills
+    );
+
+    // …and the record answers again: the version the row stands at, and the folders holding it.
+    let item = machine_item(&ctx, "quaggamap").expect("the row is still a line");
+    assert_eq!(item.version.as_deref(), Some(version.as_str()), "{item:?}");
+    assert!(
+        item.placements
+            .iter()
+            .any(|p| p.ends_with("dest-a/quaggamap")),
+        "the placement is on the surfaces again: {item:?}"
+    );
+}
+
+/// The inverse still holds: a record NOTHING claims stays retired through every later sweep — the
+/// self-heal reads the demand, never the marker's age.
+#[test]
+fn a_sweep_leaves_a_retired_record_no_row_claims_exactly_as_it_is() {
+    let rig = Rig::new("stale-marker-keep");
+    rig.seed_session();
+    let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+    let plane = FakePlane::new(log);
+    plane.serves(Vec::new());
+    let dir = FakeDirectory::new(Vec::new(), Vec::new());
+    rig.write_global("[bundles]\n");
+    let src = rig.home.0.join("tools/quaggamap");
+    skill_source(&src, b"# quaggamap\n");
+    let ctx = rig.ctx_at(Some(&rig.work.0));
+    let added = scoped_path_add(&ctx, &src, true).unwrap();
+    let record = sid(added.skill_id.as_deref().expect("an adopt records its id"));
+
+    // The row is dropped by hand, and the record retires on the next sweep — its ONE statement.
+    rig.write_global("[bundles]\n");
+    sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    let marker = rig.layout().published(&record).retired;
+    assert!(marker.exists(), "the one-time resolution ran");
+    let stamp = std::fs::read(&marker).unwrap();
+
+    // Two more sweeps say nothing and rewrite nothing.
+    for _ in 0..2 {
+        let out = sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+        assert!(
+            !out.data.skills.iter().any(|s| s.skill == "quaggamap"),
+            "a retired record is never mentioned again: {:?}",
+            out.data.skills
+        );
+    }
+    assert!(marker.exists(), "…and it is still retired");
+    assert_eq!(std::fs::read(&marker).unwrap(), stamp, "byte-identical");
+}
+
+/// `topos list <name> -g` — the deep answer, which is where a row's applied version and the
+/// folders holding it are printed.
+fn machine_item(ctx: &crate::ctx::Ctx<'_>, name: &str) -> Option<topos_types::results::ListDetail> {
+    crate::ops::list_with(
+        ctx,
+        &ops::ListRequest {
+            view: ops::ScopeView::Machine,
+            name: Some(name.to_owned()),
+            ..Default::default()
+        },
+        None,
+        None,
+        crate::ops::RowPage::unlimited(),
+    )
+    .unwrap()
+    .data
+    .detail
+}


### PR DESCRIPTION
Fixes the silent-orphan bug found by hand-smoking #55 (pre-existing — reproduced identically on a pre-branch binary): a stale `retired.json` survived a `--dest` re-add, after which every later `remove` silently skipped the uninstall, orphaning placed files with no disclosure, and `list <skill>` lost its version and placement lines.

The principle, applied in three places: **a live manifest row outranks a stale retirement marker.**

1. **The comeback doors revive what they re-bind**: `extend_folder_dest` (the bug — a path add with a `--dest` selection routes here before the plain adopt path and never reached the existing revive) and the `--as` claim door (reachable via a path reference, which binds a retired record). The other doors were audited: the plain re-adopt and workspace re-delivery already revive; the bare-name and forge paths cannot reach a retired record.
2. **The sweep self-heals**: the orphan pass that writes the marker gains the symmetric arm — a marked record that is synced, still delivered, named by the scope manifest, or receipted this run is revived, silently (revival restores exactly what the row already claims; retirement keeps its one closing statement, and a genuinely unclaimed record stays byte-identically retired — pinned by test). This repairs any machine already in the contradictory state on its next update.
3. **The remove door lifts the marker off the row it acts on** (apply mode only, local-path rows resolved by their own folder — a name lookup could revive the wrong record), before the plan resolves records, so the uninstall enumerates even from a pre-existing broken state with no sweep in between.

Four new tests, each verified red without its half: the full repro end-to-end, the remove door from the contradictory state, the sweep self-heal (with list answering again and no second closing statement), and the guard that an unclaimed retired record stays exactly as it was. 1,186 → 1,190 lib tests; fmt/clippy/xtask ci all green; no wire change.

Based on `test-and-dead-code-hygiene` (#55) so it lands cleanly after it; retargets to main automatically when #55 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
