### PR TITLE
Landing truth pass: remove stale scenes, fix beta and pricing copy

### DIFF
--- a/web/app/components/landing/harness-marks.tsx
+++ b/web/app/components/landing/harness-marks.tsx
@@ -116,14 +116,6 @@ const MARKS: Record<string, (className: string) => ReactElement> = {
 };
 
 /**
- * Whether this app publishes a mark at all — so a caller can lay out the tile that would hold it
- * without rendering an empty one for an app the map above deliberately omits.
- */
-export function hasHarnessMark(name: string): boolean {
-  return name in MARKS;
-}
-
-/**
  * The app's mark, or null when its owner publishes none — the badge around it decides what to do
  * with nothing (it keeps the name, which was always the real label).
  */

--- a/web/app/components/landing/landing-page.tsx
+++ b/web/app/components/landing/landing-page.tsx
@@ -1,9 +1,9 @@
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
 import { CopyButton } from "@/components/copy-button";
 import { FounderAddressBlock } from "@/components/landing/founder-email";
-import { HarnessMark, hasHarnessMark } from "@/components/landing/harness-marks";
-import { MicroLabel, SectionHeading, WRAP } from "@/components/landing/landing-kit";
+import { HarnessMark } from "@/components/landing/harness-marks";
+import { SectionHeading, WRAP } from "@/components/landing/landing-kit";
 import { LoopBands } from "@/components/landing/loop-bands";
 import { PricingBand } from "@/components/landing/pricing-band";
 import { RoutingStar } from "@/components/landing/routing-star";
