### PR TITLE
MCP picker: the auth note moves off the cards into the pick dialog; the exact-bytes document stops widening it

### DIFF
--- a/web/app/routes/mcp-new.tsx
+++ b/web/app/routes/mcp-new.tsx
@@ -493,18 +493,6 @@ function ServerPicker({
               <span className="w-full truncate font-mono text-[11px] text-faint">
                 {server.host}
               </span>
-              {/* THE ERRAND, ON THE CARD. The one line that costs this row its self-service
-                  standing wraps instead of truncating — half a sentence about a token someone
-                  has to mint is worse than none, and the card growing is the honest price of
-                  saying it before the click rather than after the agent fails to sign in. */}
-              {server.auth === "manual" && (
-                <span
-                  data-testid="mcp-picker-auth-note"
-                  className="w-full text-[11px] text-dim leading-snug"
-                >
-                  {server.authNote}
-                </span>
-              )}
             </span>
           </button>
         ))}
@@ -587,15 +575,19 @@ function AddServerDialog({
             person&apos;s own machine, never here, and no credential rides in these bytes.
           </p>
         )}
-        {/* The same sentence the card carried, repeated where the decision is actually made: the
-            dialog covers the row that raised it, so a caveat only the card knew would be a
-            caveat nobody reads at the moment of publishing. */}
+        {/* THE ERRAND, SAID WHERE THE DECISION IS MADE. The card carries only the chip; the one
+            sentence about a token someone has to mint or an app an admin registers lives here,
+            because this dialog is the moment of publishing — a caveat on a grid card competes
+            with twenty-four neighbours, and a caveat here is read by exactly the person acting. */}
         {server.auth === "manual" && (
           <p className="text-faint text-xs leading-relaxed" data-testid="mcp-dialog-auth-note">
             {server.authNote}
           </p>
         )}
-        <details>
+        {/* `min-w-0`, because DialogContent is a GRID: without it this item's minimum width is
+            the document's longest line, and the whole dialog grows past its own max-width
+            instead of the pre scrolling. */}
+        <details className="min-w-0">
           <summary className="cursor-pointer text-faint text-xs">
             The exact bytes this would store
           </summary>
@@ -904,7 +896,7 @@ export function PreviewCard({ preview }: { preview: PreviewData }) {
             ))}
           </ul>
         )}
-        <details>
+        <details className="min-w-0">
           <summary className="cursor-pointer text-faint text-xs">
             The exact bytes this would store
           </summary>

--- a/web/tests/unit/mcp-new.test.ts
+++ b/web/tests/unit/mcp-new.test.ts
@@ -896,17 +896,24 @@ describe("the built-in list, on the page", () => {
     expect(html).toContain(`${CURATED_MCP_SERVERS.length} servers`);
   });
 
-  it("prints the errand on exactly the rows that carry one, in full", async () => {
+  it("marks manual rows with the chip alone and keeps the errand's sentence off the cards", async () => {
     const { CURATED_MCP_SERVERS } = await import("@/lib/mcp/curated.server");
     const html = await renderPage();
     const manual = CURATED_MCP_SERVERS.filter((entry) => entry.auth === "manual");
-    // One note per manual row and not one more: a card that showed the caution chip without the
-    // line under it would be a caution nobody can act on.
-    expect(times(html, 'data-testid="mcp-picker-auth-note"')).toBe(manual.length);
+    // The card carries only the chip; the sentence lives in the pick dialog, where the person is
+    // actually deciding — a paragraph per manual row would out-shout twenty-four neighbours. The
+    // notes still ride the page's data payload (the dialog opens without a round trip), so the
+    // assertion scopes to the card buttons rather than the whole document.
     expect(times(html, ">manual setup<")).toBe(manual.length);
+    const cards = html
+      .split('data-testid="mcp-picker-option"')
+      .slice(1)
+      .map((chunk) => decode(chunk.slice(0, chunk.indexOf("</button>"))));
+    expect(cards.length).toBe(CURATED_MCP_SERVERS.length);
     for (const entry of manual) {
-      // The whole sentence, not a truncated half of it — the note wraps rather than clipping.
-      expect(decode(html), `${entry.title}'s note is not on the page`).toContain(entry.authNote);
+      const card = cards.find((c) => c.includes(entry.title));
+      expect(card, `${entry.title}'s card is missing`).toBeDefined();
+      expect(card, `${entry.title}'s note leaked onto its card`).not.toContain(entry.authNote);
     }
   });
 });


### PR DESCRIPTION
Two small UI fixes on the `mcp/new` picker:

- **Manual rows say less on the card.** The one-time-setup sentence ("Needs a GitHub personal access token per person…") no longer renders under every manual row on the list — the card keeps the `manual setup` chip alone, and the sentence lives in the pick dialog, where the person is actually deciding. The page test now asserts the chip count and that no card carries the sentence (scoped to the card buttons — the notes still ride the page's data payload so the dialog opens without a round trip).
- **"The exact bytes this would store" no longer overflows.** `DialogContent` is a CSS grid, so the `<details>` item's minimum width was the document's longest JSON line — the dialog grew past its own max-width instead of the `<pre>` scrolling. `min-w-0` on the details (both here and on the preview card's twin) restores the pre's own `overflow-auto`.

Testing: `bun run check` green, full vitest 1152/1152 with the database attached, production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)