@@ -149,101 +149,6 @@ function HeroPaths({ tenancy }: { tenancy: "single" | "multi" }) {
 /** The agent apps Topos delivers to or reads alongside — no Claude app: there is no adapter for it. */
 const WORKS_WITH = ["Claude Code", "OpenClaw", "Hermes", "Codex", "Cursor"];
 
-/** Weight-500 ink emphasis — the system's only emphasis (never bold). */
-function Em({ children }: { children: ReactNode }) {
-  return <b className="font-medium">{children}</b>;
-}
-
-/**
- * The agent app a team's people run: the app's own logomark on a quiet inset tile beside its name —
- * and the name alone for an app whose owner publishes no mark (see `harness-marks.tsx`). The name
- * is plain text, not a chip: nothing on these cards carries a border, and the tile is the only
- * field. A card naming two apps joins them in one label beside their tiles, as one line.
- */
-function AgentBadge({ apps }: { apps: string[] }) {
-  return (
-    <span className="flex min-w-0 items-center gap-[7px]">
-      {/* Two tiles sit closer to each other than to the label, so a pair reads as one object and
-          the label keeps the width it needs. */}
-      <span className="flex flex-none items-center gap-[3px]">
-        {apps.filter(hasHarnessMark).map((app) => (
-          <span
-            key={app}
-            className="flex h-[26px] w-[26px] items-center justify-center rounded-[7px] bg-panel2"
-          >
-            <HarnessMark name={app} className="h-4 w-4" />
-          </span>
-        ))}
-      </span>
-      {/* One line on every real screen; on a very narrow one the label wraps rather than
-          pushing the card wider than the page. */}
-      <span className="text-right font-mono text-[11px] text-dim">{apps.join(" · ")}</span>
-    </span>
-  );
-}
-
-/**
- * One plain sentence a first-timer reads cold, on the same "once — every" rhythm, so cause and
- * effect live inside ordinary grammar. The bundle names sit beneath as quiet chips: a skimmer can
- * ignore them, a curious reader learns that Topos carries skills, memories, and docs alike.
- */
-const TEAMS: {
-  team: string;
-  apps: string[];
-  scene: ReactNode;
-  bundles: { name: string; kind: string }[];
-}[] = [
-  {
-    team: "Marketing",
-    apps: ["OpenClaw"],
-    scene: (
-      <>
-        Update the brand voice <Em>once</Em>. <Em>Every</Em> teammate’s drafts follow it.
-      </>
-    ),
-    bundles: [
-      { name: "brand-voice", kind: "skill" },
-      { name: "campaign-facts", kind: "docs" },
-    ],
-  },
-  {
-    team: "Sales",
-    apps: ["Hermes"],
-    scene: (
-      <>
-        A client talks to <Em>one</Em> rep. <Em>Every</Em> rep’s agent remembers the conversation.
-      </>
-    ),
-    bundles: [{ name: "client-history", kind: "memory" }],
-  },
-  {
-    team: "Support",
-    apps: ["OpenClaw"],
-    scene: (
-      <>
-        Change a policy <Em>once</Em>. <Em>Every</Em> answer follows it, even a new hire’s.
-      </>
-    ),
-    bundles: [
-      { name: "product-docs", kind: "docs" },
-      { name: "escalation-rules", kind: "skill" },
-    ],
-  },
-  {
-    team: "Engineering",
-    apps: ["Claude Code", "Codex"],
-    scene: (
-      <>
-        Fix the deploy process <Em>once</Em>. <Em>Every</Em> agent deploys the new way.
-      </>
-    ),
-    bundles: [
-      { name: "deploy", kind: "skill" },
-      { name: "incident-runbook", kind: "docs" },
-    ],
-  },
-];
-
 /**
  * The unclaimed-install band: shown ONLY while a single-tenant install still awaits its first
  * owner. The claim rides the one-time link the server printed at boot — machine control is the
@@ -344,8 +249,8 @@ export function LandingPage({
               your company up to date.
             </h1>
             <p className="mt-4 max-w-[54ch] text-[16px] text-dim">
-              Topos syncs skills, memory files, and context across your team’s agents (Claude Code,
-              Codex, Cursor, and more), and anyone can{" "}
+              Topos syncs skills and MCP servers across your team’s agents (Claude Code, Codex,
+              Cursor, and more), and anyone can{" "}
               <strong className="font-medium text-ink">contribute improvements back</strong>.
             </p>
             <HeroPaths tenancy={tenancy} />
@@ -388,43 +293,6 @@ export function LandingPage({
         </div>
       </section>
 
-      <section className="pt-[52px] lg:pt-[72px]">
-        <div className={WRAP}>
-          <MicroLabel>Every team, every agent app</MicroLabel>
-          <SectionHeading className="max-w-[44ch]">
-            Give every team an agent that already knows how your company works.
-          </SectionHeading>
-          <div className="mt-6 grid gap-3 sm:grid-cols-2">
-            {TEAMS.map((team) => (
-              <div
-                key={team.team}
-                className="flex flex-col rounded-lg border border-line-soft bg-panel px-[18px] pt-[15px] pb-[14px] shadow-card"
-              >
-                {/* The header holds the mark tile's height whether or not a tile is there, so
-                    every card's sentence starts on the same line. */}
-                <div className="mb-2.5 flex min-h-[26px] items-center justify-between gap-2.5">
-                  <span className="font-display font-semibold text-[14px] text-ink tracking-[-0.01em]">
-                    {team.team}
-                  </span>
-                  <AgentBadge apps={team.apps} />
-                </div>
-                <p className="text-[14px] text-ink leading-[1.55]">{team.scene}</p>
-                <div className="mt-[13px] flex flex-wrap gap-1.5 border-line-soft border-t pt-[11px]">
-                  {team.bundles.map((bundle) => (
-                    <span
-                      key={bundle.name}
-                      className="whitespace-nowrap rounded-full bg-panel2 px-[9px] py-0.5 font-mono text-[10px] text-dim"
-                    >
-                      {bundle.name} {"·"} <span className="text-faint">{bundle.kind}</span>
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <LoopBands rail={FLEET_RAIL} />
 
       <PricingBand ctaTo={ctaTo} ctaLabel={ctaLabel} docsHref={DOCS} />
@@ -436,9 +304,8 @@ export function LandingPage({
         <div className={WRAP}>
           <SectionHeading>Setting this up for a team? Email me.</SectionHeading>
           <p className="mt-4 max-w-[62ch] text-dim">
-            Topos is in closed beta and I set up the first teams personally. Tell me how your team
-            works with agents and I’ll get your first shared skills flowing, and your feedback
-            shapes what gets built next.
+            I set up the first teams personally. Tell me how your team works with agents and I’ll
+            get your first shared skills flowing. Your feedback shapes what gets built next.
           </p>
           <p className="mt-3 text-[13px] text-faint">Robert, founder</p>
           <div className="mt-5">

--- a/web/app/components/landing/pricing-band.tsx
+++ b/web/app/components/landing/pricing-band.tsx
@@ -45,8 +45,8 @@ const TIERS: Tier[] = [
     desc: "Hosted by us. Nothing to run, nothing to keep patched.",
     feats: [
       "Everything in self-hosted",
-      "Hosted plane, backed up",
-      "Fleet visibility and one-click revert",
+      "Hosted by us, backed up daily",
+      "Zero-downtime updates",
       "Email support",
     ],
     surface: "lead",

--- a/web/app/components/landing/routing-star.tsx
+++ b/web/app/components/landing/routing-star.tsx
@@ -291,7 +291,7 @@ export function RoutingStar() {
         <g ref={chipLayer} />
       </svg>
       <p className="mt-2 text-center text-[12.5px] text-faint">
-        Verified by Topos, then delivered to the whole team.
+        Delivered exactly as published, then kept up to date.
       </p>
     </div>
   );

--- a/web/tests/e2e/landing.spec.ts
+++ b/web/tests/e2e/landing.spec.ts
@@ -59,14 +59,7 @@ test.describe("the public landing page", () => {
     // Verified unsupported — the page must claim no Claude-app delivery anywhere.
     await expect(page.getByText("Claude app")).toHaveCount(0);
 
-    // 3 — the four team cards, each with its agent-app badge and its bundle chips.
-    for (const team of ["Marketing", "Sales", "Support", "Engineering"]) {
-      await expect(page.getByText(team, { exact: true }).first()).toBeVisible();
-    }
-    await expect(page.getByText("brand-voice", { exact: false }).first()).toBeVisible();
-    await expect(page.getByText("client-history", { exact: false }).first()).toBeVisible();
-
-    // 4 — the loop: the three numbered steps and the chat scene with its receipt.
+    // 3 — the loop: the three numbered steps and the chat scene with its receipt.
     const loop = page.locator("#demo");
     await expect(loop).toContainText("Publish");
     await expect(loop).toContainText("Delivered automatically");
@@ -74,7 +67,7 @@ test.describe("the public landing page", () => {
     await expect(loop).toContainText("customer-lookup");
     await expect(loop).toContainText("Published: delivered to Support, Sales, and Engineering");
 
-    // 5 — the schematic review component: address bar, proposer, diff, and the real button copy.
+    // 4 — the schematic review component: address bar, proposer, diff, and the real button copy.
     // Asserted as TEXT, not by role: the loop bands' static variant draws the approve control as an
     // inert block, so the copy is the only thing both variants share.
     await expect(page.getByText("topos.sh/acme/skills/brand-voice/proposals")).toBeVisible();
@@ -84,7 +77,7 @@ test.describe("the public landing page", () => {
       page.getByText("Use sentence case for headings. No exclamation points."),
     ).toBeVisible();
 
-    // 6 — the pricing band: three tiers, the seat definition, and the one accent CTA. The tier
+    // 5 — the pricing band: three tiers, the seat definition, and the one accent CTA. The tier
     // figures are asserted as text because the hierarchy between the three cards is carried by the
     // neutral ramp, which the DOM does not spell.
     const pricing = page.locator("#pricing");
@@ -95,19 +88,25 @@ test.describe("the public landing page", () => {
     await expect(pricing).toContainText("Enterprise");
     await expect(pricing).toContainText("$40");
     await expect(pricing).toContainText("A seat is anyone who works with an AI agent");
+    // The Team card's hosted-tier lines say only what is true today, in plain words.
+    await expect(pricing).toContainText("Hosted by us, backed up daily");
+    await expect(pricing).toContainText("Zero-downtime updates");
+    await expect(pricing.getByText("Fleet visibility and one-click revert")).toHaveCount(0);
     await expect(pricing.getByRole("link", { name: "Talk to us" })).toHaveAttribute(
       "href",
       "#contact",
     );
 
-    // 7 — the founder band, the pricing band's "Talk to us" destination. It sits directly under
+    // 6 — the founder band, the pricing band's "Talk to us" destination. It sits directly under
     // pricing and opens on its heading: no micro-label above it.
     const contact = page.locator("#contact");
     await expect(contact).toHaveCount(1);
     await expect(
       page.getByRole("heading", { name: "Setting this up for a team? Email me." }),
     ).toBeVisible();
+    await expect(contact).toContainText("I set up the first teams personally.");
     await expect(contact.getByText("Design partners")).toHaveCount(0);
+    await expect(contact.getByText(/closed beta/i)).toHaveCount(0);
     // The order is the contract, not an accident of authoring: the band that answers the pricing
     // CTA is the page's last word, so the button never jumps the reader past anything.
     const contactIsLastBand = await page.evaluate(() => {
@@ -118,7 +117,7 @@ test.describe("the public landing page", () => {
     });
     expect(contactIsLastBand).toBe(true);
 
-    // 8 — the footer: the browser-path button leads its link row; no security link, no address.
+    // 7 — the footer: the browser-path button leads its link row; no security link, no address.
     const footer = page.locator("footer");
     // Two matches are legitimate in single tenancy: the primary button (/login) plus the plain
     // "Sign in" link (/app). The button is the first — assert it specifically.
@@ -138,11 +137,14 @@ test.describe("the public landing page", () => {
 
   test("the retired bands are gone", async ({ page }) => {
     await page.goto("/");
-    // The git-comparison band, the verb-card band, and the FAQ all left; what the nav still points
-    // at has to resolve to a band that is actually on the page.
+    // The git-comparison band, the verb-card band, the FAQ, and the team scene cards all left;
+    // what the nav still points at has to resolve to a band that is actually on the page.
     await expect(page.locator("#vs")).toHaveCount(0);
     await expect(page.locator("#agent")).toHaveCount(0);
     await expect(page.locator("#faq")).toHaveCount(0);
+    await expect(
+      page.getByText("Give every team an agent that already knows how your company works."),
+    ).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Why Topos" })).toHaveCount(0);
     await expect(page.getByRole("link", { name: "FAQ" })).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Pricing" })).toHaveAttribute("href", "#pricing");


### PR DESCRIPTION
The landing page claimed things the product does not do yet. This pass makes every claim on the page true today. Web-only: five files, landing components plus their e2e spec.

## What changed

**Scene cards removed.** The four team scene cards (Marketing / Sales / Support / Engineering) are gone whole, not rewritten: they advertised bundle kinds that do not ship (`memory`, `docs`) and scenarios the product does not deliver. Their helpers (`Em`, `AgentBadge`, `hasHarnessMark`) and unused imports went with them; the loop bands carry the same top spacing the removed section had, so the page rhythm composes unchanged.

**Hero sentence** now names only shipped kinds. Final rendered copy:

> Topos syncs skills and MCP servers across your team's agents (Claude Code, Codex, Cursor, and more), and anyone can **contribute improvements back**.

**Hero diagram caption:**

> Delivered exactly as published, then kept up to date.

(was "Verified by Topos, then delivered to the whole team.")

**Contact band** drops the closed-beta claim. Final body:

> I set up the first teams personally. Tell me how your team works with agents and I'll get your first shared skills flowing. Your feedback shapes what gets built next.

Heading and the "Robert, founder" line unchanged.

**Pricing, Team card only** (prices, tier names, subhead, Enterprise card, CTAs untouched):

- "Hosted plane, backed up" → **Hosted by us, backed up daily**
- "Fleet visibility and one-click revert" → **Zero-downtime updates** (the old line is a self-hosted feature too, contradicting "Everything in self-hosted")

**Tests.** `web/tests/e2e/landing.spec.ts`: the team-card assertions removed, the band walk renumbered, the new Team-card lines and contact body pinned, and the removed claims asserted absent ("closed beta", the old revert line, the scene-card heading).

## Verification

- `bun run check` green (biome, drift gates, typegen, tsc)
- vitest: 1152 passed (with `TEST_DATABASE_URL` set)
- Playwright e2e: 152 passed (production build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)