### PR TITLE
Entitlement-driven workspace limits and abuse guardrails

### DIFF
--- a/bins/topos/src/plane_http.rs
+++ b/bins/topos/src/plane_http.rs
@@ -2568,6 +2568,7 @@ mod tests {
                 address: "https://acme.topos.test/acme".to_owned(),
                 invited: vec!["alice@acme.com".to_owned()],
                 mailed: false,
+                skipped: Vec::new(),
             })
             .unwrap(),
             warnings: Vec::new(),

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -3287,6 +3287,14 @@ pub(crate) fn invite_tty(data: &InvitationData) -> String {
     } else {
         format!("Invited: {}", data.invited.join(", "))
     };
+    // Addresses the server SKIPPED rather than re-sent (a cooldown) — named per address in the
+    // server's own words, so "No new invitations." never reads as a silent failure.
+    for skip in &data.skipped {
+        out.push_str(&format!(
+            "\nDidn't send to {} — {}.",
+            skip.email, skip.reason
+        ));
+    }
     if data.mailed {
         out.push_str("\nInvitation email sent.");
     }

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -3298,10 +3298,14 @@ pub(crate) fn invite_tty(data: &InvitationData) -> String {
     if data.mailed {
         out.push_str("\nInvitation email sent.");
     }
-    out.push_str(&format!(
-        "\nThey join at {} — ask them to run `topos login {}` and sign in with their invited email.",
-        data.address, data.address,
-    ));
+    // The join line belongs to the addresses actually INVITED: an all-skipped receipt minted no
+    // claim to join with, so offering login directions there would point at nothing.
+    if !data.invited.is_empty() {
+        out.push_str(&format!(
+            "\nThey join at {} — ask them to run `topos login {}` and sign in with their invited email.",
+            data.address, data.address,
+        ));
+    }
     out
 }
 

--- a/contracts/openapi/openapi.json
+++ b/contracts/openapi/openapi.json
@@ -2316,6 +2316,13 @@
           "mailed": {
             "type": "boolean",
             "description": "Whether invitation mail was sent server-side (`true` only when the server can send mail)."
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkippedInvitation"
+            },
+            "description": "Addresses NOT re-sent this time — each was invited repeatedly and sits on a server-side\ncooldown; `reason` is the server's own wording (display text). Omitted when empty and\ndefaulted on the way in, so the field is additive across releases in both directions."
           }
         }
       },
@@ -3260,6 +3267,24 @@
           "machine": {
             "type": "boolean",
             "description": "Whether it is the MACHINE copy (`false` = a project checkout's) — which decides both the\nword the line uses and whether the command that shares it carries `-g`."
+          }
+        }
+      },
+      "SkippedInvitation": {
+        "type": "object",
+        "description": "One address an invitation submission SKIPPED rather than re-sent\n([`InvitationData::skipped`]) — not an error: the rest of the submission landed.",
+        "required": [
+          "email",
+          "reason"
+        ],
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "The folded address that was skipped."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why, in the server's words (display text, e.g. `already invited recently`)."
           }
         }
       },

--- a/contracts/schemas/invitation-data.schema.json
+++ b/contracts/schemas/invitation-data.schema.json
@@ -18,11 +18,38 @@
     "mailed": {
       "description": "Whether invitation mail was sent server-side (`true` only when the server can send mail).",
       "type": "boolean"
+    },
+    "skipped": {
+      "description": "Addresses NOT re-sent this time — each was invited repeatedly and sits on a server-side\ncooldown; `reason` is the server's own wording (display text). Omitted when empty and\ndefaulted on the way in, so the field is additive across releases in both directions.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/SkippedInvitation"
+      }
     }
   },
   "required": [
     "address",
     "invited",
     "mailed"
-  ]
+  ],
+  "$defs": {
+    "SkippedInvitation": {
+      "description": "One address an invitation submission SKIPPED rather than re-sent\n([`InvitationData::skipped`]) — not an error: the rest of the submission landed.",
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "The folded address that was skipped.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Why, in the server's words (display text, e.g. `already invited recently`).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "reason"
+      ]
+    }
+  }
 }

--- a/crates/topos-types/src/requests.rs
+++ b/crates/topos-types/src/requests.rs
@@ -827,6 +827,25 @@ pub struct InvitationData {
     pub invited: Vec<String>,
     /// Whether invitation mail was sent server-side (`true` only when the server can send mail).
     pub mailed: bool,
+    /// Addresses NOT re-sent this time — each was invited repeatedly and sits on a server-side
+    /// cooldown; `reason` is the server's own wording (display text). Omitted when empty and
+    /// defaulted on the way in, so the field is additive across releases in both directions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped: Vec<SkippedInvitation>,
+}
+
+/// One address an invitation submission SKIPPED rather than re-sent
+/// ([`InvitationData::skipped`]) — not an error: the rest of the submission landed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "contract-derives",
+    derive(schemars::JsonSchema, utoipa::ToSchema)
+)]
+pub struct SkippedInvitation {
+    /// The folded address that was skipped.
+    pub email: String,
+    /// Why, in the server's words (display text, e.g. `already invited recently`).
+    pub reason: String,
 }
 
 // =================================================================================================
@@ -1452,10 +1471,25 @@ mod tests {
             address: "https://topos.example/acme".to_owned(),
             invited: vec!["alice@acme.com".to_owned()],
             mailed: false,
+            skipped: Vec::new(),
         };
         let v = serde_json::to_value(&data).unwrap();
         assert_eq!(v["address"], "https://topos.example/acme");
         assert_eq!(v["mailed"], false);
+        // `skipped` omits when empty and defaults on the way in — additive both ways, so an
+        // older server's answer (no field) and an older client's parse both keep working.
+        assert!(v.get("skipped").is_none());
+        let back: InvitationData = serde_json::from_value(v).unwrap();
+        assert!(back.skipped.is_empty());
+        let with: InvitationData = serde_json::from_value(serde_json::json!({
+            "address": "https://topos.example/acme",
+            "invited": [],
+            "mailed": false,
+            "skipped": [{ "email": "bob@acme.com", "reason": "already invited recently" }],
+        }))
+        .unwrap();
+        assert_eq!(with.skipped[0].email, "bob@acme.com");
+        assert_eq!(with.skipped[0].reason, "already invited recently");
     }
 
     #[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
     # its own schema. Refresh the pin: docker buildx imagetools inspect postgres:18
     image: postgres:18@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20
     restart: unless-stopped
+    # A ceiling, not a reservation: one runaway service must not take the box down with it.
+    mem_limit: 1g
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-topos}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-topos}
@@ -130,6 +132,7 @@ services:
     # the docker-compose.build.yml override.
     image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.40}
     restart: unless-stopped
+    mem_limit: 1g
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
     # compose network; nothing outside the network can. (The image already binds 0.0.0.0:8787.)
     depends_on:
@@ -155,6 +158,7 @@ services:
     # together.
     image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.40}
     restart: unless-stopped
+    mem_limit: 1g
     depends_on:
       db:
         condition: service_healthy

--- a/web/app/components/members/invite-member-form.tsx
+++ b/web/app/components/members/invite-member-form.tsx
@@ -5,11 +5,20 @@ import { BusyFields, buttonClasses } from "@/components/ui";
 /** The members route's typed reply for `intent=invite`. */
 interface InviteActionData {
   intent: "invite";
-  status: "invited" | "owner_required" | "mail_unarmed" | "error";
+  status:
+    | "invited"
+    | "owner_required"
+    | "mail_unarmed"
+    | "error"
+    | "too_many"
+    | "invite_limit"
+    | "member_limit";
   /** Echoed on a non-success so the field keeps the typed addresses. */
   submittedEmails?: string;
   /** The addresses invited, on success. */
   invited?: string[];
+  /** Addresses not re-sent — each was already invited recently (server-wide cooldown). */
+  skipped?: string[];
   /** Whether the notice mail went out (the invitation row stands regardless). */
   emailSent?: boolean;
 }
@@ -85,10 +94,20 @@ export function InviteMemberForm({ mailArmed, isOwner }: { mailArmed: boolean; i
       </p>
       {state?.status === "invited" && (
         <p className="text-sm text-dim" role="status">
-          Invited {state.invited?.join(", ") ?? "your teammates"} as members.{" "}
-          {state.emailSent
-            ? "They were emailed the workspace address; each joins by signing up under the invited email."
-            : "The invitation stands, but the mail didn't send — invite the address again to resend."}
+          {(state.invited?.length ?? 0) > 0 && (
+            <>
+              Invited {state.invited?.join(", ")} as members.{" "}
+              {state.emailSent
+                ? "They were emailed the workspace address; each joins by signing up under the invited email."
+                : "The invitation stands, but the mail didn't send — invite the address again to resend."}
+            </>
+          )}
+          {(state.skipped?.length ?? 0) > 0 && (
+            <>
+              {(state.invited?.length ?? 0) > 0 ? " " : ""}
+              Didn&apos;t send to {state.skipped?.join(", ")} — already invited recently.
+            </>
+          )}
         </p>
       )}
       {state?.status === "owner_required" && (
@@ -99,6 +118,21 @@ export function InviteMemberForm({ mailArmed, isOwner }: { mailArmed: boolean; i
       {state?.status === "mail_unarmed" && (
         <p className="text-red-600 text-sm" role="alert">
           Mail isn&apos;t configured on this deployment — set TOPOS_MAIL_SMTP_* to invite.
+        </p>
+      )}
+      {state?.status === "too_many" && (
+        <p className="text-red-600 text-sm" role="alert">
+          Too many addresses at once. Send up to 10 invitations at a time.
+        </p>
+      )}
+      {state?.status === "invite_limit" && (
+        <p className="text-red-600 text-sm" role="alert">
+          Invitation limit reached for today. Try again tomorrow.
+        </p>
+      )}
+      {state?.status === "member_limit" && (
+        <p className="text-red-600 text-sm" role="alert">
+          This workspace is at its member limit.
         </p>
       )}
       {state?.status === "error" && (

--- a/web/app/components/skill/history-section.tsx
+++ b/web/app/components/skill/history-section.tsx
@@ -21,6 +21,12 @@ export interface HistoryStepView {
    */
   parents: string[];
   fileCount: number;
+  /**
+   * Server-computed: the row sits outside the workspace's history window. Still listed —
+   * nothing is deleted under a window — but the roll-back affordance is withheld (the action
+   * refuses it regardless), and the row says why.
+   */
+  locked?: boolean;
 }
 
 /**
@@ -91,7 +97,12 @@ export function HistorySection({ skill, data }: { skill: string; data: HistorySe
                 <span className="text-xs text-faint">
                   {step.fileCount === 1 ? "1 file" : `${step.fileCount} files`}
                 </span>
-                {data.canRevert && step.versionId !== data.head && (
+                {step.locked === true && (
+                  <span className="rounded border border-line-soft px-1.5 py-0.5 text-[11px] text-faint">
+                    Outside history window
+                  </span>
+                )}
+                {data.canRevert && step.versionId !== data.head && step.locked !== true && (
                   <div className="w-full">
                     <RevertControl
                       good={step.versionId}

--- a/web/app/components/skill/skill-invite.tsx
+++ b/web/app/components/skill/skill-invite.tsx
@@ -5,10 +5,18 @@ import { BusyFields, buttonClasses, Card } from "@/components/ui";
 /** The skill route's typed reply for `intent=invite` (mirrors the action's return union). */
 interface SkillInviteReply {
   intent: "invite";
-  status: "invited" | "owner_required" | "mail_unarmed" | "error";
+  status:
+    | "invited"
+    | "owner_required"
+    | "mail_unarmed"
+    | "error"
+    | "invite_limit"
+    | "member_limit"
+    /** The address was on its cooldown — nothing minted, nothing mailed. */
+    | "skipped";
   /** Echoed on a non-success so the field keeps the typed address through the re-render. */
   submittedEmail?: string;
-  /** The address invited, on success. */
+  /** The address invited (or, on `skipped`, the address not re-sent). */
   invited?: string;
   /** Whether the notice mail went out (the invitation row stands regardless). */
   emailSent?: boolean;
@@ -124,6 +132,21 @@ export function SkillInviteAffordance({
           {state.emailSent
             ? `They were emailed the invite; accepting puts this ${noun} in front of them first.`
             : "The invitation stands, but the mail didn't send — invite the address again to resend."}
+        </p>
+      )}
+      {state?.status === "skipped" && (
+        <p className="text-dim text-sm" role="status">
+          Didn&apos;t send to {state.invited} — already invited recently.
+        </p>
+      )}
+      {state?.status === "invite_limit" && (
+        <p className="text-red-600 text-sm" role="alert">
+          Invitation limit reached for today. Try again tomorrow.
+        </p>
+      )}
+      {state?.status === "member_limit" && (
+        <p className="text-red-600 text-sm" role="alert">
+          This workspace is at its member limit.
         </p>
       )}
       {state?.status === "owner_required" && (

--- a/web/app/lib/api/genesis.server.ts
+++ b/web/app/lib/api/genesis.server.ts
@@ -2,6 +2,8 @@ import { type BundleKind, kindEntry } from "@/lib/bundle-base";
 import { claimBundleIdentityInTx } from "@/lib/db/bundle-identity.server";
 import { mintBundleId } from "@/lib/db/identity.server";
 import {
+  bundleCapRefusal,
+  bundleCapRefusalInTx,
   type FinalTx,
   type GenesisDestination,
   type GenesisRegistration,
@@ -138,6 +140,15 @@ export async function publishGenesisBundle<T = undefined>(
   const bundleId = args.bundleId ?? mintBundleId();
   const ws = args.actor.workspaceId;
 
+  // THE BUNDLE CAP (`bundles`), before any custody call — a NEW identity at the cap must not
+  // ingest bytes it will never register (a no-op without a limit; the in-transaction check
+  // below stays the race-fenced authority). New versions of existing bundles never run this
+  // path at all.
+  const capped = await bundleCapRefusal(args.actor);
+  if (capped !== null) {
+    return { kind: "refused", refusal: capped };
+  }
+
   // THE KIND'S GATE, before any custody call — a refused candidate must leave no ingested bytes
   // behind. A kind with no content gate passes straight through.
   let identity: string | null = null;
@@ -174,6 +185,13 @@ export async function publishGenesisBundle<T = undefined>(
 
   const landed = await inFinalTxOrRefusal<{ landing: GenesisLanding; extra: T }, McpGateRefusal>(
     async (tx, refuse) => {
+      // The bundle cap's AUTHORITY — re-checked in this transaction under the advisory lock,
+      // so two concurrent geneses at the boundary serialize (the pre-vault read above only
+      // keeps the common refusal byte-free). A refusal rolls the whole registration back.
+      const stillCapped = await bundleCapRefusalInTx(tx, args.actor);
+      if (stillCapped !== null) {
+        refuse(stillCapped);
+      }
       const registration = await registerGenesisBundleInTx(
         tx,
         args.actor,

--- a/web/app/lib/api/genesis.server.ts
+++ b/web/app/lib/api/genesis.server.ts
@@ -145,7 +145,7 @@ export async function publishGenesisBundle<T = undefined>(
   // ingest bytes it will never register (a no-op without a limit; the in-transaction check
   // below stays the race-fenced authority). New versions of existing bundles never run this
   // path at all.
-  const capped = await bundleCapRefusal(args.actor);
+  const capped = await bundleCapRefusal(args.actor, bundleId);
   if (capped !== null) {
     return { kind: "refused", refusal: capped };
   }
@@ -197,7 +197,7 @@ export async function publishGenesisBundle<T = undefined>(
       // The bundle cap's AUTHORITY — re-checked in this transaction under the advisory lock,
       // so two concurrent geneses at the boundary serialize (the pre-vault read above only
       // keeps the common refusal byte-free). A refusal rolls the whole registration back.
-      const stillCapped = await bundleCapRefusalInTx(tx, args.actor);
+      const stillCapped = await bundleCapRefusalInTx(tx, args.actor, bundleId);
       if (stillCapped !== null) {
         refuse(stillCapped);
       }

--- a/web/app/lib/api/genesis.server.ts
+++ b/web/app/lib/api/genesis.server.ts
@@ -1,3 +1,4 @@
+import { candidateStoredBytes, storageCapRefusalForIngest } from "@/lib/api/storage-quota.server";
 import { type BundleKind, kindEntry } from "@/lib/bundle-base";
 import { claimBundleIdentityInTx } from "@/lib/db/bundle-identity.server";
 import { mintBundleId } from "@/lib/db/identity.server";
@@ -147,6 +148,14 @@ export async function publishGenesisBundle<T = undefined>(
   const capped = await bundleCapRefusal(args.actor);
   if (capped !== null) {
     return { kind: "refused", refusal: capped };
+  }
+
+  // THE STORAGE QUOTA (`storage-bytes`), HERE so every genesis door meets it — the web
+  // creation pages call this path directly, never the lane routes' own check — and before any
+  // custody call, so a refusal leaves no ingested bytes (a no-op without a limit).
+  const overQuota = await storageCapRefusalForIngest(ws, candidateStoredBytes(args.candidate));
+  if (overQuota !== null) {
+    return { kind: "refused", refusal: overQuota };
   }
 
   // THE KIND'S GATE, before any custody call — a refused candidate must leave no ingested bytes

--- a/web/app/lib/api/publish-flow.server.ts
+++ b/web/app/lib/api/publish-flow.server.ts
@@ -118,13 +118,38 @@ async function recordUpstreamInTx(
 }
 
 /**
+ * What a candidate would add to custody AT MOST: the decoded size of every file it carries,
+ * computed arithmetically off the base64 lengths (never by materializing the bytes — the
+ * publish cap is large). This is the honest admission charge: the quota is defined over
+ * STORED custody bytes, so the wire's base64 expansion and JSON framing must not count
+ * against it. Still conservative — content-addressed dedup only ever stores less than this
+ * (an unchanged file adds nothing), and only the vault could price that exactly.
+ */
+export function candidateStoredBytes(candidate: WireCandidate): number {
+  let total = 0;
+  for (const file of candidate.files) {
+    const b64 = file.content_base64;
+    const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
+    total += Math.max(0, Math.floor((b64.length / 4) * 3) - padding);
+  }
+  return total;
+}
+
+/**
  * The per-workspace STORAGE quota (`storage-bytes`), consulted by both ingest doors (publish +
  * propose) after auth and before any vault call. A no-op without a limit (the OSS default —
- * the stat is not even read). With one: stored + this request's bytes over the limit refuses
- * with the house DENIED envelope; a failed stat read ALLOWS (fail-open — the ingest shares the
- * same backend and fails on a real outage; the skip is logged in storage.server.ts). The
- * refusal is deliberately NOT persisted as an op receipt: it reflects the workspace's standing
- * limit, and the same op retried under a wider limit must re-evaluate, not replay.
+ * the stat is not even read). With one: stored + the candidate's decoded bytes over the limit
+ * refuses with the house DENIED envelope; a failed stat read ALLOWS (fail-open — the ingest
+ * shares the same backend and fails on a real outage; the skip is logged in
+ * storage.server.ts). The refusal is deliberately NOT persisted as an op receipt: it reflects
+ * the workspace's standing limit, and the same op retried under a wider limit must
+ * re-evaluate, not replay.
+ *
+ * ADMISSION, not accounting: the stat is a pre-ingest read, so concurrent publishes that all
+ * pass it can overshoot the limit by at most the sum of their in-flight candidates — bounded
+ * by the body cap per request — and the very next stat read enforces again. An exact
+ * reservation would have to live inside the vault's ingest itself; the vault is deliberately
+ * policy-free, so this tier holds the line at bounded-overshoot admission.
  */
 export async function storageQuotaRefusal(
   actor: SessionActor,

--- a/web/app/lib/api/publish-flow.server.ts
+++ b/web/app/lib/api/publish-flow.server.ts
@@ -1,3 +1,4 @@
+import { composition } from "@/composition.server";
 import type { WireCandidate } from "@/lib/api/candidate.server";
 import { receiptNow } from "@/lib/api/candidate.server";
 import { publishGenesisBundle } from "@/lib/api/genesis.server";
@@ -30,6 +31,7 @@ import {
   mcpNameTakenRefusal,
 } from "@/lib/mcp/publish-gate.server";
 import { commitVersion, publishVersion } from "@/lib/plane/custody.server";
+import { workspaceStoredBytes } from "@/lib/plane/storage.server";
 
 /**
  * The shared publish/propose ORCHESTRATION — the one flow behind `POST /v1/publish` (with the
@@ -113,6 +115,44 @@ async function recordUpstreamInTx(
       ON CONFLICT (bundle_id, version_id) DO NOTHING
     `);
   }
+}
+
+/**
+ * The per-workspace STORAGE quota (`storage-bytes`), consulted by both ingest doors (publish +
+ * propose) after auth and before any vault call. A no-op without a limit (the OSS default —
+ * the stat is not even read). With one: stored + this request's bytes over the limit refuses
+ * with the house DENIED envelope; a failed stat read ALLOWS (fail-open — the ingest shares the
+ * same backend and fails on a real outage; the skip is logged in storage.server.ts). The
+ * refusal is deliberately NOT persisted as an op receipt: it reflects the workspace's standing
+ * limit, and the same op retried under a wider limit must re-evaluate, not replay.
+ */
+export async function storageQuotaRefusal(
+  actor: SessionActor,
+  opId: string,
+  command: string,
+  requestBytes: number,
+): Promise<Response | null> {
+  const entitlements = await composition.entitlements.forWorkspace(actor.workspaceId);
+  const limit = entitlements.limit("storage-bytes");
+  if (limit === null) {
+    return null;
+  }
+  const stored = await workspaceStoredBytes(actor.workspaceId);
+  if (stored === null || stored + requestBytes <= limit) {
+    return null;
+  }
+  const receipt = buildReceipt({
+    opId,
+    command,
+    outcome: "DENIED",
+    workspaceId: actor.workspaceId,
+    createdAt: receiptNow(),
+  });
+  return envelopeResponse(
+    deniedEnvelope(command, "STORAGE_LIMIT_REACHED", undefined, receipt, {
+      message: "Storage limit reached for this workspace.",
+    }),
+  );
 }
 
 export async function publishFlow(args: PublishFlowArgs): Promise<Response> {

--- a/web/app/lib/api/publish-flow.server.ts
+++ b/web/app/lib/api/publish-flow.server.ts
@@ -1,4 +1,3 @@
-import { composition } from "@/composition.server";
 import type { WireCandidate } from "@/lib/api/candidate.server";
 import { receiptNow } from "@/lib/api/candidate.server";
 import { publishGenesisBundle } from "@/lib/api/genesis.server";
@@ -31,7 +30,6 @@ import {
   mcpNameTakenRefusal,
 } from "@/lib/mcp/publish-gate.server";
 import { commitVersion, publishVersion } from "@/lib/plane/custody.server";
-import { workspaceStoredBytes } from "@/lib/plane/storage.server";
 
 /**
  * The shared publish/propose ORCHESTRATION — the one flow behind `POST /v1/publish` (with the
@@ -115,69 +113,6 @@ async function recordUpstreamInTx(
       ON CONFLICT (bundle_id, version_id) DO NOTHING
     `);
   }
-}
-
-/**
- * What a candidate would add to custody AT MOST: the decoded size of every file it carries,
- * computed arithmetically off the base64 lengths (never by materializing the bytes — the
- * publish cap is large). This is the honest admission charge: the quota is defined over
- * STORED custody bytes, so the wire's base64 expansion and JSON framing must not count
- * against it. Still conservative — content-addressed dedup only ever stores less than this
- * (an unchanged file adds nothing), and only the vault could price that exactly.
- */
-export function candidateStoredBytes(candidate: WireCandidate): number {
-  let total = 0;
-  for (const file of candidate.files) {
-    const b64 = file.content_base64;
-    const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
-    total += Math.max(0, Math.floor((b64.length / 4) * 3) - padding);
-  }
-  return total;
-}
-
-/**
- * The per-workspace STORAGE quota (`storage-bytes`), consulted by both ingest doors (publish +
- * propose) after auth and before any vault call. A no-op without a limit (the OSS default —
- * the stat is not even read). With one: stored + the candidate's decoded bytes over the limit
- * refuses with the house DENIED envelope; a failed stat read ALLOWS (fail-open — the ingest
- * shares the same backend and fails on a real outage; the skip is logged in
- * storage.server.ts). The refusal is deliberately NOT persisted as an op receipt: it reflects
- * the workspace's standing limit, and the same op retried under a wider limit must
- * re-evaluate, not replay.
- *
- * ADMISSION, not accounting: the stat is a pre-ingest read, so concurrent publishes that all
- * pass it can overshoot the limit by at most the sum of their in-flight candidates — bounded
- * by the body cap per request — and the very next stat read enforces again. An exact
- * reservation would have to live inside the vault's ingest itself; the vault is deliberately
- * policy-free, so this tier holds the line at bounded-overshoot admission.
- */
-export async function storageQuotaRefusal(
-  actor: SessionActor,
-  opId: string,
-  command: string,
-  requestBytes: number,
-): Promise<Response | null> {
-  const entitlements = await composition.entitlements.forWorkspace(actor.workspaceId);
-  const limit = entitlements.limit("storage-bytes");
-  if (limit === null) {
-    return null;
-  }
-  const stored = await workspaceStoredBytes(actor.workspaceId);
-  if (stored === null || stored + requestBytes <= limit) {
-    return null;
-  }
-  const receipt = buildReceipt({
-    opId,
-    command,
-    outcome: "DENIED",
-    workspaceId: actor.workspaceId,
-    createdAt: receiptNow(),
-  });
-  return envelopeResponse(
-    deniedEnvelope(command, "STORAGE_LIMIT_REACHED", undefined, receipt, {
-      message: "Storage limit reached for this workspace.",
-    }),
-  );
 }
 
 export async function publishFlow(args: PublishFlowArgs): Promise<Response> {

--- a/web/app/lib/api/storage-quota.server.ts
+++ b/web/app/lib/api/storage-quota.server.ts
@@ -1,0 +1,99 @@
+import { composition } from "@/composition.server";
+import { receiptNow } from "@/lib/api/candidate.server";
+import { buildReceipt, deniedEnvelope, envelopeResponse } from "@/lib/api/receipts.server";
+import type { SessionActor } from "@/lib/auth/guards.server";
+import type { McpGateRefusal } from "@/lib/mcp/publish-gate.server";
+import { workspaceStoredBytes } from "@/lib/plane/storage.server";
+
+/**
+ * The per-workspace STORAGE quota (`storage-bytes`) — ONE admission check for EVERY custody
+ * ingest door: the session lane's publish/propose routes, the shared genesis path all three
+ * creation doors run (so add-from-GitHub and add-an-MCP-server cannot ingest around it), and
+ * the upstream checker's imports. A no-op without a limit (the OSS default — the stat is not
+ * even read). With one: stored + the candidate's decoded bytes over the limit refuses; a
+ * failed stat read ALLOWS (fail-open — the ingest shares the same backend and fails on a real
+ * outage; the skip is logged in storage.server.ts).
+ *
+ * ADMISSION, not accounting: the stat is a pre-ingest read, so concurrent ingests that all
+ * pass it can overshoot the limit by at most the sum of their in-flight candidates — bounded
+ * by the body cap per request — and the very next stat read enforces again. An exact
+ * reservation would have to live inside the vault's ingest itself; the vault is deliberately
+ * policy-free, so this tier holds the line at bounded-overshoot admission.
+ */
+
+/** The one refusal every non-route door renders (the same code the route envelope carries). */
+const STORAGE_LIMIT_REFUSAL: McpGateRefusal = {
+  code: "STORAGE_LIMIT_REACHED",
+  message: "Storage limit reached for this workspace.",
+};
+
+/**
+ * What a candidate would add to custody AT MOST: the decoded size of every file it carries,
+ * computed arithmetically off the base64 lengths (never by materializing the bytes — the
+ * publish cap is large). This is the honest admission charge: the quota is defined over
+ * STORED custody bytes, so the wire's base64 expansion and JSON framing must not count
+ * against it. Still conservative — content-addressed dedup only ever stores less than this
+ * (an unchanged file adds nothing), and only the vault could price that exactly.
+ */
+export function candidateStoredBytes(candidate: {
+  files: readonly { content_base64: string }[];
+}): number {
+  let total = 0;
+  for (const file of candidate.files) {
+    const b64 = file.content_base64;
+    const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
+    total += Math.max(0, Math.floor((b64.length / 4) * 3) - padding);
+  }
+  return total;
+}
+
+/** The admission decision itself — shared by every door below. */
+export async function storageCapExceeded(workspaceId: string, addBytes: number): Promise<boolean> {
+  const entitlements = await composition.entitlements.forWorkspace(workspaceId);
+  const limit = entitlements.limit("storage-bytes");
+  if (limit === null) {
+    return false;
+  }
+  const stored = await workspaceStoredBytes(workspaceId);
+  return stored !== null && stored + addBytes > limit;
+}
+
+/**
+ * The quota as the GENESIS path's refusal shape — the same typed answer every genesis door
+ * already renders, decided before any custody call so a refusal leaves no ingested bytes.
+ */
+export async function storageCapRefusalForIngest(
+  workspaceId: string,
+  addBytes: number,
+): Promise<McpGateRefusal | null> {
+  return (await storageCapExceeded(workspaceId, addBytes)) ? STORAGE_LIMIT_REFUSAL : null;
+}
+
+/**
+ * The quota as the SESSION LANE's wire answer (publish/propose routes), consulted after auth
+ * and the replay check. Deliberately NOT persisted as an op receipt: the refusal reflects the
+ * workspace's standing limit, and the same op retried under a wider limit must re-evaluate,
+ * not replay.
+ */
+export async function storageQuotaRefusal(
+  actor: SessionActor,
+  opId: string,
+  command: string,
+  requestBytes: number,
+): Promise<Response | null> {
+  if (!(await storageCapExceeded(actor.workspaceId, requestBytes))) {
+    return null;
+  }
+  const receipt = buildReceipt({
+    opId,
+    command,
+    outcome: "DENIED",
+    workspaceId: actor.workspaceId,
+    createdAt: receiptNow(),
+  });
+  return envelopeResponse(
+    deniedEnvelope(command, STORAGE_LIMIT_REFUSAL.code, undefined, receipt, {
+      message: STORAGE_LIMIT_REFUSAL.message,
+    }),
+  );
+}

--- a/web/app/lib/api/wire.server.ts
+++ b/web/app/lib/api/wire.server.ts
@@ -180,8 +180,9 @@ export async function readCappedBody(
   // The declared length is only a HINT — a caller may omit it entirely (chunked transfer), and
   // then a plain `request.text()` would buffer the whole stream before anything could object.
   // So the cap is enforced AS the body arrives: the read is abandoned the moment it is exceeded,
-  // and the connection is cancelled rather than drained. This matters most on the publish-family
-  // routes, whose cap is large by necessity and whose credential check comes after the body.
+  // and the connection is cancelled rather than drained. Every authenticated lane route also
+  // resolves its credential BEFORE reading the body, so this cap bounds what an AUTHENTICATED
+  // caller can make the tier buffer — an unauthenticated one buffers nothing.
   const body = request.body;
   if (body === null) {
     return "";

--- a/web/app/lib/auth/guards.server.ts
+++ b/web/app/lib/auth/guards.server.ts
@@ -1,7 +1,13 @@
 import { data, redirect } from "react-router";
 import { composition } from "@/composition.server";
 import { bearerToken, uniformNotFound } from "@/lib/api/wire.server";
-import { seatOf, sessionActor, theWorkspace, workspaceByName } from "@/lib/db/identity.server";
+import {
+  seatOf,
+  sessionActor,
+  sessionActorByCredential,
+  theWorkspace,
+  workspaceByName,
+} from "@/lib/db/identity.server";
 import { personDisplay } from "@/lib/person-display";
 import { publicOrigin } from "@/lib/plane/public-base.server";
 import { getAuth } from "./server";
@@ -349,6 +355,36 @@ export async function requireSessionActor(
     userId: row.userId,
     display: row.userDisplay,
     workspaceId,
+    sessionId: row.sessionId,
+    role: row.role,
+    sessionStatus: row.sessionStatus,
+  } as SessionActor;
+}
+
+/**
+ * The session lane's front door for routes whose workspace rides in the BODY (the publish
+ * family): the SAME resolve as `requireSessionActor`, keyed by the credential alone — the
+ * credential is workspace-scoped and hash-unique, so at most one live session answers, and
+ * its row names the one workspace it may act in. This lets the route authenticate BEFORE
+ * reading the request body, so an unauthenticated caller can never make this tier buffer a
+ * publish-sized body. The route MUST then hold the parsed body's workspace against
+ * `actor.workspaceId` (fold a mismatch to the uniform 404) — the same answer the
+ * workspace-keyed lookup gave a foreign-workspace body. ACTIVE sessions only; every miss is
+ * the ONE uniform wire 404.
+ */
+export async function requireSessionActorPreBody(request: Request): Promise<SessionActor> {
+  const credential = bearerToken(request);
+  if (credential === null) {
+    throw uniformNotFound();
+  }
+  const row = await sessionActorByCredential(credential);
+  if (row === null || row.sessionStatus !== "active") {
+    throw uniformNotFound();
+  }
+  return {
+    userId: row.userId,
+    display: row.userDisplay,
+    workspaceId: row.workspaceId,
     sessionId: row.sessionId,
     role: row.role,
     sessionStatus: row.sessionStatus,

--- a/web/app/lib/db/identity.server.ts
+++ b/web/app/lib/db/identity.server.ts
@@ -5,6 +5,7 @@ import { eq, sql } from "drizzle-orm";
 import { composition } from "@/composition.server";
 import { serverEnv } from "@/env.server";
 import { type Db, getDb, isUniqueViolation } from "./index.server";
+import { memberCapReachedInTx } from "./invite-caps.server";
 import {
   assignment,
   auditEvent,
@@ -909,7 +910,11 @@ export type LoginApproveOutcome =
     }
   /** The create arm's typed refusal: the slug is reserved or taken (indistinguishable, like
    * /new); the whole transaction rolled back and the flow stays pending for a retry. */
-  | { outcome: "taken" };
+  | { outcome: "taken" }
+  /** The create arm's per-person floors (counted inside the birth fence, exactly as /new's) —
+   * typed, honest, and the flow stays pending. */
+  | { outcome: "rate-limited" }
+  | { outcome: "owned-limit" };
 
 /** The in-transaction abort sentinel: an approval that cannot complete must ROLL BACK any
  * invitation accept or workspace birth it already made (a bare `return null` from a Drizzle
@@ -918,6 +923,9 @@ export type LoginApproveOutcome =
 const APPROVE_ABORT = Symbol("login-approve-abort");
 /** The create arm's typed rollback: same discipline, surfaced as `taken` instead of null. */
 const APPROVE_TAKEN = Symbol("login-approve-taken");
+/** The create arm's floor rollbacks — the same discipline, surfaced typed like `taken`. */
+const APPROVE_RATE_LIMITED = Symbol("login-approve-rate-limited");
+const APPROVE_OWNED_LIMIT = Symbol("login-approve-owned-limit");
 
 /**
  * FENCE 2 — the login-flow approve, one FOR UPDATE transaction: lock the pending row by
@@ -1025,9 +1033,10 @@ export async function approveLoginFlow(
             throw APPROVE_ABORT;
           }
           // The workspace birth runs INSIDE this fence — the identical one-transaction birth
-          // /new runs (the shared tx body). The route ran the policy pre-checks (entitlement
-          // gate + the per-person floor) before calling; a reserved slug answers the typed
-          // rollback here, and a create-race unique violation surfaces at the boundary below.
+          // /new runs (the shared tx body, per-person advisory lock + counted floors
+          // included). The route ran the surface pre-check (tenancy + the entitlement gate)
+          // before calling; a reserved slug and the floors answer their typed rollbacks here,
+          // and a create-race unique violation surfaces at the boundary below.
           const born = await createWorkspaceTx(
             tx,
             approver,
@@ -1036,6 +1045,12 @@ export async function approveLoginFlow(
           );
           if (born.outcome === "taken") {
             throw APPROVE_TAKEN;
+          }
+          if (born.outcome === "rate-limited") {
+            throw APPROVE_RATE_LIMITED;
+          }
+          if (born.outcome === "owned-limit") {
+            throw APPROVE_OWNED_LIMIT;
           }
           chosenWorkspaceId = born.workspaceId;
           via = "create";
@@ -1077,6 +1092,12 @@ export async function approveLoginFlow(
     }
     if (error === APPROVE_TAKEN || (choice?.kind === "create" && isUniqueViolation(error))) {
       return { outcome: "taken" };
+    }
+    if (error === APPROVE_RATE_LIMITED) {
+      return { outcome: "rate-limited" };
+    }
+    if (error === APPROVE_OWNED_LIMIT) {
+      return { outcome: "owned-limit" };
     }
     throw error;
   }
@@ -1595,6 +1616,54 @@ export async function sessionActor(
 }
 
 /**
+ * The credential-FIRST resolve for routes whose workspace rides in the BODY (the publish
+ * family): the same live-session → seat chain as `sessionActor`, keyed by the credential alone
+ * — it is workspace-scoped and hash-unique, so at most one session answers, and the session
+ * row itself names the one workspace it may act in. The caller authenticates BEFORE reading
+ * the request body (so an unauthenticated caller never makes this tier buffer a large body),
+ * then binds the parsed body's workspace against `workspaceId` — a mismatch is the same
+ * uniform 404 the old workspace-keyed lookup answered.
+ */
+export async function sessionActorByCredential(
+  credential: string,
+): Promise<(SessionActorRow & { workspaceId: string }) | null> {
+  const rows = await getDb().execute(
+    sql`UPDATE web.cli_session cs SET last_seen_at = now()
+        FROM ${seat} s, web."user" u, ${workspace} w
+        WHERE cs.credential_sha256 = ${sha256OfText(credential)}
+          AND w.id = cs.workspace_id
+          AND ${sessionUnexpiredSql("cs", "w")}
+          AND u.id = cs.user_id
+          AND s.user_id = cs.user_id AND s.workspace_id = cs.workspace_id
+        RETURNING cs.id AS session_id, cs.workspace_id, cs.user_id,
+          -- The display rule (app/lib/person-display.ts): a blank name falls back to the email.
+          COALESCE(NULLIF(btrim(u.name), ''), u.email) AS user_display, s.role,
+          cs.status AS session_status`,
+  );
+  const row = rows.rows[0] as
+    | {
+        session_id: string;
+        workspace_id: string;
+        user_id: string;
+        user_display: string;
+        role: SessionActorRow["role"];
+        session_status: SessionStatus;
+      }
+    | undefined;
+  if (!row) {
+    return null;
+  }
+  return {
+    sessionId: row.session_id,
+    workspaceId: row.workspace_id,
+    userId: row.user_id,
+    userDisplay: row.user_display,
+    role: row.role,
+    sessionStatus: row.session_status,
+  };
+}
+
+/**
  * The invited sign-up's binding leg: convert every pending, unexpired invitation for this
  * (verified) address into a seat, atomically per run. Called from the auth layer's
  * after-verification hook — the mailbox round-trip IS the identity rung, so this is the one
@@ -1622,6 +1691,12 @@ export async function bindInvitedSeats(
         role: string;
         invited_by: string | null;
       };
+      // The member cap's seat-mint backstop (a no-op without a `members` limit): a full
+      // workspace is SKIPPED — its invitation stays pending, so a wider limit later binds it
+      // on the next verification pass or through the accept ceremony.
+      if (await memberCapReachedInTx(tx, inv.workspace_id, userId)) {
+        continue;
+      }
       await tx.execute(
         sql`UPDATE web.invitation
             SET status = 'accepted', accepted_by = ${userId}, accepted_at = now()
@@ -1894,7 +1969,10 @@ export type InviteAcceptOutcome =
   | { outcome: "wrong_account" }
   /** The invited address's account never proved its mailbox — one round-trip first (the true
    * owner passes; a squatter cannot). */
-  | { outcome: "unverified" };
+  | { outcome: "unverified" }
+  /** The workspace's member limit is reached — the invitation stays pending (a wider limit
+   * lets the same link succeed later); nothing is consumed. */
+  | { outcome: "workspace_full" };
 
 /**
  * FENCE — the invitation accept, ONE transaction beside bindInvitedSeats: the email-binding
@@ -1921,6 +1999,12 @@ async function acceptInvitationTx(
   }
   if (!account.emailVerified && !opts.mailboxProven) {
     return { outcome: "unverified" };
+  }
+  // The member cap's seat-mint backstop (a no-op without a `members` limit): a full workspace
+  // refuses BEFORE anything is written — the invitation stays pending, and an accepter who
+  // already holds a seat is never refused (the insert below no-ops for them anyway).
+  if (await memberCapReachedInTx(tx, inv.workspaceId, account.userId)) {
+    return { outcome: "workspace_full" };
   }
   if (opts.mailboxProven && !account.emailVerified) {
     await tx.execute(sql`UPDATE web."user" SET email_verified = true WHERE id = ${account.userId}`);

--- a/web/app/lib/db/identity.server.ts
+++ b/web/app/lib/db/identity.server.ts
@@ -2000,14 +2000,18 @@ async function acceptInvitationTx(
   if (!account.emailVerified && !opts.mailboxProven) {
     return { outcome: "unverified" };
   }
-  // The member cap's seat-mint backstop (a no-op without a `members` limit): a full workspace
-  // refuses BEFORE anything is written — the invitation stays pending, and an accepter who
-  // already holds a seat is never refused (the insert below no-ops for them anyway).
-  if (await memberCapReachedInTx(tx, inv.workspaceId, account.userId)) {
-    return { outcome: "workspace_full" };
-  }
   if (opts.mailboxProven && !account.emailVerified) {
     await tx.execute(sql`UPDATE web."user" SET email_verified = true WHERE id = ${account.userId}`);
+  }
+  // The member cap's seat-mint backstop (a no-op without a `members` limit): a full workspace
+  // refuses with the invitation UNCONSUMED — it stays pending, so the same link admits once
+  // there is room — and an accepter who already holds a seat is never refused (the insert
+  // below no-ops for them anyway). AFTER the mailbox-proof flip above, deliberately: the
+  // typed refusal COMMITS (it is an answer, not a fault), and possession of the mailed token
+  // proved the mailbox whatever the seat count says — an account-minting accept refused here
+  // must not come back a second verification round-trip poorer.
+  if (await memberCapReachedInTx(tx, inv.workspaceId, account.userId)) {
+    return { outcome: "workspace_full" };
   }
   await tx.execute(
     sql`UPDATE web.invitation

--- a/web/app/lib/db/identity.server.ts
+++ b/web/app/lib/db/identity.server.ts
@@ -5,7 +5,7 @@ import { eq, sql } from "drizzle-orm";
 import { composition } from "@/composition.server";
 import { serverEnv } from "@/env.server";
 import { type Db, getDb, isUniqueViolation } from "./index.server";
-import { memberCapReachedInTx } from "./invite-caps.server";
+import { lockMemberCapInTx, memberCapReachedInTx } from "./invite-caps.server";
 import {
   assignment,
   auditEvent,
@@ -914,7 +914,12 @@ export type LoginApproveOutcome =
   /** The create arm's per-person floors (counted inside the birth fence, exactly as /new's) —
    * typed, honest, and the flow stays pending. */
   | { outcome: "rate-limited" }
-  | { outcome: "owned-limit" };
+  | { outcome: "owned-limit" }
+  /** An invitation-bound approval met the workspace's member limit: BOTH the flow and the
+   * invitation stay pending (nothing consumed; the same approval works once there is room),
+   * and the refusal is reported rather than folded into "gone" — or worse, fallen through to
+   * a workspace the invitation never named. */
+  | { outcome: "workspace-full" };
 
 /** The in-transaction abort sentinel: an approval that cannot complete must ROLL BACK any
  * invitation accept or workspace birth it already made (a bare `return null` from a Drizzle
@@ -926,6 +931,8 @@ const APPROVE_TAKEN = Symbol("login-approve-taken");
 /** The create arm's floor rollbacks — the same discipline, surfaced typed like `taken`. */
 const APPROVE_RATE_LIMITED = Symbol("login-approve-rate-limited");
 const APPROVE_OWNED_LIMIT = Symbol("login-approve-owned-limit");
+/** The invitation arms' member-limit rollback — typed; the flow and invitation stay pending. */
+const APPROVE_WORKSPACE_FULL = Symbol("login-approve-workspace-full");
 
 /**
  * FENCE 2 — the login-flow approve, one FOR UPDATE transaction: lock the pending row by
@@ -982,10 +989,9 @@ export async function approveLoginFlow(
       // the exchange later re-reads. The fences answer wrong_account/unverified BEFORE any
       // write, so falling through to the posted choice commits nothing of the invitation.
       if (row.invite_token_sha256 !== null) {
-        const inv = await lockPendingInvitationTx(
-          tx,
-          sql`i.token_sha256 = ${row.invite_token_sha256}`,
-        );
+        const byToken = sql`i.token_sha256 = ${row.invite_token_sha256}`;
+        await lockMemberCapForInvitationTx(tx, byToken);
+        const inv = await lockPendingInvitationTx(tx, byToken);
         if (inv !== null) {
           const outcome = await acceptInvitationTx(tx, inv, await sessionAccountTx(tx, approver), {
             mailboxProven: false,
@@ -993,6 +999,11 @@ export async function approveLoginFlow(
           if (outcome.outcome === "accepted") {
             chosenWorkspaceId = outcome.workspaceId;
             via = "invite-token";
+          } else if (outcome.outcome === "workspace_full") {
+            // The token BINDS this flow to its one workspace: a member-limit refusal must
+            // never fall through to the posted choice and connect somewhere the invitation
+            // never named. Typed rollback — flow and invitation both stay pending.
+            throw APPROVE_WORKSPACE_FULL;
           }
         }
       }
@@ -1013,13 +1024,20 @@ export async function approveLoginFlow(
         } else if (choice.kind === "invitation") {
           // The approver's OWN pending invitation, by id — the same accept fences as the token
           // weave (addressee + verified mailbox), so a guessed id buys nothing.
-          const inv = await lockPendingInvitationTx(tx, sql`i.id = ${choice.id}`);
+          const byId = sql`i.id = ${choice.id}`;
+          await lockMemberCapForInvitationTx(tx, byId);
+          const inv = await lockPendingInvitationTx(tx, byId);
           if (inv === null) {
             throw APPROVE_ABORT;
           }
           const outcome = await acceptInvitationTx(tx, inv, await sessionAccountTx(tx, approver), {
             mailboxProven: false,
           });
+          if (outcome.outcome === "workspace_full") {
+            // Typed, not folded into "gone": the flow and the invitation both remain pending,
+            // and the approver deserves the actual refusal.
+            throw APPROVE_WORKSPACE_FULL;
+          }
           if (outcome.outcome !== "accepted") {
             throw APPROVE_ABORT;
           }
@@ -1098,6 +1116,9 @@ export async function approveLoginFlow(
     }
     if (error === APPROVE_OWNED_LIMIT) {
       return { outcome: "owned-limit" };
+    }
+    if (error === APPROVE_WORKSPACE_FULL) {
+      return { outcome: "workspace-full" };
     }
     throw error;
   }
@@ -1677,6 +1698,22 @@ export async function bindInvitedSeats(
 ): Promise<number> {
   const lowered = email.trim().toLowerCase();
   return await getDb().transaction(async (tx) => {
+    // The members-cap advisory locks come BEFORE the row locks (the one lock order every
+    // ceremony follows — the invite door holds the same advisory key while it upserts these
+    // rows, so taking rows first would invert into a deadlock). A workspace's id never moves
+    // between rows, so the unlocked peek is stable; sorted, so two concurrent bindings with
+    // overlapping sets queue instead of cycling. A no-op per workspace without a limit.
+    const peek = await tx.execute(
+      sql`SELECT DISTINCT workspace_id FROM web.invitation
+          WHERE email = ${lowered} AND status = 'pending'
+            AND (expires_at IS NULL OR expires_at > now())`,
+    );
+    const workspaceIds = (peek.rows as { workspace_id: string }[])
+      .map((r) => r.workspace_id)
+      .sort();
+    for (const wsId of workspaceIds) {
+      await lockMemberCapInTx(tx, wsId);
+    }
     const rows = await tx.execute(
       sql`SELECT id, workspace_id, role, invited_by FROM web.invitation
           WHERE email = ${lowered} AND status = 'pending'
@@ -1914,6 +1951,27 @@ interface LockedInvitation {
   hintChannelId: string | null;
 }
 
+/**
+ * Peek the workspace a live invitation names (NO lock) and take the members-cap advisory lock
+ * for it — called BEFORE `lockPendingInvitationTx`, so the one lock order every ceremony
+ * follows (members advisory → invitation row) holds here too: the invite door holds the same
+ * advisory key while it upserts invitation rows, so an accept that locked its row first would
+ * invert into a deadlock. The workspace id of an invitation row never changes, so the unlocked
+ * peek is stable; a dead token peeks nothing and locks nothing; a no-op without a `members`
+ * limit (the OSS default).
+ */
+async function lockMemberCapForInvitationTx(tx: Tx, cond: ReturnType<typeof sql>): Promise<void> {
+  const rows = await tx.execute(
+    sql`SELECT i.workspace_id FROM web.invitation i
+        WHERE ${cond} AND i.status = 'pending'
+          AND (i.expires_at IS NULL OR i.expires_at > now())`,
+  );
+  const ws = (rows.rows[0] as { workspace_id: string } | undefined)?.workspace_id;
+  if (ws !== undefined) {
+    await lockMemberCapInTx(tx, ws);
+  }
+}
+
 /** Lock ONE live (pending, unexpired) invitation row by an arbitrary predicate — the shared
  * FOR-UPDATE fence of accept, decline, and the login-approval weave. */
 async function lockPendingInvitationTx(
@@ -2096,7 +2154,9 @@ export async function acceptInvitationByToken(
   opts: { mailboxProven: boolean },
 ): Promise<InviteAcceptOutcome> {
   return await getDb().transaction(async (tx) => {
-    const inv = await lockPendingInvitationTx(tx, sql`i.token_sha256 = ${sha256OfText(token)}`);
+    const byToken = sql`i.token_sha256 = ${sha256OfText(token)}`;
+    await lockMemberCapForInvitationTx(tx, byToken);
+    const inv = await lockPendingInvitationTx(tx, byToken);
     if (inv === null) {
       return { outcome: "gone" };
     }

--- a/web/app/lib/db/invite-caps.server.ts
+++ b/web/app/lib/db/invite-caps.server.ts
@@ -1,0 +1,145 @@
+import { sql } from "drizzle-orm";
+import { composition } from "@/composition.server";
+import type { getDb } from "./index.server";
+
+/**
+ * The invitation caps — ONE spelling shared by both invitation doors (the members page's
+ * `createInvitations` and the session lane's `laneInvite`), enforced INSIDE their existing
+ * transactions. These checks ARE the enforcement: route actions bypass every in-process
+ * limiter (rate-limit.server.ts says so), so a pre-check throttle outside the transaction
+ * would be a decoration, not a cap. The OSS defaults keep everything but the floored daily
+ * cap a no-op — a self-hosted team never meets the member cap or a lowered daily cap.
+ *
+ * Three caps, in the order a submission meets them:
+ *  1. per-submission — at most MAX_INVITES_PER_SUBMISSION addresses; over refuses WHOLE.
+ *  2. member cap (`members`) — seats + live pending invitations at/over the limit refuses.
+ *  3. per-account daily — `invitation_created` audit rows in a rolling day (the same
+ *     append-only counting the workspace-create floor uses; rides `audit_actor_user`).
+ *     FLOORED: an absent `invites-per-day` row means 10/day while the account is under 48
+ *     hours old, else 50/day — and a present row wins even when lower.
+ *
+ * Plus one per-ADDRESS cooldown that is not a refusal at all: an address invited repeatedly
+ * (server-wide — mail leaves the server, not a workspace) is SKIPPED for a while, and the
+ * receipt says so per address. Skipped addresses write no rows, so a skip never extends its
+ * own cooldown.
+ */
+
+/** How many addresses one submission may carry. */
+export const MAX_INVITES_PER_SUBMISSION = 10;
+
+/** The floored daily caps (see `invites-per-day` in the entitlements seam). */
+const DAILY_FLOOR_YOUNG_ACCOUNT = 10;
+const DAILY_FLOOR = 50;
+const YOUNG_ACCOUNT_HOURS = 48;
+
+/** The per-address cooldown: this many `invitation_created` rows in the window skips the address. */
+const COOLDOWN_MAX_INVITES = 3;
+const COOLDOWN_WINDOW_DAYS = 7;
+
+/** The transaction handle the checks run under (any caller's tx). */
+type Tx = Parameters<Parameters<ReturnType<typeof getDb>["transaction"]>[0]>[0];
+
+export type InviteCapRefusal = "too_many_addresses" | "member_limit" | "invite_limit";
+
+/** The per-submission cap — pure input policy, checked before any transaction opens. */
+export function submissionCapRefusal(addressCount: number): "too_many_addresses" | null {
+  return addressCount > MAX_INVITES_PER_SUBMISSION ? "too_many_addresses" : null;
+}
+
+/**
+ * The stateful caps, INSIDE the caller's transaction: the member cap, then the daily cap.
+ * `null` clears both. The daily count is prospective (existing rows + this submission), so a
+ * submission can never step over the cap; the member count follows the brief's simple form —
+ * at/over refuses, and the seat-mint check backstops any pending overshoot.
+ */
+export async function inviteCapRefusalInTx(
+  tx: Tx,
+  args: { workspaceId: string; actorUserId: string; addressCount: number },
+): Promise<InviteCapRefusal | null> {
+  const entitlements = await composition.entitlements.forWorkspace(args.workspaceId);
+
+  const memberLimit = entitlements.limit("members");
+  if (memberLimit !== null) {
+    const rows = await tx.execute(
+      sql`SELECT
+            (SELECT count(*)::int FROM web.seat WHERE workspace_id = ${args.workspaceId})
+          + (SELECT count(*)::int FROM web.invitation
+              WHERE workspace_id = ${args.workspaceId} AND status = 'pending'
+                AND (expires_at IS NULL OR expires_at > now())) AS n`,
+    );
+    if (((rows.rows[0] as { n: number } | undefined)?.n ?? 0) >= memberLimit) {
+      return "member_limit";
+    }
+  }
+
+  // The daily cap always has a value: the entitlement row when present (it wins even when
+  // lower), else the account-age floor.
+  let dailyCap = entitlements.limit("invites-per-day");
+  if (dailyCap === null) {
+    const age = await tx.execute(
+      sql`SELECT created_at > now() - make_interval(hours => ${YOUNG_ACCOUNT_HOURS}) AS young
+          FROM web."user" WHERE id = ${args.actorUserId}`,
+    );
+    const young = (age.rows[0] as { young: boolean } | undefined)?.young ?? true;
+    dailyCap = young ? DAILY_FLOOR_YOUNG_ACCOUNT : DAILY_FLOOR;
+  }
+  const recent = await tx.execute(
+    sql`SELECT count(*)::int AS n FROM web.audit_event
+        WHERE kind = 'invitation_created' AND outcome = 'ok'
+          AND actor_user_id = ${args.actorUserId}
+          AND created_at > now() - interval '24 hours'`,
+  );
+  const sent = (recent.rows[0] as { n: number } | undefined)?.n ?? 0;
+  if (sent + args.addressCount > dailyCap) {
+    return "invite_limit";
+  }
+  return null;
+}
+
+/**
+ * The member cap at SEAT MINT — the backstop behind the invite-time check, inside the accept
+ * ceremony's transaction. A no-op when no `members` limit exists (the OSS default). When one
+ * does: an advisory transaction lock serializes concurrent accepts against the same workspace
+ * (each ceremony locks only its own invitation row, so two different invitations would
+ * otherwise both read the same seat count), a user already seated is never refused (the seat
+ * insert is idempotent — nothing grows), and a full workspace refuses. The workspace-birth
+ * owner seat never comes through here — it is exempt by construction.
+ */
+export async function memberCapReachedInTx(
+  tx: Tx,
+  workspaceId: string,
+  userId: string,
+): Promise<boolean> {
+  const entitlements = await composition.entitlements.forWorkspace(workspaceId);
+  const limit = entitlements.limit("members");
+  if (limit === null) {
+    return false;
+  }
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`members:${workspaceId}`}))`);
+  const rows = await tx.execute(
+    sql`SELECT
+          (SELECT count(*)::int FROM web.seat WHERE workspace_id = ${workspaceId}) AS seats,
+          EXISTS(SELECT 1 FROM web.seat
+                  WHERE workspace_id = ${workspaceId} AND user_id = ${userId}) AS seated`,
+  );
+  const row = rows.rows[0] as { seats: number; seated: boolean } | undefined;
+  if (row === undefined || row.seated) {
+    return false;
+  }
+  return row.seats >= limit;
+}
+
+/**
+ * The per-address cooldown, inside the caller's transaction: whether THIS address was invited
+ * COOLDOWN_MAX_INVITES times or more in the window, server-wide. True = skip the address (not
+ * a submission error); the caller reports it as `already invited recently`.
+ */
+export async function inviteCooldownActiveInTx(tx: Tx, email: string): Promise<boolean> {
+  const rows = await tx.execute(
+    sql`SELECT count(*)::int AS n FROM web.audit_event
+        WHERE kind = 'invitation_created' AND outcome = 'ok'
+          AND subject = ${email}
+          AND created_at > now() - make_interval(days => ${COOLDOWN_WINDOW_DAYS})`,
+  );
+  return ((rows.rows[0] as { n: number } | undefined)?.n ?? 0) >= COOLDOWN_MAX_INVITES;
+}

--- a/web/app/lib/db/invite-caps.server.ts
+++ b/web/app/lib/db/invite-caps.server.ts
@@ -63,12 +63,14 @@ export async function inviteCapRefusalInTx(
   tx: Tx,
   args: { workspaceId: string; actorUserId: string; emails: string[] },
 ): Promise<InviteCapRefusal | null> {
-  // The per-inviter lock FIRST — the daily counter always has a floor, so every submission
+  // Entitlements resolve BEFORE any lock is taken (see the provider contract in
+  // topos-web/entitlements.ts) — a provider answer must never extend how long a lock is held.
+  const entitlements = await composition.entitlements.forWorkspace(args.workspaceId);
+  // The per-inviter lock next — the daily counter always has a floor, so every submission
   // takes it: two concurrent submissions from one account serialize here, and the second
   // reads the first's committed audit rows (held to commit; per-account, so different
   // inviters never queue behind each other).
   await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`invites:${args.actorUserId}`}))`);
-  const entitlements = await composition.entitlements.forWorkspace(args.workspaceId);
   const distinct = [...new Set(args.emails)];
 
   const memberLimit = entitlements.limit("members");

--- a/web/app/lib/db/invite-caps.server.ts
+++ b/web/app/lib/db/invite-caps.server.ts
@@ -47,19 +47,31 @@ export function submissionCapRefusal(addressCount: number): "too_many_addresses"
 }
 
 /**
- * The stateful caps, INSIDE the caller's transaction: the member cap, then the daily cap.
- * `null` clears both. The daily count is prospective (existing rows + this submission), so a
- * submission can never step over the cap; the member count follows the brief's simple form —
- * at/over refuses, and the seat-mint check backstops any pending overshoot.
+ * The stateful caps, INSIDE the caller's transaction AND serialized by advisory transaction
+ * locks — a count read in a transaction is still a check-then-act race without one (two
+ * concurrent submissions would both read the same audit total and both commit past the cap).
+ * Lock ORDER is fixed everywhere (inviter → workspace members → addresses, sorted) so
+ * concurrent submissions can never deadlock. `null` clears both caps. The daily count is
+ * prospective (existing rows + this submission), so a submission can never step over the cap;
+ * the member count follows the at/over form, and the seat-mint check backstops any pending
+ * overshoot.
  */
 export async function inviteCapRefusalInTx(
   tx: Tx,
   args: { workspaceId: string; actorUserId: string; addressCount: number },
 ): Promise<InviteCapRefusal | null> {
+  // The per-inviter lock FIRST — the daily counter always has a floor, so every submission
+  // takes it: two concurrent submissions from one account serialize here, and the second
+  // reads the first's committed audit rows (held to commit; per-account, so different
+  // inviters never queue behind each other).
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`invites:${args.actorUserId}`}))`);
   const entitlements = await composition.entitlements.forWorkspace(args.workspaceId);
 
   const memberLimit = entitlements.limit("members");
   if (memberLimit !== null) {
+    // The SAME key the seat-mint backstop takes (`members:<ws>`), so invite-time and
+    // accept-time counts serialize with each other, not only with themselves.
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`members:${args.workspaceId}`}))`);
     const rows = await tx.execute(
       sql`SELECT
             (SELECT count(*)::int FROM web.seat WHERE workspace_id = ${args.workspaceId})
@@ -130,9 +142,23 @@ export async function memberCapReachedInTx(
 }
 
 /**
- * The per-address cooldown, inside the caller's transaction: whether THIS address was invited
- * COOLDOWN_MAX_INVITES times or more in the window, server-wide. True = skip the address (not
- * a submission error); the caller reports it as `already invited recently`.
+ * Serialize this submission's ADDRESSES against every concurrent submission touching any of
+ * them — taken once, before a door's mint loop, in SORTED unique order (the fixed global
+ * order is what makes two overlapping submissions queue instead of deadlock). Without these
+ * locks, two concurrent submissions to the same address could both read a cooldown count of
+ * COOLDOWN_MAX_INVITES − 1 and both send.
+ */
+export async function lockInviteAddressesInTx(tx: Tx, emails: string[]): Promise<void> {
+  for (const email of [...new Set(emails)].sort()) {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`invite-addr:${email}`}))`);
+  }
+}
+
+/**
+ * The per-address cooldown, inside the caller's transaction and behind
+ * `lockInviteAddressesInTx`: whether THIS address was invited COOLDOWN_MAX_INVITES times or
+ * more in the window, server-wide. True = skip the address (not a submission error); the
+ * caller reports it as `already invited recently`.
  */
 export async function inviteCooldownActiveInTx(tx: Tx, email: string): Promise<boolean> {
   const rows = await tx.execute(

--- a/web/app/lib/db/invite-caps.server.ts
+++ b/web/app/lib/db/invite-caps.server.ts
@@ -1,6 +1,7 @@
-import { sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { composition } from "@/composition.server";
 import type { getDb } from "./index.server";
+import { invitation } from "./schema.app";
 
 /**
  * The invitation caps — ONE spelling shared by both invitation doors (the members page's
@@ -50,15 +51,17 @@ export function submissionCapRefusal(addressCount: number): "too_many_addresses"
  * The stateful caps, INSIDE the caller's transaction AND serialized by advisory transaction
  * locks — a count read in a transaction is still a check-then-act race without one (two
  * concurrent submissions would both read the same audit total and both commit past the cap).
- * Lock ORDER is fixed everywhere (inviter → workspace members → addresses, sorted) so
- * concurrent submissions can never deadlock. `null` clears both caps. The daily count is
- * prospective (existing rows + this submission), so a submission can never step over the cap;
- * the member count follows the at/over form, and the seat-mint check backstops any pending
- * overshoot.
+ * Lock ORDER is fixed everywhere (inviter → workspace members → addresses, sorted; the accept
+ * ceremonies take their members lock BEFORE any invitation-row lock for the same reason) so
+ * concurrent transactions can never deadlock. `null` clears both caps. BOTH counts are
+ * PROSPECTIVE — what stands plus what THIS submission adds — so a batch can never step over a
+ * cap that its first address alone would have cleared: the member count adds the submission's
+ * distinct addresses that do not already hold a live pending row (a re-invite adds nothing, so
+ * resending at the limit still works), and the daily count adds the whole submission.
  */
 export async function inviteCapRefusalInTx(
   tx: Tx,
-  args: { workspaceId: string; actorUserId: string; addressCount: number },
+  args: { workspaceId: string; actorUserId: string; emails: string[] },
 ): Promise<InviteCapRefusal | null> {
   // The per-inviter lock FIRST — the daily counter always has a floor, so every submission
   // takes it: two concurrent submissions from one account serialize here, and the second
@@ -66,20 +69,37 @@ export async function inviteCapRefusalInTx(
   // inviters never queue behind each other).
   await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`invites:${args.actorUserId}`}))`);
   const entitlements = await composition.entitlements.forWorkspace(args.workspaceId);
+  const distinct = [...new Set(args.emails)];
 
   const memberLimit = entitlements.limit("members");
   if (memberLimit !== null) {
     // The SAME key the seat-mint backstop takes (`members:<ws>`), so invite-time and
     // accept-time counts serialize with each other, not only with themselves.
     await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`members:${args.workspaceId}`}))`);
-    const rows = await tx.execute(
+    const standingRows = await tx.execute(
       sql`SELECT
             (SELECT count(*)::int FROM web.seat WHERE workspace_id = ${args.workspaceId})
           + (SELECT count(*)::int FROM web.invitation
               WHERE workspace_id = ${args.workspaceId} AND status = 'pending'
                 AND (expires_at IS NULL OR expires_at > now())) AS n`,
     );
-    if (((rows.rows[0] as { n: number } | undefined)?.n ?? 0) >= memberLimit) {
+    const standing = (standingRows.rows[0] as { n: number } | undefined)?.n ?? 0;
+    // What this submission ADDS: its distinct addresses minus those already live-pending here
+    // (the upsert re-arms those rows without adding one). Cooldown skips are not subtracted —
+    // they are decided later, so the check stays conservative.
+    const alreadyPending = await tx
+      .select({ email: invitation.email })
+      .from(invitation)
+      .where(
+        and(
+          eq(invitation.workspaceId, args.workspaceId),
+          eq(invitation.status, "pending"),
+          inArray(invitation.email, distinct),
+          sql`(${invitation.expiresAt} IS NULL OR ${invitation.expiresAt} > now())`,
+        ),
+      );
+    const adds = distinct.length - new Set(alreadyPending.map((r) => r.email)).size;
+    if (standing + adds > memberLimit) {
       return "member_limit";
     }
   }
@@ -102,18 +122,34 @@ export async function inviteCapRefusalInTx(
           AND created_at > now() - interval '24 hours'`,
   );
   const sent = (recent.rows[0] as { n: number } | undefined)?.n ?? 0;
-  if (sent + args.addressCount > dailyCap) {
+  if (sent + args.emails.length > dailyCap) {
     return "invite_limit";
   }
   return null;
 }
 
 /**
+ * Take the members-cap advisory lock ALONE — no count. The accept ceremonies call this BEFORE
+ * locking their invitation row, so the one lock order (members advisory → invitation row)
+ * holds against the invite door, which takes the same advisory key and then upserts rows: an
+ * accept that locked its row first while an invite held the advisory key and waited on that
+ * row would be a deadlock. A no-op when no `members` limit exists (the OSS default), exactly
+ * like the count itself; re-acquiring inside the same transaction later is free.
+ */
+export async function lockMemberCapInTx(tx: Tx, workspaceId: string): Promise<void> {
+  const entitlements = await composition.entitlements.forWorkspace(workspaceId);
+  if (entitlements.limit("members") === null) {
+    return;
+  }
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`members:${workspaceId}`}))`);
+}
+
+/**
  * The member cap at SEAT MINT — the backstop behind the invite-time check, inside the accept
  * ceremony's transaction. A no-op when no `members` limit exists (the OSS default). When one
  * does: an advisory transaction lock serializes concurrent accepts against the same workspace
- * (each ceremony locks only its own invitation row, so two different invitations would
- * otherwise both read the same seat count), a user already seated is never refused (the seat
+ * (taken BEFORE the ceremony's invitation-row lock via `lockMemberCapInTx`; re-acquired here
+ * for callers with no row lock at all), a user already seated is never refused (the seat
  * insert is idempotent — nothing grows), and a full workspace refuses. The workspace-birth
  * owner seat never comes through here — it is exempt by construction.
  */

--- a/web/app/lib/db/queries.custody.server.ts
+++ b/web/app/lib/db/queries.custody.server.ts
@@ -1,4 +1,5 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { composition } from "@/composition.server";
 import type { MemberActor, SessionActor } from "@/lib/auth/guards.server";
 import { kindEntry } from "@/lib/bundle-base";
 import { claimBundleIdentityInTx } from "@/lib/db/bundle-identity.server";
@@ -13,7 +14,7 @@ import {
   proposal,
   workspace,
 } from "@/lib/db/schema.app";
-import { planeCurrentPointer } from "@/lib/db/schema.custody";
+import { planeCurrentPointer, planeVersion } from "@/lib/db/schema.custody";
 import { serverDocumentOf } from "@/lib/mcp/catalog.server";
 import { type McpGateRefusal, mcpNameTakenRefusal } from "@/lib/mcp/publish-gate.server";
 import { custodyVersionMetaFresh } from "@/lib/plane/reads.server";
@@ -181,6 +182,126 @@ const RESERVED_BUNDLE_NAMES = new Set(["topos", "topos-mcp"]);
 /** Is `name` reserved for the client's own directories? (see [`RESERVED_BUNDLE_NAMES`]) */
 export function isReservedBundleName(name: string): boolean {
   return RESERVED_BUNDLE_NAMES.has(name);
+}
+
+// ── The bundle cap (`bundles`) ──────────────────────────────────────────────────────────────
+
+/** The bundle cap's one refusal — the same shape every genesis door already renders. */
+const BUNDLE_LIMIT_REFUSAL: McpGateRefusal = {
+  code: "BUNDLE_LIMIT_REACHED",
+  message: "This workspace is at its bundle limit.",
+};
+
+async function activeBundleCount(executor: Pick<Tx, "execute">, ws: string): Promise<number> {
+  const rows = await executor.execute(
+    sql`SELECT count(*)::int AS n FROM ${bundle}
+        WHERE workspace_id = ${ws} AND status = 'active'`,
+  );
+  return (rows.rows[0] as { n: number } | undefined)?.n ?? 0;
+}
+
+/**
+ * The bundle cap (`bundles` — active catalog rows), consulted ONLY when a NEW bundle identity
+ * is being created; new versions of existing bundles never come through here. A no-op without
+ * a limit (the OSS default). Two spellings of one check:
+ *  - `bundleCapRefusal` runs BEFORE the vault call — the cheap read that keeps the common
+ *    refusal from leaving ingested bytes behind;
+ *  - `bundleCapRefusalInTx` is the AUTHORITY, inside the registration transaction under an
+ *    advisory lock, so two concurrent geneses at the boundary serialize instead of both
+ *    slipping past the count.
+ */
+export async function bundleCapRefusal(actor: PublishActor): Promise<McpGateRefusal | null> {
+  const entitlements = await composition.entitlements.forWorkspace(actor.workspaceId);
+  const limit = entitlements.limit("bundles");
+  if (limit === null) {
+    return null;
+  }
+  return (await activeBundleCount(getDb(), actor.workspaceId)) >= limit
+    ? BUNDLE_LIMIT_REFUSAL
+    : null;
+}
+
+export async function bundleCapRefusalInTx(
+  tx: Tx,
+  actor: PublishActor,
+): Promise<McpGateRefusal | null> {
+  const entitlements = await composition.entitlements.forWorkspace(actor.workspaceId);
+  const limit = entitlements.limit("bundles");
+  if (limit === null) {
+    return null;
+  }
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`bundles:${actor.workspaceId}`}))`);
+  return (await activeBundleCount(tx, actor.workspaceId)) >= limit ? BUNDLE_LIMIT_REFUSAL : null;
+}
+
+// ── The history window (`history-days`) ─────────────────────────────────────────────────────
+
+/**
+ * The workspace's revert-reach window in days, or null when none is set (the OSS default —
+ * unlimited). Nothing is ever deleted under a window: rows older than the cutoff stay listed
+ * (annotated) and only the REVERT doors refuse them, so a wider window restores access whole.
+ */
+export async function historyWindowDays(workspaceId: string): Promise<number | null> {
+  const entitlements = await composition.entitlements.forWorkspace(workspaceId);
+  return entitlements.limit("history-days");
+}
+
+/**
+ * Whether a revert target sits OUTSIDE the workspace's history window: the version's own
+ * recorded creation time (the custody mirror) against now minus the window. No window, or a
+ * version the mirror does not hold, is `false` — the revert flow's own refusals (unknown
+ * version, purged target) stay the authority on what exists.
+ */
+export async function versionOutsideHistoryWindow(
+  actor: PublishActor,
+  bundleId: string,
+  versionId: string,
+): Promise<boolean> {
+  const days = await historyWindowDays(actor.workspaceId);
+  if (days === null) {
+    return false;
+  }
+  const rows = await getDb()
+    .select({ createdAt: planeVersion.createdAt })
+    .from(planeVersion)
+    .where(
+      and(
+        eq(planeVersion.workspaceId, actor.workspaceId),
+        eq(planeVersion.bundleId, bundleId),
+        eq(planeVersion.versionId, versionId),
+      ),
+    )
+    .limit(1);
+  const createdAt = rows[0]?.createdAt;
+  if (createdAt === undefined) {
+    return false;
+  }
+  return createdAt.getTime() < Date.now() - days * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * The creation times of a set of versions (the history page's lock annotation read) — one
+ * query over the custody mirror; versions the mirror does not hold are simply absent.
+ */
+export async function versionCreatedAtMap(
+  actor: PublishActor,
+  bundleId: string,
+  versionIds: string[],
+): Promise<Map<string, Date>> {
+  if (versionIds.length === 0) {
+    return new Map();
+  }
+  const rows = await getDb()
+    .select({ versionId: planeVersion.versionId, createdAt: planeVersion.createdAt })
+    .from(planeVersion)
+    .where(
+      and(
+        eq(planeVersion.workspaceId, actor.workspaceId),
+        eq(planeVersion.bundleId, bundleId),
+        inArray(planeVersion.versionId, versionIds),
+      ),
+    );
+  return new Map(rows.map((r) => [r.versionId, r.createdAt]));
 }
 
 export interface GenesisRegistration {

--- a/web/app/lib/db/queries.custody.server.ts
+++ b/web/app/lib/db/queries.custody.server.ts
@@ -200,30 +200,53 @@ async function activeBundleCount(executor: Pick<Tx, "execute">, ws: string): Pro
   return (rows.rows[0] as { n: number } | undefined)?.n ?? 0;
 }
 
+/** Whether an ACTIVE row with this id already stands in this workspace — such a "creation"
+ * adds no row (the registration no-ops on the id), so the cap must not refuse its retry. */
+async function activeBundleExists(
+  executor: Pick<Tx, "execute">,
+  ws: string,
+  bundleId: string,
+): Promise<boolean> {
+  const rows = await executor.execute(
+    sql`SELECT 1 FROM ${bundle}
+        WHERE workspace_id = ${ws} AND id = ${bundleId} AND status = 'active' LIMIT 1`,
+  );
+  return rows.rows.length > 0;
+}
+
 /**
- * The bundle cap (`bundles` — active catalog rows), consulted ONLY when a NEW bundle identity
- * is being created; new versions of existing bundles never come through here. A no-op without
- * a limit (the OSS default). Two spellings of one check:
+ * The bundle cap (`bundles` — active catalog rows), consulted ONLY where an ACTIVE row may be
+ * ADDED: a new identity's genesis, and unarchive. New versions of existing bundles never come
+ * through here, and a retry naming an id that already stands ACTIVE here is no growth — the
+ * registration no-ops on it, so refusing would turn a lost-ack retry of a landed publish into
+ * `BUNDLE_LIMIT_REACHED`. A no-op without a limit (the OSS default). Two spellings of one
+ * check:
  *  - `bundleCapRefusal` runs BEFORE the vault call — the cheap read that keeps the common
  *    refusal from leaving ingested bytes behind;
  *  - `bundleCapRefusalInTx` is the AUTHORITY, inside the registration transaction under an
  *    advisory lock, so two concurrent geneses at the boundary serialize instead of both
  *    slipping past the count.
  */
-export async function bundleCapRefusal(actor: PublishActor): Promise<McpGateRefusal | null> {
+export async function bundleCapRefusal(
+  actor: PublishActor,
+  bundleId: string,
+): Promise<McpGateRefusal | null> {
   const entitlements = await composition.entitlements.forWorkspace(actor.workspaceId);
   const limit = entitlements.limit("bundles");
   if (limit === null) {
     return null;
   }
-  return (await activeBundleCount(getDb(), actor.workspaceId)) >= limit
-    ? BUNDLE_LIMIT_REFUSAL
-    : null;
+  const db = getDb();
+  if (await activeBundleExists(db, actor.workspaceId, bundleId)) {
+    return null;
+  }
+  return (await activeBundleCount(db, actor.workspaceId)) >= limit ? BUNDLE_LIMIT_REFUSAL : null;
 }
 
 export async function bundleCapRefusalInTx(
   tx: Tx,
   actor: PublishActor,
+  bundleId: string,
 ): Promise<McpGateRefusal | null> {
   const entitlements = await composition.entitlements.forWorkspace(actor.workspaceId);
   const limit = entitlements.limit("bundles");
@@ -231,6 +254,9 @@ export async function bundleCapRefusalInTx(
     return null;
   }
   await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`bundles:${actor.workspaceId}`}))`);
+  if (await activeBundleExists(tx, actor.workspaceId, bundleId)) {
+    return null;
+  }
   return (await activeBundleCount(tx, actor.workspaceId)) >= limit ? BUNDLE_LIMIT_REFUSAL : null;
 }
 

--- a/web/app/lib/db/queries.lane.server.ts
+++ b/web/app/lib/db/queries.lane.server.ts
@@ -14,6 +14,7 @@ import { getDb } from "@/lib/db/index.server";
 import {
   inviteCapRefusalInTx,
   inviteCooldownActiveInTx,
+  lockInviteAddressesInTx,
   submissionCapRefusal,
 } from "@/lib/db/invite-caps.server";
 import { personDisplayLeftSql } from "@/lib/db/person-display.server";
@@ -707,6 +708,7 @@ export async function laneInvite(
     const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
     const minted: { email: string; token: string }[] = [];
     const skipped: string[] = [];
+    await lockInviteAddressesInTx(tx, folded);
     for (const email of folded) {
       if (await inviteCooldownActiveInTx(tx, email)) {
         skipped.push(email);

--- a/web/app/lib/db/queries.lane.server.ts
+++ b/web/app/lib/db/queries.lane.server.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
+import { composition } from "@/composition.server";
 import type { SessionActor } from "@/lib/auth/guards.server";
 import {
   auditInTx,
@@ -10,6 +11,11 @@ import {
   supersedeDeclinedInvitationTx,
 } from "@/lib/db/identity.server";
 import { getDb } from "@/lib/db/index.server";
+import {
+  inviteCapRefusalInTx,
+  inviteCooldownActiveInTx,
+  submissionCapRefusal,
+} from "@/lib/db/invite-caps.server";
 import { personDisplayLeftSql } from "@/lib/db/person-display.server";
 import { foldInviteEmail, INVITATION_TTL_MS } from "@/lib/db/queries.roster.server";
 import {
@@ -489,15 +495,30 @@ function protectionRoleGate(
   return role === "owner" ? null : "owner_role_required";
 }
 
+/**
+ * Whether ENABLING review protection is available to this workspace (`allows("reviews")`,
+ * OSS default: open). The gate is on enabling only — loosening back to `open` is never gated,
+ * and bundles already protected keep working (no retroactive strip).
+ */
+export async function reviewsEnableRefused(workspaceId: string): Promise<boolean> {
+  const entitlements = await composition.entitlements.forWorkspace(workspaceId);
+  return !entitlements.allows("reviews");
+}
+
 /** Pin a bundle's protection level (`open` | `reviewed`; the route validated the value). */
 export async function laneProtectBundle(
   actor: SessionActor,
   bundleId: string,
   level: "open" | "reviewed",
-): Promise<"set" | "unknown_skill" | "owner_role_required" | "reviewer_role_required"> {
+): Promise<
+  "set" | "unknown_skill" | "owner_role_required" | "reviewer_role_required" | "reviews_unavailable"
+> {
   const gate = protectionRoleGate(actor.role, level === "reviewed");
   if (gate !== null) {
     return gate;
+  }
+  if (level === "reviewed" && (await reviewsEnableRefused(actor.workspaceId))) {
+    return "reviews_unavailable";
   }
   const ws = actor.workspaceId;
   return await getDb().transaction(async (tx) => {
@@ -526,10 +547,19 @@ export async function laneProtectChannel(
   actor: SessionActor,
   channelName: string,
   mode: "open" | "curated",
-): Promise<"set" | "unknown_channel" | "owner_role_required" | "reviewer_role_required"> {
+): Promise<
+  | "set"
+  | "unknown_channel"
+  | "owner_role_required"
+  | "reviewer_role_required"
+  | "reviews_unavailable"
+> {
   const gate = protectionRoleGate(actor.role, mode === "curated");
   if (gate !== null) {
     return gate;
+  }
+  if (mode === "curated" && (await reviewsEnableRefused(actor.workspaceId))) {
+    return "reviews_unavailable";
   }
   const ws = actor.workspaceId;
   return await getDb().transaction(async (tx) => {
@@ -581,6 +611,9 @@ export type LaneInviteOutcome =
   | {
       outcome: "invited";
       minted: { email: string; token: string }[];
+      /** Addresses on a cooldown (invited repeatedly, server-wide) — no row written, no mail;
+       * the receipt reports each as `already invited recently`. */
+      skipped: string[];
       /**
        * The RESOLVED first destination — the bundle's own catalog kind ('skill' or 'mcp') or
        * 'channel', read from the row the hint resolved to rather than assumed from which field
@@ -592,7 +625,13 @@ export type LaneInviteOutcome =
   | { outcome: "owner_role_required" }
   | { outcome: "unknown_skill" }
   | { outcome: "unknown_channel" }
-  | { outcome: "bad_email" };
+  | { outcome: "bad_email" }
+  /** Over the per-submission address cap — the whole submission refuses. */
+  | { outcome: "too_many_addresses" }
+  /** The workspace's member limit (seats + pending invitations) is reached. */
+  | { outcome: "member_limit" }
+  /** The inviter's rolling-day cap is reached. */
+  | { outcome: "invite_limit" };
 
 /**
  * The session lane's invitation write. Inviting is OWNER-ONLY — the gate runs against the
@@ -619,7 +658,20 @@ export async function laneInvite(
   if (actor.role !== "owner") {
     return { outcome: "owner_role_required" };
   }
+  if (submissionCapRefusal(folded.length) !== null) {
+    return { outcome: "too_many_addresses" };
+  }
   return await getDb().transaction(async (tx) => {
+    // The stateful caps (member limit + the rolling-day cap), counted INSIDE this transaction —
+    // the same hard-cap discipline as the members-page door (invite-caps.server.ts).
+    const refusal = await inviteCapRefusalInTx(tx, {
+      workspaceId: ws,
+      actorUserId: actor.userId,
+      addressCount: folded.length,
+    });
+    if (refusal !== null) {
+      return { outcome: refusal };
+    }
     let hintBundleId: string | null = null;
     let hintChannelId: string | null = null;
     // The destination as RESOLVED. The lane's `skill` field names any bundle in the catalog,
@@ -654,7 +706,12 @@ export async function laneInvite(
     }
     const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
     const minted: { email: string; token: string }[] = [];
+    const skipped: string[] = [];
     for (const email of folded) {
+      if (await inviteCooldownActiveInTx(tx, email)) {
+        skipped.push(email);
+        continue;
+      }
       const token = mintInviteToken();
       await supersedeDeclinedInvitationTx(tx, ws, email);
       await tx.execute(sql`
@@ -684,6 +741,7 @@ export async function laneInvite(
     return {
       outcome: "invited",
       minted,
+      skipped,
       ...(resolvedHint === undefined ? {} : { hint: resolvedHint }),
     };
   });

--- a/web/app/lib/db/queries.lane.server.ts
+++ b/web/app/lib/db/queries.lane.server.ts
@@ -668,7 +668,7 @@ export async function laneInvite(
     const refusal = await inviteCapRefusalInTx(tx, {
       workspaceId: ws,
       actorUserId: actor.userId,
-      addressCount: folded.length,
+      emails: folded,
     });
     if (refusal !== null) {
       return { outcome: refusal };

--- a/web/app/lib/db/queries.lifecycle.server.ts
+++ b/web/app/lib/db/queries.lifecycle.server.ts
@@ -247,6 +247,15 @@ export async function unarchiveBundle(
     if (taken.length > 0) {
       return { outcome: "name_taken" } as const;
     }
+    // The bundle cap counts ACTIVE rows, so archived→active is the same step past it a
+    // genesis takes — checked here under the same advisory lock (a no-op without a limit),
+    // or archive-then-replace-then-unarchive would mint one active bundle over the cap.
+    // BEFORE the MCP name claim below, load-bearingly: this typed refusal COMMITS, and a
+    // claim already written by then would leave an archived bundle monopolizing a registry
+    // name it does not serve — archive keeps meaning the name is released.
+    if ((await bundleCapRefusalInTx(tx, actor)) !== null) {
+      return { outcome: "bundle_limit" } as const;
+    }
     // An MCP bundle carries a SECOND name — the registry name inside its document — and that
     // one is unique across the workspace's active catalog, which is what keeps the registry
     // read lane's `…/servers/{name}` unambiguous. Archiving freed it, so restoring is a claim
@@ -266,12 +275,6 @@ export async function unarchiveBundle(
       if (claim === "taken") {
         return { outcome: "mcp_name_taken" } as const;
       }
-    }
-    // The bundle cap counts ACTIVE rows, so archived→active is the same step past it a
-    // genesis takes — checked here under the same advisory lock (a no-op without a limit),
-    // or archive-then-replace-then-unarchive would mint one active bundle over the cap.
-    if ((await bundleCapRefusalInTx(tx, actor)) !== null) {
-      return { outcome: "bundle_limit" } as const;
     }
     await tx
       .update(bundle)

--- a/web/app/lib/db/queries.lifecycle.server.ts
+++ b/web/app/lib/db/queries.lifecycle.server.ts
@@ -253,7 +253,7 @@ export async function unarchiveBundle(
     // BEFORE the MCP name claim below, load-bearingly: this typed refusal COMMITS, and a
     // claim already written by then would leave an archived bundle monopolizing a registry
     // name it does not serve — archive keeps meaning the name is released.
-    if ((await bundleCapRefusalInTx(tx, actor)) !== null) {
+    if ((await bundleCapRefusalInTx(tx, actor, bundleId)) !== null) {
       return { outcome: "bundle_limit" } as const;
     }
     // An MCP bundle carries a SECOND name — the registry name inside its document — and that

--- a/web/app/lib/db/queries.lifecycle.server.ts
+++ b/web/app/lib/db/queries.lifecycle.server.ts
@@ -4,7 +4,11 @@ import { kindEntry } from "@/lib/bundle-base";
 import { releaseBundleIdentityInTx } from "@/lib/db/bundle-identity.server";
 import { auditInTx } from "@/lib/db/identity.server";
 import { getDb } from "@/lib/db/index.server";
-import { claimCurrentNameInTx, isReservedBundleName } from "@/lib/db/queries.custody.server";
+import {
+  bundleCapRefusalInTx,
+  claimCurrentNameInTx,
+  isReservedBundleName,
+} from "@/lib/db/queries.custody.server";
 import { reviewsEnableRefused } from "@/lib/db/queries.lane.server";
 import { bundle, bundleNameHint, channelBundle, notice, proposal } from "@/lib/db/schema.app";
 import { deleteBundleBytes, purgeVersionBytes } from "@/lib/plane/custody.server";
@@ -210,7 +214,10 @@ export type UnarchiveOutcome =
   | { outcome: "mcp_name_taken" }
   | { outcome: "mcp_document_unreadable" }
   | { outcome: "not_archived" }
-  | { outcome: "unknown_skill" };
+  | { outcome: "unknown_skill" }
+  /** The workspace's bundle limit (`bundles` — ACTIVE rows) is reached: restoring would step
+   * over the same cap a genesis meets, so it refuses under the same lock. */
+  | { outcome: "bundle_limit" };
 
 /** Unarchive — renames back if the base name is still free, else a typed refusal. Channel
  * placements are NOT restored (curation moved on); re-entitled detach records heal. */
@@ -259,6 +266,12 @@ export async function unarchiveBundle(
       if (claim === "taken") {
         return { outcome: "mcp_name_taken" } as const;
       }
+    }
+    // The bundle cap counts ACTIVE rows, so archived→active is the same step past it a
+    // genesis takes — checked here under the same advisory lock (a no-op without a limit),
+    // or archive-then-replace-then-unarchive would mint one active bundle over the cap.
+    if ((await bundleCapRefusalInTx(tx, actor)) !== null) {
+      return { outcome: "bundle_limit" } as const;
     }
     await tx
       .update(bundle)

--- a/web/app/lib/db/queries.lifecycle.server.ts
+++ b/web/app/lib/db/queries.lifecycle.server.ts
@@ -5,6 +5,7 @@ import { releaseBundleIdentityInTx } from "@/lib/db/bundle-identity.server";
 import { auditInTx } from "@/lib/db/identity.server";
 import { getDb } from "@/lib/db/index.server";
 import { claimCurrentNameInTx, isReservedBundleName } from "@/lib/db/queries.custody.server";
+import { reviewsEnableRefused } from "@/lib/db/queries.lane.server";
 import { bundle, bundleNameHint, channelBundle, notice, proposal } from "@/lib/db/schema.app";
 import { deleteBundleBytes, purgeVersionBytes } from "@/lib/plane/custody.server";
 
@@ -377,18 +378,26 @@ export async function purgeVersion(
   return { outcome: "purged" };
 }
 
-export type ProtectionOutcome = { outcome: "set" } | { outcome: "unknown_skill" };
+export type ProtectionOutcome =
+  | { outcome: "set" }
+  | { outcome: "unknown_skill" }
+  /** ENABLING review protection is not available to this workspace (`allows("reviews")`). */
+  | { outcome: "reviews_unavailable" };
 
 /**
  * Pin (or unpin) ONE bundle's protection: 'open'/'reviewed' overrides the workspace default,
  * null returns the bundle to inheriting it. The OwnerActor brand is the gate (the route re-guards
  * as owner); the publish gate and the review four-eyes check both read the resolved cascade.
+ * ENABLING `reviewed` is entitlement-gated; loosening and unpinning never are.
  */
 export async function setBundleProtection(
   actor: OwnerActor,
   bundleId: string,
   protection: "open" | "reviewed" | null,
 ): Promise<ProtectionOutcome> {
+  if (protection === "reviewed" && (await reviewsEnableRefused(actor.workspaceId))) {
+    return { outcome: "reviews_unavailable" };
+  }
   const ws = actor.workspaceId;
   return await getDb().transaction(async (tx) => {
     const rows = await tx

--- a/web/app/lib/db/queries.roster.server.ts
+++ b/web/app/lib/db/queries.roster.server.ts
@@ -10,6 +10,7 @@ import { getDb } from "@/lib/db/index.server";
 import {
   inviteCapRefusalInTx,
   inviteCooldownActiveInTx,
+  lockInviteAddressesInTx,
   submissionCapRefusal,
 } from "@/lib/db/invite-caps.server";
 import { personDisplaySql } from "@/lib/db/person-display.server";
@@ -166,6 +167,7 @@ export async function createInvitations(
     if (refusal !== null) {
       return refusal;
     }
+    await lockInviteAddressesInTx(tx, folded);
     for (const email of folded) {
       if (await inviteCooldownActiveInTx(tx, email)) {
         skipped.push(email);

--- a/web/app/lib/db/queries.roster.server.ts
+++ b/web/app/lib/db/queries.roster.server.ts
@@ -7,6 +7,11 @@ import {
   supersedeDeclinedInvitationTx,
 } from "@/lib/db/identity.server";
 import { getDb } from "@/lib/db/index.server";
+import {
+  inviteCapRefusalInTx,
+  inviteCooldownActiveInTx,
+  submissionCapRefusal,
+} from "@/lib/db/invite-caps.server";
 import { personDisplaySql } from "@/lib/db/person-display.server";
 import { invitation, seat } from "@/lib/db/schema.app";
 import { user } from "@/lib/db/schema.auth";
@@ -90,9 +95,21 @@ export interface InviteHintRef {
 }
 
 export type InviteOutcome =
-  | { outcome: "invited"; minted: MintedInvitation[] }
+  | {
+      outcome: "invited";
+      minted: MintedInvitation[];
+      /** Addresses on a cooldown (invited repeatedly, server-wide) — no row written, no mail;
+       * the receipt reports each as `already invited recently`. */
+      skipped: string[];
+    }
   | { outcome: "owner_role_required" }
-  | { outcome: "bad_email" };
+  | { outcome: "bad_email" }
+  /** Over the per-submission address cap — the whole submission refuses. */
+  | { outcome: "too_many_addresses" }
+  /** The workspace's member limit (seats + pending invitations) is reached. */
+  | { outcome: "member_limit" }
+  /** The inviter's rolling-day cap is reached. */
+  | { outcome: "invite_limit" };
 
 const MAX_EMAIL_LEN = 128;
 /** Path-safe + the mailbox specials — the same closed charset the wire folds. */
@@ -113,7 +130,10 @@ export function foldInviteEmail(email: string): string | null {
  * token — the old link dies with its hash). A prior DECLINED row for the address is superseded
  * (deleted; the audit trail keeps the record). The OWNER gate runs HERE against the actor's
  * role (inviting is owner-only, like revoking); the mail-armed gate and the notice send run in
- * the route. Every write lands its audit row in the same transaction.
+ * the route. Every write lands its audit row in the same transaction — and so do the
+ * invitation CAPS (invite-caps.server.ts): the member limit and the rolling-day cap are
+ * counted inside the transaction (hard caps, not pre-check throttles), and a repeatedly
+ * invited address is skipped rather than re-mailed.
  */
 export async function createInvitations(
   actor: MemberActor,
@@ -131,10 +151,26 @@ export async function createInvitations(
     }
     folded.push(canonical);
   }
+  if (submissionCapRefusal(folded.length) !== null) {
+    return { outcome: "too_many_addresses" };
+  }
   const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
   const minted: MintedInvitation[] = [];
-  await getDb().transaction(async (tx) => {
+  const skipped: string[] = [];
+  const capped = await getDb().transaction(async (tx) => {
+    const refusal = await inviteCapRefusalInTx(tx, {
+      workspaceId: actor.workspaceId,
+      actorUserId: actor.userId,
+      addressCount: folded.length,
+    });
+    if (refusal !== null) {
+      return refusal;
+    }
     for (const email of folded) {
+      if (await inviteCooldownActiveInTx(tx, email)) {
+        skipped.push(email);
+        continue;
+      }
       const token = mintInviteToken();
       await supersedeDeclinedInvitationTx(tx, actor.workspaceId, email);
       await tx.execute(sql`
@@ -160,8 +196,12 @@ export async function createInvitations(
       });
       minted.push({ email, token });
     }
+    return null;
   });
-  return { outcome: "invited", minted };
+  if (capped !== null) {
+    return { outcome: capped };
+  }
+  return { outcome: "invited", minted, skipped };
 }
 
 export type RevokeInvitationOutcome = "revoked" | "missing";

--- a/web/app/lib/db/queries.roster.server.ts
+++ b/web/app/lib/db/queries.roster.server.ts
@@ -162,7 +162,7 @@ export async function createInvitations(
     const refusal = await inviteCapRefusalInTx(tx, {
       workspaceId: actor.workspaceId,
       actorUserId: actor.userId,
-      addressCount: folded.length,
+      emails: folded,
     });
     if (refusal !== null) {
       return refusal;

--- a/web/app/lib/db/queries.server.ts
+++ b/web/app/lib/db/queries.server.ts
@@ -4,6 +4,7 @@ import type { MemberActor, OwnerActor, UserActor } from "@/lib/auth/guards.serve
 import { auditInTx } from "@/lib/db/identity.server";
 import { getDb } from "@/lib/db/index.server";
 import { personDisplayLeftSql } from "@/lib/db/person-display.server";
+import { reviewsEnableRefused } from "@/lib/db/queries.lane.server";
 import { bundle, proposal, proposalComment, seat, workspace } from "@/lib/db/schema.app";
 import { user } from "@/lib/db/schema.auth";
 import { planeCurrentPointer, planeVersionDigest } from "@/lib/db/schema.custody";
@@ -393,16 +394,21 @@ export async function insertProposalComment(
 
 // ── The review-default knob (a plain workspace column now) ──────────────────────────────────
 
-export type ReviewDefaultOutcome = "set";
+export type ReviewDefaultOutcome = "set" | "reviews_unavailable";
 
 /**
  * Set the workspace's protection DEFAULT (`open`/`reviewed` — what an unpinned bundle
  * inherits). The OwnerActor brand IS the gate; the audit row lands in the same transaction.
+ * ENABLING the reviewed default is entitlement-gated (`allows("reviews")`); switching it back
+ * to open never is.
  */
 export async function setReviewDefault(
   actor: OwnerActor,
   required: boolean,
 ): Promise<ReviewDefaultOutcome> {
+  if (required && (await reviewsEnableRefused(actor.workspaceId))) {
+    return "reviews_unavailable";
+  }
   const value = required ? "reviewed" : "open";
   await getDb().transaction(async (tx) => {
     await tx

--- a/web/app/lib/db/schema.app.ts
+++ b/web/app/lib/db/schema.app.ts
@@ -917,6 +917,10 @@ export const auditEvent = webSchema.table(
     index("audit_ws_time").on(table.workspaceId, table.createdAt),
     index("audit_actor_user").on(table.actorUserId).where(sql`actor_user_id is not null`),
     index("audit_actor_session").on(table.actorSessionId).where(sql`actor_session_id is not null`),
+    // The per-address invite-cooldown read (server-wide, subject = the invited address).
+    index("audit_invite_subject")
+      .on(table.subject, table.createdAt)
+      .where(sql`kind = 'invitation_created'`),
   ],
 );
 

--- a/web/app/lib/db/upstream.server.ts
+++ b/web/app/lib/db/upstream.server.ts
@@ -1,5 +1,6 @@
 import { gunzipSync } from "node:zlib";
 import { sql } from "drizzle-orm";
+import { storageCapExceeded } from "@/lib/api/storage-quota.server";
 import { getDb } from "@/lib/db/index.server";
 import { validateCandidateFiles } from "@/lib/mcp/validate.server";
 import { commitVersion } from "@/lib/plane/custody.server";
@@ -471,6 +472,19 @@ export async function checkBundleUpstream(
     if (!validated.ok) {
       return { outcome: "error", message: validated.message };
     }
+  }
+
+  // THE STORAGE QUOTA (`storage-bytes`) covers this ingest door too — the checker imports
+  // bytes nobody pasted, so an uncapped lane here would grow custody around the limit. A
+  // no-op without a limit; on a full workspace the check is SKIPPED as a typed error (the
+  // stamp is not written, so the same commit is re-considered once there is room).
+  if (
+    await storageCapExceeded(
+      row.workspace_id,
+      tree.files.reduce((n, f) => n + f.bytes.length, 0),
+    )
+  ) {
+    return { outcome: "error", message: "Storage limit reached for this workspace." };
   }
 
   // Import as a CANDIDATE (commit-only — `current` never moves from here). The vault rehashes;

--- a/web/app/lib/db/workspace-create.server.ts
+++ b/web/app/lib/db/workspace-create.server.ts
@@ -28,7 +28,9 @@ export type CreateWorkspaceResult =
   /** The composition switched self-serve creation off — the surface does not exist. */
   | { outcome: "off" }
   /** The per-person creation floor tripped — honest and disclosed, unlike `taken`. */
-  | { outcome: "rate-limited" };
+  | { outcome: "rate-limited" }
+  /** The per-person OWNED-workspaces cap tripped — the same honest, disclosed family. */
+  | { outcome: "owned-limit" };
 
 /**
  * The per-person creation floor: how many workspaces one account may mint in a rolling day.
@@ -38,6 +40,15 @@ export type CreateWorkspaceResult =
  * and slug-squatting is user-visible damage. Counted from the immutable audit trail.
  */
 const CREATE_FLOOR_PER_DAY = 10;
+
+/**
+ * The per-person OWNED-workspaces floor: how many workspaces one account may own at once.
+ * `limit("workspaces-owned")` (scope `forWorkspace(null)`, like `workspace-create`) overrides
+ * it — a present row wins even when lower; ABSENT means this floor, the same inversion as the
+ * daily floor and for the same reason. Counted from CURRENT owner seats (rides seat_user_idx),
+ * so leaving a workspace really does free a slot.
+ */
+const OWNED_FLOOR = 3;
 
 /**
  * Whether a name is a free, valid workspace address slug: shape-valid AND not reserved AND not
@@ -57,12 +68,13 @@ export async function workspaceNameAvailable(name: string): Promise<boolean> {
 
 /**
  * The policy pre-checks `createWorkspace` runs BEFORE its transaction — exported so the
- * /verify approval's create arm can run the SAME gate + floor before entering its own fence
- * (byte-identical policy, one spelling). `ok` clears every gate.
+ * /verify approval's create arm can run the SAME gate before entering its own fence
+ * (byte-identical policy, one spelling). `ok` clears every gate. The two COUNTED floors
+ * (daily + owned) deliberately do NOT live here: a pre-transaction count is a check-then-act
+ * race two concurrent submits step through, so both run inside `createWorkspaceTx`, under the
+ * per-person advisory lock.
  */
-export async function createWorkspacePrecheck(
-  actor: UserActor,
-): Promise<"ok" | "off" | "rate-limited"> {
+export async function createWorkspacePrecheck(): Promise<"ok" | "off"> {
   // Self-serve creation is a MULTI surface, whatever the entitlements say: single tenancy IS
   // its one boot-minted workspace, and a second row would break every LIMIT-1 resolution of
   // it. `/new` never mounts there, but a crafted POST reaches the shared ceremony — so the
@@ -75,44 +87,81 @@ export async function createWorkspacePrecheck(
   if (!entitlements.allows("workspace-create")) {
     return "off";
   }
-  // The rolling-day floor (see CREATE_FLOOR_PER_DAY) — counted from the audit trail, which is
-  // append-only and survives the person leaving/deleting workspaces to reset a row count.
-  const cap = entitlements.limit("workspace-create-per-day") ?? CREATE_FLOOR_PER_DAY;
-  const recent = await getDb().execute(
+  return "ok";
+}
+
+/**
+ * The two per-person creation floors, counted INSIDE the birth transaction under the advisory
+ * lock — so both doors (`/new` and the /verify create arm) meet the identical, race-free
+ * check through the shared tx body. The daily floor counts the append-only audit trail (it
+ * survives the person deleting workspaces to reset a row count); the owned floor counts
+ * CURRENT owner seats.
+ */
+async function createFloorsRefusalTx(
+  tx: Tx,
+  userId: string,
+): Promise<"rate-limited" | "owned-limit" | null> {
+  const entitlements = await composition.entitlements.forWorkspace(null);
+  const dailyCap = entitlements.limit("workspace-create-per-day") ?? CREATE_FLOOR_PER_DAY;
+  const recent = await tx.execute(
     sql`SELECT count(*)::int AS n FROM ${auditEvent}
         WHERE kind = 'workspace_created' AND outcome = 'ok'
-          AND actor_user_id = ${actor.userId}
+          AND actor_user_id = ${userId}
           AND created_at > now() - interval '24 hours'`,
   );
-  if (((recent.rows[0] as { n: number } | undefined)?.n ?? 0) >= cap) {
+  if (((recent.rows[0] as { n: number } | undefined)?.n ?? 0) >= dailyCap) {
     return "rate-limited";
   }
-  return "ok";
+  const ownedCap = entitlements.limit("workspaces-owned") ?? OWNED_FLOOR;
+  const owned = await tx.execute(
+    sql`SELECT count(*)::int AS n FROM ${seat}
+        WHERE user_id = ${userId} AND role = 'owner'`,
+  );
+  if (((owned.rows[0] as { n: number } | undefined)?.n ?? 0) >= ownedCap) {
+    return "owned-limit";
+  }
+  return null;
 }
 
 /** The drizzle transaction handle `createWorkspaceTx` runs under (any caller's tx). */
 type Tx = Parameters<Parameters<ReturnType<typeof getDb>["transaction"]>[0]>[0];
 
 /**
- * The one-transaction workspace BIRTH, inside the CALLER's transaction: the claimed workspace
- * row + the default `everyone` channel + the creator's owner seat + the baseline assignment +
- * the `workspace_created` audit row. A RESERVED name returns the typed `taken` before any
- * write; a name RACE surfaces as the unique violation on `workspace.name` — deliberately NOT
- * caught here (a failed statement aborts the enclosing transaction, so the CALLER maps it at
- * its own boundary, exactly as `createWorkspace` does below). `via` tags the audit row when
- * the birth runs inside another ceremony (the login approval's create arm).
+ * The one-transaction workspace BIRTH, inside the CALLER's transaction: the per-person
+ * advisory lock + the two counted floors (daily + owned — the TOCTOU-free spelling both
+ * doors share), then the claimed workspace row + the default `everyone` channel + the
+ * creator's owner seat + the baseline assignment + the `workspace_created` audit row. A
+ * RESERVED name returns the typed `taken` before any write; a name RACE surfaces as the
+ * unique violation on `workspace.name` — deliberately NOT caught here (a failed statement
+ * aborts the enclosing transaction, so the CALLER maps it at its own boundary, exactly as
+ * `createWorkspace` does below). `via` tags the audit row when the birth runs inside another
+ * ceremony (the login approval's create arm).
  */
 export async function createWorkspaceTx(
   tx: Tx,
   actor: { userId: string; display: string },
   input: { name: string; displayName: string },
   opts: { via?: "login" } = {},
-): Promise<{ outcome: "created"; workspaceId: string } | { outcome: "taken" }> {
+): Promise<
+  | { outcome: "created"; workspaceId: string }
+  | { outcome: "taken" }
+  | { outcome: "rate-limited" }
+  | { outcome: "owned-limit" }
+> {
   const { name, displayName } = input;
   // Self-defending door: callers validate for UX, but a malformed name must fail typed here,
   // not as a raw CHECK-constraint 500 from the insert below.
   if (!isWorkspaceNameShape(name)) {
     throw new Error("createWorkspaceTx: name is not a valid workspace address slug");
+  }
+  // The per-person lock FIRST, then the counted floors under it: two concurrent submits from
+  // one account serialize here, so the second reads the first's rows and the caps hold
+  // exactly (released with the transaction; the key hashes the acting user, so different
+  // accounts never queue behind each other).
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${actor.userId}))`);
+  const floored = await createFloorsRefusalTx(tx, actor.userId);
+  if (floored !== null) {
+    return { outcome: floored };
   }
   if (isReservedWorkspaceName(name, composition.reservedWorkspaceNames)) {
     return { outcome: "taken" };
@@ -172,7 +221,7 @@ export async function createWorkspace(
   if (!isWorkspaceNameShape(name)) {
     throw new Error("createWorkspace: name is not a valid workspace address slug");
   }
-  const precheck = await createWorkspacePrecheck(actor);
+  const precheck = await createWorkspacePrecheck();
   if (precheck !== "ok") {
     return { outcome: precheck };
   }
@@ -184,18 +233,23 @@ export async function createWorkspace(
     return { outcome: "taken" };
   }
   let workspaceId = "";
+  let refused: "taken" | "rate-limited" | "owned-limit" | null = null;
   try {
     await getDb().transaction(async (tx) => {
       const born = await createWorkspaceTx(tx, actor, { name, displayName });
-      // Unreachable in practice — the reserved read above already refused — but the tx body is
-      // shared, so honor its typed answer rather than assuming.
-      if (born.outcome === "taken") {
-        throw TAKEN_IN_TX;
+      if (born.outcome !== "created") {
+        // A refusal wrote nothing, but roll back anyway — the tx body is shared, and its
+        // typed answers must never half-commit whatever a future revision writes first.
+        refused = born.outcome;
+        throw REFUSED_IN_TX;
       }
       workspaceId = born.workspaceId;
     });
   } catch (error) {
-    if (error === TAKEN_IN_TX || isUniqueViolation(error)) {
+    if (error === REFUSED_IN_TX && refused !== null) {
+      return { outcome: refused };
+    }
+    if (isUniqueViolation(error)) {
       return { outcome: "taken" };
     }
     throw error;
@@ -203,5 +257,5 @@ export async function createWorkspace(
   return { outcome: "created", workspaceId, name };
 }
 
-/** Rollback sentinel for the shared tx body's `taken` inside `createWorkspace`'s own tx. */
-const TAKEN_IN_TX = Symbol("workspace-create-taken");
+/** Rollback sentinel for the shared tx body's typed refusals inside `createWorkspace`'s own tx. */
+const REFUSED_IN_TX = Symbol("workspace-create-refused");

--- a/web/app/lib/mail/invite-mail.server.ts
+++ b/web/app/lib/mail/invite-mail.server.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { serverEnv } from "@/env.server";
 import { kindEntry } from "@/lib/bundle-base";
 import { recordDevMail } from "@/lib/mail/dev-outbox.server";
-import { escapeHtml, mailDelivery, sendMail } from "@/lib/mail/transport.server";
+import { escapeHtml, mailDelivery, sendMail, stripMailControl } from "@/lib/mail/transport.server";
 
 /**
  * The invitation-mail seam. The mail is where the single-use INVITE LINK travels — worth one
@@ -53,29 +53,46 @@ function hintNounFor(kind: string): string {
   return kind === "channel" ? "channel" : kindEntry(kind).noun;
 }
 
+/** How long a user-entered display value may run in the notice (subject lines included). */
+const MAIL_FIELD_MAX = 60;
+
+/**
+ * A user-influenced value, made mail-safe at COMPOSE time: control characters (newlines
+ * included) stripped — our own strip, never a reliance on the mail library's header folding —
+ * and display fields cut to a readable length with an ellipsis, so a 10k-character workspace
+ * name cannot balloon a subject.
+ */
+function mailField(value: string, max = MAIL_FIELD_MAX): string {
+  const stripped = stripMailControl(value);
+  return stripped.length > max ? `${stripped.slice(0, max - 1)}…` : stripped;
+}
+
 /** The notice body — shared by the text mail and the dev recording (user-entered fields escaped
  * only in the HTML mirror). The hint leads: a hinted invitation names its first destination in
  * the subject and the opening line, because that is what the invitee was invited FOR. */
-function inviteLines({
-  workspaceDisplayName,
-  inviteUrl,
-  agentUrl,
-  invitedBy,
-  hint,
-}: InviteEmailInput): {
+function inviteLines(input: InviteEmailInput): {
   subject: string;
   text: string;
   html: string;
 } {
+  const { hint } = input;
+  // EVERY user-influenced value is made mail-safe HERE, at compose time — control characters
+  // (a `\r\n` in a workspace name must never reach the subject) stripped and display fields
+  // cut to length; the URLs are server-built but ride the same strip as a belt.
+  const workspaceDisplayName = mailField(input.workspaceDisplayName);
+  const invitedBy = mailField(input.invitedBy);
+  const hintName = hint === undefined ? "" : mailField(hint.name);
+  const inviteUrl = stripMailControl(input.inviteUrl);
+  const agentUrl = stripMailControl(input.agentUrl);
   // What a person calls the thing this invitation leads with. A hint's `kind` is NOT always a
   // bundle kind — an invitation may lead with a CHANNEL, which the bundle records know nothing
   // about and would silently read as the plain case. Named first, then the records answer.
   const hintNoun = hint === undefined ? "" : hintNounFor(hint.kind);
-  const hintLead = hint === undefined ? "" : ` — starting with the ${hint.name} ${hintNoun}`;
+  const hintLead = hint === undefined ? "" : ` — starting with the ${hintName} ${hintNoun}`;
   const subject = `You're invited to ${workspaceDisplayName} on Topos${hintLead}`;
   const intro =
     `${invitedBy} invited you to ${workspaceDisplayName} on Topos — shared skills for your AI agents.` +
-    (hint === undefined ? "" : ` First up: the ${hint.name} ${hintNoun}.`);
+    (hint === undefined ? "" : ` First up: the ${hintName} ${hintNoun}.`);
   const agentPaste = `Set up Topos for us: fetch ${agentUrl} and follow it. Our invite: ${inviteUrl}`;
   const text =
     `${intro}\n\n` +
@@ -89,7 +106,7 @@ function inviteLines({
     `<p>${escapeHtml(invitedBy)} invited you to <strong>${escapeHtml(workspaceDisplayName)}</strong> on Topos — shared skills for your AI agents.${
       hint === undefined
         ? ""
-        : ` First up: the <strong>${escapeHtml(hint.name)}</strong> ${escapeHtml(hintNoun)}.`
+        : ` First up: the <strong>${escapeHtml(hintName)}</strong> ${escapeHtml(hintNoun)}.`
     }</p>` +
     `<p><a href="${escapeHtml(inviteUrl)}">Accept in your browser</a></p>` +
     `<p>Or ask your agent to join — paste this to it:</p>` +

--- a/web/app/lib/mail/transport.server.ts
+++ b/web/app/lib/mail/transport.server.ts
@@ -99,7 +99,9 @@ export async function sendMail(message: MailMessage): Promise<void> {
     await transporter(settings).sendMail({
       from: settings.from,
       to: message.to,
-      subject: message.subject,
+      // The transport-level belt behind the compose-time strip: no subject leaves this module
+      // carrying a control character, whatever a caller composed.
+      subject: stripMailControl(message.subject),
       text: message.text,
       ...(message.html === undefined ? {} : { html: message.html }),
     });
@@ -120,4 +122,15 @@ export function escapeHtml(value: string): string {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
+}
+
+/**
+ * Strip control characters (newlines included) from a user-influenced string headed into a
+ * mail — OUR OWN strip, not a reliance on the mail library's internal header folding: a `\r\n`
+ * smuggled through a workspace name must never reach a subject line, where it would open a
+ * header-injection seam. Runs of control characters collapse to one space so words stay apart.
+ */
+export function stripMailControl(value: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: the control range IS the strip.
+  return value.replace(/[\x00-\x1f\x7f]+/g, " ");
 }

--- a/web/app/lib/plane/contract/schema.d.ts
+++ b/web/app/lib/plane/contract/schema.d.ts
@@ -548,6 +548,12 @@ export interface components {
             invited: string[];
             /** @description Whether invitation mail was sent server-side (`true` only when the server can send mail). */
             mailed: boolean;
+            /**
+             * @description Addresses NOT re-sent this time — each was invited repeatedly and sits on a server-side
+             *     cooldown; `reason` is the server's own wording (display text). Omitted when empty and
+             *     defaulted on the way in, so the field is additive across releases in both directions.
+             */
+            skipped?: components["schemas"]["SkippedInvitation"][];
         };
         /**
          * @description `POST /v1/workspaces/{ws}/invitations` body — invitation as an INVITATION-ROW write: each email
@@ -1143,6 +1149,16 @@ export interface components {
              *     word the line uses and whether the command that shares it carries `-g`.
              */
             machine: boolean;
+        };
+        /**
+         * @description One address an invitation submission SKIPPED rather than re-sent
+         *     ([`InvitationData::skipped`]) — not an error: the rest of the submission landed.
+         */
+        SkippedInvitation: {
+            /** @description The folded address that was skipped. */
+            email: string;
+            /** @description Why, in the server's words (display text, e.g. `already invited recently`). */
+            reason: string;
         };
         /**
          * @description The closed set of terminal outcomes the agent branches on. SCREAMING_SNAKE on the wire.

--- a/web/app/lib/plane/lifecycle-copy.ts
+++ b/web/app/lib/plane/lifecycle-copy.ts
@@ -39,6 +39,8 @@ export function unarchiveDeniedCopy(outcome: string): string {
       return "This skill isn't archived.";
     case "unknown_skill":
       return "This skill no longer exists.";
+    case "bundle_limit":
+      return "This workspace is at its bundle limit.";
     default:
       return "The server declined this unarchive.";
   }

--- a/web/app/lib/plane/storage.server.ts
+++ b/web/app/lib/plane/storage.server.ts
@@ -24,6 +24,28 @@ export async function storageStats(): Promise<Map<string, number>> {
   return parseStorageStats(body);
 }
 
+/**
+ * ONE workspace's stored bytes, for the publish-ingest quota check — the same vault stat,
+ * filtered app-side (the vault knows numbers, never identity; a workspace with no custody yet
+ * simply has no entry, which is 0). FAIL-OPEN BY DESIGN: a stat failure returns `null` and the
+ * caller allows — the ingest shares the same backend and will fail on a real outage — but the
+ * failure is logged, because a quota that silently stopped being enforced is a fact an
+ * operator needs.
+ */
+export async function workspaceStoredBytes(workspaceId: string): Promise<number | null> {
+  try {
+    const stats = await storageStats();
+    return stats.get(workspaceId) ?? 0;
+  } catch (error) {
+    // The deliberate fail-open trace (message only — storageStats errors are fixed,
+    // credential-free strings).
+    console.error(
+      `storage quota check skipped (stat read failed): ${error instanceof Error ? error.message : "unknown"}`,
+    );
+    return null;
+  }
+}
+
 /** Strict shape parse: `{workspaces: [{workspace_id, stored_bytes}]}`, nothing looser. */
 function parseStorageStats(body: unknown): Map<string, number> {
   if (typeof body !== "object" || body === null || !("workspaces" in body)) {

--- a/web/app/lib/plane/storage.server.ts
+++ b/web/app/lib/plane/storage.server.ts
@@ -25,17 +25,30 @@ export async function storageStats(): Promise<Map<string, number>> {
 }
 
 /**
+ * How long one stat read answers every quota check before the vault is asked again. The
+ * admission is bounded-overshoot by design (storage-quota.server.ts), so a briefly stale
+ * total only widens that bound by what lands within the window — and without it, a
+ * multi-tenant store would pay the vault's whole-store accounting scan on EVERY capped
+ * ingest (twice on a genesis: the route door and the shared genesis door both ask). A
+ * workspace-scoped vault read would retire both the cache and the app-side filter.
+ */
+const STORED_BYTES_TTL_MS = 10_000;
+let statCache: { at: number; stats: Map<string, number> } | null = null;
+
+/**
  * ONE workspace's stored bytes, for the publish-ingest quota check — the same vault stat,
  * filtered app-side (the vault knows numbers, never identity; a workspace with no custody yet
- * simply has no entry, which is 0). FAIL-OPEN BY DESIGN: a stat failure returns `null` and the
- * caller allows — the ingest shares the same backend and will fail on a real outage — but the
- * failure is logged, because a quota that silently stopped being enforced is a fact an
- * operator needs.
+ * simply has no entry, which is 0) and cached for a few seconds (above). FAIL-OPEN BY DESIGN:
+ * a stat failure returns `null` and the caller allows — the ingest shares the same backend and
+ * will fail on a real outage — but the failure is logged, because a quota that silently
+ * stopped being enforced is a fact an operator needs. Failures are never cached.
  */
 export async function workspaceStoredBytes(workspaceId: string): Promise<number | null> {
   try {
-    const stats = await storageStats();
-    return stats.get(workspaceId) ?? 0;
+    if (statCache === null || Date.now() - statCache.at > STORED_BYTES_TTL_MS) {
+      statCache = { at: Date.now(), stats: await storageStats() };
+    }
+    return statCache.stats.get(workspaceId) ?? 0;
   } catch (error) {
     // The deliberate fail-open trace (message only — storageStats errors are fixed,
     // credential-free strings).

--- a/web/app/lib/workspace-create-copy.ts
+++ b/web/app/lib/workspace-create-copy.ts
@@ -8,6 +8,7 @@
 export const ADDRESS_TAKEN = "That address is taken — try another.";
 export const CREATE_RATE_LIMITED =
   "You’ve created several workspaces recently — wait a while before creating another.";
+export const WORKSPACE_LIMIT = "You have reached the workspace limit for your account.";
 export const NAME_REQUIRED = "Enter a name for your workspace (1–100 characters).";
 export const SLUG_SHAPE =
   "The address uses lowercase letters, numbers, and hyphens (up to 100 characters).";

--- a/web/app/routes/api.v1.channel-protection.ts
+++ b/web/app/routes/api.v1.channel-protection.ts
@@ -1,15 +1,17 @@
 import type { ActionFunctionArgs } from "react-router";
 import { laneGate } from "@/lib/api/compat.server";
-import { rowOpResponse } from "@/lib/api/row-envelopes.server";
+import { deniedCodeEnvelope, rowOpResponse } from "@/lib/api/row-envelopes.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
 import { requireSessionActor } from "@/lib/auth/guards.server";
 import { laneProtectChannel } from "@/lib/db/queries.lane.server";
 
 /**
  * `PUT /api/v1/workspaces/{ws}/channels/{ch}/protection` — set a channel's mode (`curated` |
- * `open`). `{ch}` is the channel NAME. A JSON body `{ level }`; malformed body → 400 before
- * auth, invalid level → 400 unconditionally. An unknown channel is the uniform 404. Tightening
- * to `curated` takes reviewer+; loosening to `open` takes owner.
+ * `open`). `{ch}` is the channel NAME. A JSON body `{ level }`; the credential resolves
+ * BEFORE the body (the lane-wide order — a non-member meets only the uniform 404, and body
+ * validation 400s only an authenticated member). An unknown channel is the uniform 404.
+ * Tightening to `curated` takes reviewer+ AND the reviews entitlement
+ * (`REVIEWS_NOT_AVAILABLE`); loosening to `open` takes owner and is never entitlement-gated.
  */
 const BODY_CAP = 64 * 1024;
 
@@ -26,6 +28,7 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (request.method !== "PUT") {
     return uniformNotFound();
   }
+  const actor = await requireSessionActor(request, params.ws ?? "");
   const body = await readCappedBody(request, BODY_CAP, "protection body");
   if (body instanceof Response) {
     return body;
@@ -43,8 +46,14 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (level !== "open" && level !== "curated") {
     return badRequest("a channel protection level must be `curated` or `open`");
   }
-  const actor = await requireSessionActor(request, params.ws ?? "");
   const status = await laneProtectChannel(actor, params.channel ?? "", level);
+  if (status === "reviews_unavailable") {
+    return deniedCodeEnvelope(
+      "protect",
+      "REVIEWS_NOT_AVAILABLE",
+      "Review protection is not available on this workspace.",
+    );
+  }
   return rowOpResponse("protect", status, { set: "set" }, PROTECT_DENIED);
 }
 

--- a/web/app/routes/api.v1.invitations.ts
+++ b/web/app/routes/api.v1.invitations.ts
@@ -17,8 +17,11 @@ import { agentDocUrl, inviteUrl, workspaceAddress } from "@/lib/ws-url.server";
  *
  * INVITING REQUIRES ARMED MAIL: the mailbox is where the tokened link travels, so on an
  * unarmed deployment the op refuses TYPED (`MAIL_NOT_CONFIGURED`) — an invitation nobody could
- * receive would mislead the inviter. ORDERING mirrors the door's posture: a malformed body is
- * a 400 BEFORE the credential resolve; a malformed email is a 400 AFTER auth.
+ * receive would mislead the inviter. ORDERING is the lane-wide auth-before-body: the
+ * credential resolves first (an unauthenticated caller buffers nothing and learns nothing —
+ * every answer is the uniform 404), and body validation 400s only an authenticated member.
+ * The invitation CAPS (per-submission, member limit, the rolling-day cap, the per-address
+ * cooldown) are enforced in the DAL, inside the write transaction.
  */
 const BODY_CAP = 64 * 1024;
 
@@ -30,6 +33,7 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (request.method !== "POST") {
     return uniformNotFound();
   }
+  const actor = await requireSessionActor(request, params.ws ?? "");
   const raw = await readCappedBody(request, BODY_CAP, "invitation body");
   if (raw instanceof Response) {
     return raw;
@@ -57,7 +61,6 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
     return badRequest("an invitation carries at most one first destination — skill OR channel");
   }
 
-  const actor = await requireSessionActor(request, params.ws ?? "");
   if (!inviteMailDelivery().canSend) {
     return deniedCodeEnvelope("invite", "MAIL_NOT_CONFIGURED");
   }
@@ -94,7 +97,17 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
     return okDataEnvelope("invite", {
       address,
       invited: outcome.minted.map((m) => m.email),
-      mailed: true,
+      // Honest: an all-skipped submission (every address on its cooldown) sent nothing.
+      mailed: outcome.minted.length > 0,
+      // Addresses on a cooldown (invited repeatedly) — not re-sent, reported per address.
+      ...(outcome.skipped.length === 0
+        ? {}
+        : {
+            skipped: outcome.skipped.map((email) => ({
+              email,
+              reason: "already invited recently",
+            })),
+          }),
     });
   }
   if (outcome.outcome === "owner_role_required") {
@@ -105,6 +118,27 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   }
   if (outcome.outcome === "unknown_channel") {
     return deniedCodeEnvelope("invite", "UNKNOWN_CHANNEL");
+  }
+  if (outcome.outcome === "too_many_addresses") {
+    return deniedCodeEnvelope(
+      "invite",
+      "TOO_MANY_ADDRESSES",
+      "Too many addresses at once. Send up to 10 invitations at a time.",
+    );
+  }
+  if (outcome.outcome === "invite_limit") {
+    return deniedCodeEnvelope(
+      "invite",
+      "INVITE_LIMIT_REACHED",
+      "Invitation limit reached for today. Try again tomorrow.",
+    );
+  }
+  if (outcome.outcome === "member_limit") {
+    return deniedCodeEnvelope(
+      "invite",
+      "MEMBER_LIMIT_REACHED",
+      "This workspace is at its member limit.",
+    );
   }
   return internalError();
 }

--- a/web/app/routes/api.v1.notices-ack.ts
+++ b/web/app/routes/api.v1.notices-ack.ts
@@ -8,7 +8,8 @@ import { laneAckNotices } from "@/lib/db/queries.lane.server";
 /**
  * `POST /api/v1/workspaces/{ws}/notices/ack` — mark the caller's own notices read by id (the
  * delivery feed carries them unacked; an interactive session acks what it narrated). A JSON
- * body `{ ids }`; a malformed body is a 400 BEFORE the credential resolve. Idempotent (only
+ * body `{ ids }`; the credential resolves BEFORE the body (the lane-wide order — an
+ * unauthenticated caller buffers nothing and meets only the uniform 404). Idempotent (only
  * the person's own unacked rows move); the 200 envelope carries `{ status: "acked" }`.
  */
 const BODY_CAP = 64 * 1024;
@@ -21,6 +22,7 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (request.method !== "POST") {
     return uniformNotFound();
   }
+  const actor = await requireSessionActor(request, params.ws ?? "");
   const body = await readCappedBody(request, BODY_CAP, "notices ack body");
   if (body instanceof Response) {
     return body;
@@ -40,7 +42,6 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   ) {
     return badRequest("malformed notices ack body");
   }
-  const actor = await requireSessionActor(request, params.ws ?? "");
   const status = await laneAckNotices(actor, ids as string[]);
   return rowOpResponse("notices", status, { acked: "acked" }, {});
 }

--- a/web/app/routes/api.v1.propose.ts
+++ b/web/app/routes/api.v1.propose.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import type { ActionFunctionArgs } from "react-router";
 import {
   parseBundleKind,
@@ -7,7 +6,11 @@ import {
   receiptNow,
 } from "@/lib/api/candidate.server";
 import { laneGate } from "@/lib/api/compat.server";
-import { publishFlow, storageQuotaRefusal } from "@/lib/api/publish-flow.server";
+import {
+  candidateStoredBytes,
+  publishFlow,
+  storageQuotaRefusal,
+} from "@/lib/api/publish-flow.server";
 import { buildReceipt, deniedEnvelope, envelopeResponse } from "@/lib/api/receipts.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
 import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
@@ -82,8 +85,15 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   }
 
   // The per-workspace storage quota — after auth and the replay check (a replayed op re-serves
-  // its stored envelope), before any vault ingest. A no-op without a `storage-bytes` limit.
-  const quota = await storageQuotaRefusal(actor, head.opId, "publish", Buffer.byteLength(raw));
+  // its stored envelope), before any vault ingest; charged at the candidate's DECODED bytes
+  // (what custody could at most grow by), never the wire's base64/JSON framing. A no-op
+  // without a `storage-bytes` limit.
+  const quota = await storageQuotaRefusal(
+    actor,
+    head.opId,
+    "publish",
+    candidateStoredBytes(candidate),
+  );
   if (quota !== null) {
     return quota;
   }

--- a/web/app/routes/api.v1.propose.ts
+++ b/web/app/routes/api.v1.propose.ts
@@ -6,12 +6,9 @@ import {
   receiptNow,
 } from "@/lib/api/candidate.server";
 import { laneGate } from "@/lib/api/compat.server";
-import {
-  candidateStoredBytes,
-  publishFlow,
-  storageQuotaRefusal,
-} from "@/lib/api/publish-flow.server";
+import { publishFlow } from "@/lib/api/publish-flow.server";
 import { buildReceipt, deniedEnvelope, envelopeResponse } from "@/lib/api/receipts.server";
+import { candidateStoredBytes, storageQuotaRefusal } from "@/lib/api/storage-quota.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
 import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
 import { findReceipt } from "@/lib/db/queries.custody.server";

--- a/web/app/routes/api.v1.propose.ts
+++ b/web/app/routes/api.v1.propose.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import type { ActionFunctionArgs } from "react-router";
 import {
   parseBundleKind,
@@ -6,10 +7,10 @@ import {
   receiptNow,
 } from "@/lib/api/candidate.server";
 import { laneGate } from "@/lib/api/compat.server";
-import { publishFlow } from "@/lib/api/publish-flow.server";
+import { publishFlow, storageQuotaRefusal } from "@/lib/api/publish-flow.server";
 import { buildReceipt, deniedEnvelope, envelopeResponse } from "@/lib/api/receipts.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
-import { requireSessionActor } from "@/lib/auth/guards.server";
+import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
 import { findReceipt } from "@/lib/db/queries.custody.server";
 
 /**
@@ -27,6 +28,12 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   if (request.method !== "POST") {
     return uniformNotFound();
   }
+  // AUTH BEFORE THE BODY: the credential resolves first (it is workspace-scoped, so the live
+  // session names the one workspace it may act in), so an unauthenticated caller is refused
+  // before this tier buffers anything against the large propose cap. The body's workspace is
+  // then HELD against the session's below — a mismatch is the same uniform 404 the old
+  // workspace-keyed resolve answered.
+  const actor = await requireSessionActorPreBody(request);
   const raw = await readCappedBody(request, BODY_CAP, "propose body");
   if (raw instanceof Response) {
     return raw;
@@ -53,8 +60,10 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   if (typeof kind === "string") {
     return badRequest(kind);
   }
+  if (head.workspaceId !== actor.workspaceId) {
+    return uniformNotFound();
+  }
 
-  const actor = await requireSessionActor(request, head.workspaceId);
   const replay = await findReceipt(actor, head.opId, raw);
   if (replay.kind === "replay") {
     return envelopeResponse(replay.outcome);
@@ -70,6 +79,13 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
       createdAt: receiptNow(),
     });
     return envelopeResponse(deniedEnvelope("publish", "OP_ID_REUSED", undefined, receipt));
+  }
+
+  // The per-workspace storage quota — after auth and the replay check (a replayed op re-serves
+  // its stored envelope), before any vault ingest. A no-op without a `storage-bytes` limit.
+  const quota = await storageQuotaRefusal(actor, head.opId, "publish", Buffer.byteLength(raw));
+  if (quota !== null) {
+    return quota;
   }
 
   return publishFlow({

--- a/web/app/routes/api.v1.publish.ts
+++ b/web/app/routes/api.v1.publish.ts
@@ -6,12 +6,9 @@ import {
   receiptNow,
 } from "@/lib/api/candidate.server";
 import { laneGate } from "@/lib/api/compat.server";
-import {
-  candidateStoredBytes,
-  publishFlow,
-  storageQuotaRefusal,
-} from "@/lib/api/publish-flow.server";
+import { publishFlow } from "@/lib/api/publish-flow.server";
 import { buildReceipt, deniedEnvelope, envelopeResponse } from "@/lib/api/receipts.server";
+import { candidateStoredBytes, storageQuotaRefusal } from "@/lib/api/storage-quota.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
 import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
 import { findReceipt } from "@/lib/db/queries.custody.server";

--- a/web/app/routes/api.v1.publish.ts
+++ b/web/app/routes/api.v1.publish.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import type { ActionFunctionArgs } from "react-router";
 import {
   parseBundleKind,
@@ -6,10 +7,10 @@ import {
   receiptNow,
 } from "@/lib/api/candidate.server";
 import { laneGate } from "@/lib/api/compat.server";
-import { publishFlow } from "@/lib/api/publish-flow.server";
+import { publishFlow, storageQuotaRefusal } from "@/lib/api/publish-flow.server";
 import { buildReceipt, deniedEnvelope, envelopeResponse } from "@/lib/api/receipts.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
-import { requireSessionActor } from "@/lib/auth/guards.server";
+import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
 import { findReceipt } from "@/lib/db/queries.custody.server";
 
 /**
@@ -29,6 +30,12 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   if (request.method !== "POST") {
     return uniformNotFound();
   }
+  // AUTH BEFORE THE BODY: the credential resolves first (it is workspace-scoped, so the live
+  // session names the one workspace it may act in), so an unauthenticated caller is refused
+  // before this tier buffers anything against the large publish cap. The body's workspace is
+  // then HELD against the session's below — a mismatch is the same uniform 404 the old
+  // workspace-keyed resolve answered.
+  const actor = await requireSessionActorPreBody(request);
   const raw = await readCappedBody(request, BODY_CAP, "publish body");
   if (raw instanceof Response) {
     return raw;
@@ -55,8 +62,10 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   if (typeof kind === "string") {
     return badRequest(kind);
   }
+  if (head.workspaceId !== actor.workspaceId) {
+    return uniformNotFound();
+  }
 
-  const actor = await requireSessionActor(request, head.workspaceId);
   const replay = await findReceipt(actor, head.opId, raw);
   if (replay.kind === "replay") {
     return envelopeResponse(replay.outcome);
@@ -72,6 +81,13 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
       createdAt: receiptNow(),
     });
     return envelopeResponse(deniedEnvelope("publish", "OP_ID_REUSED", undefined, receipt));
+  }
+
+  // The per-workspace storage quota — after auth and the replay check (a replayed op re-serves
+  // its stored envelope), before any vault ingest. A no-op without a `storage-bytes` limit.
+  const quota = await storageQuotaRefusal(actor, head.opId, "publish", Buffer.byteLength(raw));
+  if (quota !== null) {
+    return quota;
   }
 
   return publishFlow({

--- a/web/app/routes/api.v1.publish.ts
+++ b/web/app/routes/api.v1.publish.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import type { ActionFunctionArgs } from "react-router";
 import {
   parseBundleKind,
@@ -7,7 +6,11 @@ import {
   receiptNow,
 } from "@/lib/api/candidate.server";
 import { laneGate } from "@/lib/api/compat.server";
-import { publishFlow, storageQuotaRefusal } from "@/lib/api/publish-flow.server";
+import {
+  candidateStoredBytes,
+  publishFlow,
+  storageQuotaRefusal,
+} from "@/lib/api/publish-flow.server";
 import { buildReceipt, deniedEnvelope, envelopeResponse } from "@/lib/api/receipts.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
 import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
@@ -84,8 +87,15 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   }
 
   // The per-workspace storage quota — after auth and the replay check (a replayed op re-serves
-  // its stored envelope), before any vault ingest. A no-op without a `storage-bytes` limit.
-  const quota = await storageQuotaRefusal(actor, head.opId, "publish", Buffer.byteLength(raw));
+  // its stored envelope), before any vault ingest; charged at the candidate's DECODED bytes
+  // (what custody could at most grow by), never the wire's base64/JSON framing. A no-op
+  // without a `storage-bytes` limit.
+  const quota = await storageQuotaRefusal(
+    actor,
+    head.opId,
+    "publish",
+    candidateStoredBytes(candidate),
+  );
   if (quota !== null) {
     return quota;
   }

--- a/web/app/routes/api.v1.report.ts
+++ b/web/app/routes/api.v1.report.ts
@@ -115,6 +115,9 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (request.method !== "PUT") {
     return uniformNotFound();
   }
+  // AUTH BEFORE THE BODY — the lane-wide order: only an authenticated session can make this
+  // tier buffer against the report cap (which is sized generously; see above).
+  const actor = await requireSessionActor(request, params.ws ?? "");
   const body = await readCappedBody(request, BODY_CAP, "report body");
   if (body instanceof Response) {
     return body;
@@ -151,7 +154,6 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
     }
     applied.push({ skillId: row.skill_id, versionId: row.version_id, harnesses });
   }
-  const actor = await requireSessionActor(request, params.ws ?? "");
   const outcome = await reportApplied(actor, applied);
   if (outcome === "session_ended") {
     // The session ended between the guard and the write (a revocation won the race) — the

--- a/web/app/routes/api.v1.reverts.ts
+++ b/web/app/routes/api.v1.reverts.ts
@@ -9,7 +9,7 @@ import {
   okPointerEnvelope,
 } from "@/lib/api/receipts.server";
 import { badRequest, internalError, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
-import { requireSessionActor } from "@/lib/auth/guards.server";
+import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
 import { auditInTx } from "@/lib/db/identity.server";
 import {
   findReceipt,
@@ -17,6 +17,7 @@ import {
   insertReceiptInTx,
   movePointerWithKindPrecondition,
   publishTargetOf,
+  versionOutsideHistoryWindow,
 } from "@/lib/db/queries.custody.server";
 import { revertPointer } from "@/lib/plane/custody.server";
 
@@ -36,6 +37,9 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   if (request.method !== "POST") {
     return uniformNotFound();
   }
+  // AUTH BEFORE THE BODY — the lane-wide order: the credential resolves first (workspace-scoped,
+  // so the session names its one workspace), and the body's workspace is held against it below.
+  const actor = await requireSessionActorPreBody(request);
   const raw = await readCappedBody(request, BODY_CAP, "revert body");
   if (raw instanceof Response) {
     return raw;
@@ -63,8 +67,10 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   if (author.length === 0) {
     return badRequest("malformed revert author");
   }
+  if (head.workspaceId !== actor.workspaceId) {
+    return uniformNotFound();
+  }
 
-  const actor = await requireSessionActor(request, head.workspaceId);
   const replay = await findReceipt(actor, head.opId, raw);
   if (replay.kind === "replay") {
     return envelopeResponse(replay.outcome);
@@ -113,6 +119,19 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
       buildReceipt({ ...receiptBase, outcome: "DENIED" }),
     );
     await inFinalTx((tx) => insertReceiptInTx(tx, actor, head.opId, raw, envelope));
+    return envelopeResponse(envelope);
+  }
+  // The history window (`history-days`, a no-op without a limit): a target older than the
+  // window refuses typed. NOT persisted as a receipt — the refusal reflects the workspace's
+  // standing window, and the same op under a wider window must re-evaluate, not replay.
+  if (await versionOutsideHistoryWindow(actor, target.bundleId, good)) {
+    const envelope = deniedEnvelope(
+      "revert",
+      "OUTSIDE_HISTORY_WINDOW",
+      target.name,
+      buildReceipt({ ...receiptBase, outcome: "DENIED" }),
+      { message: "That version is outside this workspace's history window." },
+    );
     return envelopeResponse(envelope);
   }
 

--- a/web/app/routes/api.v1.reviews.ts
+++ b/web/app/routes/api.v1.reviews.ts
@@ -10,7 +10,7 @@ import {
   okReceiptEnvelope,
 } from "@/lib/api/receipts.server";
 import { badRequest, internalError, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
-import { requireSessionActor } from "@/lib/auth/guards.server";
+import { requireSessionActorPreBody } from "@/lib/auth/guards.server";
 import {
   findReceipt,
   inFinalTx,
@@ -41,6 +41,9 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   if (request.method !== "POST") {
     return uniformNotFound();
   }
+  // AUTH BEFORE THE BODY — the lane-wide order: the credential resolves first (workspace-scoped,
+  // so the session names its one workspace), and the body's workspace is held against it below.
+  const actor = await requireSessionActorPreBody(request);
   const raw = await readCappedBody(request, BODY_CAP, "review body");
   if (raw instanceof Response) {
     return raw;
@@ -72,7 +75,9 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
     return badRequest("a reject carries its reason back to the author");
   }
 
-  const actor = await requireSessionActor(request, head.workspaceId);
+  if (head.workspaceId !== actor.workspaceId) {
+    return uniformNotFound();
+  }
   const replay = await findReceipt(actor, head.opId, raw);
   if (replay.kind === "replay") {
     return envelopeResponse(replay.outcome);

--- a/web/app/routes/api.v1.skill-protection.ts
+++ b/web/app/routes/api.v1.skill-protection.ts
@@ -1,17 +1,18 @@
 import type { ActionFunctionArgs } from "react-router";
 import { laneGate } from "@/lib/api/compat.server";
-import { rowOpResponse } from "@/lib/api/row-envelopes.server";
+import { deniedCodeEnvelope, rowOpResponse } from "@/lib/api/row-envelopes.server";
 import { badRequest, readCappedBody, uniformNotFound } from "@/lib/api/wire.server";
 import { requireSessionActor } from "@/lib/auth/guards.server";
 import { laneProtectBundle } from "@/lib/db/queries.lane.server";
 
 /**
  * `PUT /api/v1/workspaces/{ws}/skills/{skill}/protection` — set a bundle's protection level
- * (`reviewed` | `open`). `{skill}` is the immutable id. A JSON body `{ level }`. A malformed
- * body AND an invalid LEVEL are both a 400 BEFORE the credential resolve, so a bad level is a
- * 400 unconditionally — never a membership signal a non-member could read off. Tightening to
- * `reviewed` takes reviewer+ (`REVIEWER_ROLE_REQUIRED`); loosening to `open` takes owner
- * (`OWNER_ROLE_REQUIRED`).
+ * (`reviewed` | `open`). `{skill}` is the immutable id. A JSON body `{ level }`. The
+ * credential resolves BEFORE the body (the lane-wide order): a non-member meets only the
+ * uniform 404 whatever the body says, and body validation 400s only an authenticated member.
+ * Tightening to `reviewed` takes reviewer+ (`REVIEWER_ROLE_REQUIRED`) AND the reviews
+ * entitlement (`REVIEWS_NOT_AVAILABLE` with its way back); loosening to `open` takes owner
+ * (`OWNER_ROLE_REQUIRED`) and is never entitlement-gated.
  */
 const BODY_CAP = 64 * 1024;
 
@@ -28,6 +29,7 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (request.method !== "PUT") {
     return uniformNotFound();
   }
+  const actor = await requireSessionActor(request, params.ws ?? "");
   const body = await readCappedBody(request, BODY_CAP, "protection body");
   if (body instanceof Response) {
     return body;
@@ -45,8 +47,14 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
   if (level !== "open" && level !== "reviewed") {
     return badRequest("a skill protection level must be `reviewed` or `open`");
   }
-  const actor = await requireSessionActor(request, params.ws ?? "");
   const status = await laneProtectBundle(actor, params.skill ?? "", level);
+  if (status === "reviews_unavailable") {
+    return deniedCodeEnvelope(
+      "protect",
+      "REVIEWS_NOT_AVAILABLE",
+      "Review protection is not available on this workspace.",
+    );
+  }
   return rowOpResponse("protect", status, { set: "set" }, PROTECT_DENIED);
 }
 

--- a/web/app/routes/invite-redeem.tsx
+++ b/web/app/routes/invite-redeem.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import {
   type ActionFunctionArgs,
+  data,
   Form,
   Link,
   type LoaderFunctionArgs,
@@ -174,6 +175,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 const CREATE_FAILED = "Couldn't finish accepting the invitation. Try the link again.";
+const MEMBER_LIMIT = "This workspace is at its member limit.";
 
 export async function action({ request, params }: ActionFunctionArgs) {
   requireBelt(request);
@@ -229,6 +231,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
       { userId: actor.userId, display: actor.display },
       { mailboxProven: false },
     );
+    if (result.outcome === "workspace_full") {
+      // The member limit — the invitation stays pending, so the same link works once the
+      // workspace has room; a bare redirect would re-render the accept card with no answer.
+      return { kind: "error" as const, message: MEMBER_LIMIT };
+    }
     if (result.outcome !== "accepted") {
       // The loader recomputes the honest state for every refusal (gone → the constant page,
       // wrong account → the switch page, unverified → the round-trip prompt).
@@ -317,6 +324,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
       { userId, display },
       { mailboxProven: true },
     );
+    if (accepted.outcome === "workspace_full") {
+      // The member limit — the fresh account stands (its session cookies still land; it
+      // admits nothing) and the invitation stays pending for when the workspace has room.
+      return data({ kind: "error" as const, message: MEMBER_LIMIT }, { headers: cookieHeaders });
+    }
     if (accepted.outcome !== "accepted") {
       // A race consumed the token between the resolve and the accept: the account stands (a
       // harmless orphan that can sign in and admits nothing); the page answers constantly.

--- a/web/app/routes/skill-current.tsx
+++ b/web/app/routes/skill-current.tsx
@@ -218,8 +218,19 @@ async function inviteToSkillIntent(
     });
     return { intent: "invite" as const, status: "owner_required" as const, submittedEmail: raw };
   }
+  // The invitation caps (invite-caps.server.ts) — typed, honest refusals, the address kept.
+  if (outcome.outcome === "invite_limit") {
+    return { intent: "invite" as const, status: "invite_limit" as const, submittedEmail: raw };
+  }
+  if (outcome.outcome === "member_limit") {
+    return { intent: "invite" as const, status: "member_limit" as const, submittedEmail: raw };
+  }
   if (outcome.outcome !== "invited") {
     return { intent: "invite" as const, status: "error" as const, submittedEmail: raw };
+  }
+  if (outcome.minted.length === 0) {
+    // The one address was on its cooldown — nothing minted, nothing mailed.
+    return { intent: "invite" as const, status: "skipped" as const, invited: folded };
   }
 
   let emailSent = true;

--- a/web/app/routes/skill-history.tsx
+++ b/web/app/routes/skill-history.tsx
@@ -226,8 +226,15 @@ async function revertAction(
   const short = good.slice(0, 12);
 
   // The history window (`history-days`, a no-op without a limit): a target older than the
-  // window refuses in the same words the lane's revert door uses.
+  // window refuses in the same words the lane's revert door uses. The attempt still lands its
+  // admin_event row — every ceremony attempt does, denials included.
   if (await versionOutsideHistoryWindow(actor, row.skillId, good)) {
+    await recordAdminEvent(actor, {
+      kind: "revert",
+      subject: row.skillId,
+      detail: short,
+      outcome: "denied",
+    });
     return data<RevertActionData>({
       status: "denied",
       reason: "That version is outside this workspace's history window.",

--- a/web/app/routes/skill-history.tsx
+++ b/web/app/routes/skill-history.tsx
@@ -14,7 +14,12 @@ import {
 import { baseOf, bundleNameOf, bundleNoun, bundlePath, useBundleBase } from "@/lib/bundle-base";
 import { requireCanonicalBase } from "@/lib/bundle-base.server";
 import { recordAdminEvent } from "@/lib/db/audit.server";
-import { movePointerWithKindPrecondition } from "@/lib/db/queries.custody.server";
+import {
+  historyWindowDays,
+  movePointerWithKindPrecondition,
+  versionCreatedAtMap,
+  versionOutsideHistoryWindow,
+} from "@/lib/db/queries.custody.server";
 import { purgeVersion } from "@/lib/db/queries.lifecycle.server";
 import { skillIndexRow } from "@/lib/db/queries.server";
 import { resolveSkillName } from "@/lib/db/resolve.server";
@@ -114,12 +119,32 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       row.versionId,
       { depth: DEPTH, from: resume },
     );
+    // The history window (`history-days`, a no-op without a limit): rows older than the cutoff
+    // are ANNOTATED server-side — nothing is deleted, and the revert action below refuses them
+    // (a wider window restores access whole). Computed from the custody mirror's own recorded
+    // creation times.
+    const windowDays = await historyWindowDays(ws);
+    const locked = new Set<string>();
+    if (windowDays !== null && page.steps.length > 0) {
+      const createdAt = await versionCreatedAtMap(
+        actor,
+        row.skillId,
+        page.steps.map((s) => s.versionId),
+      );
+      const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+      for (const step of page.steps) {
+        const at = createdAt.get(step.versionId);
+        if (at !== undefined && at.getTime() < cutoff) {
+          locked.add(step.versionId);
+        }
+      }
+    }
     history = {
       published: true,
       head: row.versionId,
       canRevert: actor.role !== "member",
       expectedGeneration: String(row.generation),
-      steps: page.steps,
+      steps: page.steps.map((s) => ({ ...s, locked: locked.has(s.versionId) })),
       cursor: page.cursor,
       truncated: page.truncated,
     };
@@ -199,6 +224,15 @@ async function revertAction(
     return data<RevertActionData>({ status: "error" });
   }
   const short = good.slice(0, 12);
+
+  // The history window (`history-days`, a no-op without a limit): a target older than the
+  // window refuses in the same words the lane's revert door uses.
+  if (await versionOutsideHistoryWindow(actor, row.skillId, good)) {
+    return data<RevertActionData>({
+      status: "denied",
+      reason: "That version is outside this workspace's history window.",
+    });
+  }
 
   const carryForward = () =>
     revertPointer(ws, row.skillId, {

--- a/web/app/routes/skill-import.tsx
+++ b/web/app/routes/skill-import.tsx
@@ -272,6 +272,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
         `);
       },
     });
+    if (landed.kind === "refused") {
+      // A typed refusal (the bundle cap — a skill has no content gate) surfaces in its own
+      // words rather than folding into the retry line: retrying cannot change the answer.
+      return data<PublishError>(
+        { form: "publish", error: landed.refusal.message },
+        { status: 400 },
+      );
+    }
     if (landed.kind !== "ok") {
       return data<PublishError>(
         { form: "publish", error: "The publish did not land — try again." },

--- a/web/app/routes/skill-settings.tsx
+++ b/web/app/routes/skill-settings.tsx
@@ -261,6 +261,12 @@ async function protectionIntent(request: Request, ws: string, skill: string, for
   if (outcome.outcome === "set") {
     return data<SettingsFormError>({ form: "protection", message: "" });
   }
+  if (outcome.outcome === "reviews_unavailable") {
+    return data<SettingsFormError>({
+      form: "protection",
+      message: "Review protection is not available on this workspace.",
+    });
+  }
   return data<SettingsFormError>({ form: "protection", message: "This skill no longer exists." });
 }
 

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -262,6 +262,14 @@ export async function action({ request }: ActionFunctionArgs) {
         ? await createRefused(userCode, actor, CREATE_RATE_LIMITED, choiceCreate, 429)
         : await createRefused(userCode, actor, WORKSPACE_LIMIT, choiceCreate, 403);
     }
+    if (approved.outcome === "workspace-full") {
+      // An invitation-bound approval met the member limit: the flow AND the invitation stay
+      // pending (approving again works once there is room), and the card says the real reason.
+      return data(
+        { kind: "refused" as const, error: "This workspace is at its member limit." },
+        { status: 409 },
+      );
+    }
     if (loopback !== null && device !== null && approved.flowChallenge === device) {
       // The state-bound localhost hand-off — a pure accelerator that wakes the waiting CLI;
       // its poll (the one completion mechanism) then runs the exchange that mints. Fired

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -43,6 +43,7 @@ import {
   CREATE_RATE_LIMITED,
   NAME_REQUIRED,
   SLUG_SHAPE,
+  WORKSPACE_LIMIT,
 } from "@/lib/workspace-create-copy";
 import {
   isWorkspaceNameShape,
@@ -223,11 +224,12 @@ export async function action({ request }: ActionFunctionArgs) {
       throw data(null, { status: 400 });
     }
     if (choice !== null && choice.kind === "create") {
-      // The SAME policy pre-checks /new runs (tenancy + entitlement gate + the per-person
-      // floor), then the field validation — byte-identical refusal strings, then the fence.
-      // Existence FIRST: on single tenancy (or creation switched off) the option does not
-      // exist, so a crafted POST answers the house 404 whatever its fields say.
-      const precheck = await createWorkspacePrecheck(actor);
+      // The SAME surface pre-check /new runs (tenancy + the entitlement gate), then the field
+      // validation — byte-identical refusal strings, then the fence (which owns the counted
+      // per-person floors, under the same advisory lock as /new's transaction). Existence
+      // FIRST: on single tenancy (or creation switched off) the option does not exist, so a
+      // crafted POST answers the house 404 whatever its fields say.
+      const precheck = await createWorkspacePrecheck();
       if (precheck === "off") {
         notFound();
       }
@@ -236,9 +238,6 @@ export async function action({ request }: ActionFunctionArgs) {
       }
       if (!isWorkspaceNameShape(choice.slug)) {
         return await createRefused(userCode, actor, SLUG_SHAPE, choice, 400);
-      }
-      if (precheck === "rate-limited") {
-        return await createRefused(userCode, actor, CREATE_RATE_LIMITED, choice, 429);
       }
     }
     const approved = await approveLoginFlow(
@@ -254,6 +253,14 @@ export async function action({ request }: ActionFunctionArgs) {
       // and surface the typed error on the create form for the retry.
       const choiceCreate = choice as Extract<LoginApproveChoice, { kind: "create" }>;
       return await createRefused(userCode, actor, ADDRESS_TAKEN, choiceCreate, 400);
+    }
+    if (approved.outcome === "rate-limited" || approved.outcome === "owned-limit") {
+      // The create arm's counted floors, refused inside the fence — same re-resolve, the
+      // matching honest string on the form.
+      const choiceCreate = choice as Extract<LoginApproveChoice, { kind: "create" }>;
+      return approved.outcome === "rate-limited"
+        ? await createRefused(userCode, actor, CREATE_RATE_LIMITED, choiceCreate, 429)
+        : await createRefused(userCode, actor, WORKSPACE_LIMIT, choiceCreate, 403);
     }
     if (loopback !== null && device !== null && approved.flowChallenge === device) {
       // The state-bound localhost hand-off — a pure accelerator that wakes the waiting CLI;

--- a/web/app/routes/workspace-members.tsx
+++ b/web/app/routes/workspace-members.tsx
@@ -149,6 +149,16 @@ async function inviteIntent(request: Request, ws: string, formData: FormData) {
     });
     return { intent: "invite" as const, status: "owner_required" as const, submittedEmails: raw };
   }
+  // The invitation caps (invite-caps.server.ts) — typed, honest refusals, the addresses kept.
+  if (outcome.outcome === "too_many_addresses") {
+    return { intent: "invite" as const, status: "too_many" as const, submittedEmails: raw };
+  }
+  if (outcome.outcome === "invite_limit") {
+    return { intent: "invite" as const, status: "invite_limit" as const, submittedEmails: raw };
+  }
+  if (outcome.outcome === "member_limit") {
+    return { intent: "invite" as const, status: "member_limit" as const, submittedEmails: raw };
+  }
   if (outcome.outcome !== "invited") {
     return { intent: "invite" as const, status: "error" as const, submittedEmails: raw };
   }
@@ -172,7 +182,14 @@ async function inviteIntent(request: Request, ws: string, formData: FormData) {
   } catch {
     emailSent = false;
   }
-  return { intent: "invite" as const, status: "invited" as const, invited: emails, emailSent };
+  return {
+    intent: "invite" as const,
+    status: "invited" as const,
+    // What actually went out: cooldown-skipped addresses minted nothing and got no mail.
+    invited: outcome.minted.map((m) => m.email),
+    skipped: outcome.skipped,
+    emailSent,
+  };
 }
 
 /**

--- a/web/app/routes/workspace-new.tsx
+++ b/web/app/routes/workspace-new.tsx
@@ -25,6 +25,7 @@ import {
   CREATE_RATE_LIMITED,
   NAME_REQUIRED,
   SLUG_SHAPE,
+  WORKSPACE_LIMIT,
 } from "@/lib/workspace-create-copy";
 import {
   isWorkspaceNameShape,
@@ -114,6 +115,10 @@ export async function action({ request }: ActionFunctionArgs) {
   if (result.outcome === "rate-limited") {
     // Honest and disclosed, unlike `taken` — a floor is not a secret.
     return data<ActionData>({ error: CREATE_RATE_LIMITED, displayName, slug }, { status: 429 });
+  }
+  if (result.outcome === "owned-limit") {
+    // The same honest family: the standing owned-workspaces cap, disclosed outright.
+    return data<ActionData>({ error: WORKSPACE_LIMIT, displayName, slug }, { status: 403 });
   }
   throw redirect(next ?? wsPathServer(result.name));
 }

--- a/web/app/routes/workspace-settings.tsx
+++ b/web/app/routes/workspace-settings.tsx
@@ -160,14 +160,18 @@ async function knobIntent<Outcome extends string>(
   return { status: "denied", error: args.deniedError(outcome) };
 }
 
-/** The review-required gate — the workspace's protection DEFAULT, as one switch. */
+/** The review-required gate — the workspace's protection DEFAULT, as one switch. Enabling it
+ * is entitlement-gated (`allows("reviews")`); switching it back off never is. */
 async function reviewRequiredIntent(request: Request, ws: string, formData: FormData) {
   const value = String(formData.get("review_required") ?? "") === "true";
   const result = await knobIntent(request, ws, {
     auditKind: "policy_review_default",
     detail: value ? "reviewed" : "open",
     run: (owner) => setReviewDefault(owner, value),
-    deniedError: () => SERVER_ERROR,
+    deniedError: (outcome) =>
+      outcome === "reviews_unavailable"
+        ? "Review protection is not available on this workspace."
+        : SERVER_ERROR,
   });
   return { intent: "set-review-required" as const, ...result };
 }

--- a/web/app/topos-web/entitlements.ts
+++ b/web/app/topos-web/entitlements.ts
@@ -8,6 +8,12 @@
  * A downstream provider is also in-process — an interface implementation reading its own
  * tables, never an RPC.
  *
+ * PROVIDER CONTRACT: `forWorkspace` may be called while the caller holds an OPEN DATABASE
+ * TRANSACTION (the cap checks run inside their write transactions, advisory locks held), so a
+ * provider must answer WITHOUT borrowing the web app's connection pool — its own client, or an
+ * in-process cache — or concurrent writes could occupy every pooled connection while each
+ * waits on a provider query that needs one. The OSS default touches no I/O at all.
+ *
  * THE KEYS THE PRODUCT CONSULTS — each named once here, with its scope, its default when the
  * provider answers nothing (`null` / `true`), and where it is enforced. Refusal copy at every
  * enforcement point is neutral ("limit for this workspace") — this seam is the only coupling a

--- a/web/app/topos-web/entitlements.ts
+++ b/web/app/topos-web/entitlements.ts
@@ -7,6 +7,36 @@
  * The OSS default is allow-all, in-process: every switch on, every limit absent (unlimited).
  * A downstream provider is also in-process — an interface implementation reading its own
  * tables, never an RPC.
+ *
+ * THE KEYS THE PRODUCT CONSULTS — each named once here, with its scope, its default when the
+ * provider answers nothing (`null` / `true`), and where it is enforced. Refusal copy at every
+ * enforcement point is neutral ("limit for this workspace") — this seam is the only coupling a
+ * downstream mapping has.
+ *
+ * Switches (`allows`; absent ⇒ ON):
+ *  - `workspace-create` — scope `forWorkspace(null)`: whether self-serve workspace creation
+ *    exists at all (`/new` and the /verify create arm).
+ *  - `reviews` — per workspace: whether review protection may be ENABLED (the skill/channel
+ *    protection writes and the workspace review default). Already-protected bundles keep
+ *    working — the gate is on enabling, never a retroactive strip.
+ *
+ * Limits (`limit`; absent ⇒ unlimited, EXCEPT the floored keys below):
+ *  - `members` — per workspace: seats + pending invitations, consulted at invite creation
+ *    (both DAL doors) and at seat mint (the accept ceremonies; the workspace-birth owner
+ *    seat is exempt).
+ *  - `bundles` — per workspace: active catalog rows, consulted when a NEW bundle identity is
+ *    created (every genesis door). New versions of existing bundles are never blocked.
+ *  - `storage-bytes` — per workspace: stored custody bytes, consulted at publish/propose
+ *    ingest (stat read fails OPEN — the ingest shares the backend and fails on real outage).
+ *  - `history-days` — per workspace: how far back reverts may reach; older rows stay listed
+ *    (annotated, never deleted — a wider window restores access).
+ *  - `invites-per-day` — per account: FLOORED — an absent row means the built-in floor
+ *    (10/day while the account is under 48h old, else 50/day), and a present row wins even
+ *    when lower. The same inversion as `workspace-create-per-day`.
+ *  - `workspaces-owned` — scope `forWorkspace(null)`: FLOORED at 3 — count of currently
+ *    owned workspaces, consulted at workspace creation; a present row wins even when lower.
+ *  - `workspace-create-per-day` — scope `forWorkspace(null)`: FLOORED (see
+ *    `workspace-create.server.ts`); a present row wins even when lower.
  */
 export interface Entitlements {
   /** Feature switch — absent keys default ON in the OSS build. */

--- a/web/drizzle/0016_invite-cooldown-index.sql
+++ b/web/drizzle/0016_invite-cooldown-index.sql
@@ -1,0 +1,5 @@
+-- The per-address invite-cooldown read: a repeatedly invited address is skipped for a while,
+-- counted server-wide off the append-only audit trail (kind = 'invitation_created', subject =
+-- the invited address). Additive; rides the same partial-index discipline as the actor indexes.
+
+CREATE INDEX "audit_invite_subject" ON "web"."audit_event" USING btree ("subject","created_at") WHERE kind = 'invitation_created';

--- a/web/drizzle/meta/0016_snapshot.json
+++ b/web/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,3440 @@
+{
+  "id": "e608c880-678f-432c-8726-9847cf029007",
+  "prevId": "789f83fe-1247-4d77-b67a-0622b94a6d2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "web.account": {
+      "name": "account",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.session": {
+      "name": "session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_idx": {
+          "name": "session_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.user": {
+      "name": "user",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_email_lowercase": {
+          "name": "user_email_lowercase",
+          "value": "\"web\".\"user\".\"email\" = lower(\"web\".\"user\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.verification": {
+      "name": "verification",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expires_idx": {
+          "name": "verification_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.approval": {
+      "name": "approval",
+      "schema": "web",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer": {
+          "name": "reviewer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_reviewer_idx": {
+          "name": "approval_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_proposal_id_proposal_id_fk": {
+          "name": "approval_proposal_id_proposal_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "proposal",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_reviewer_user_id_fk": {
+          "name": "approval_reviewer_user_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "reviewer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "approval_proposal_id_reviewer_pk": {
+          "name": "approval_proposal_id_reviewer_pk",
+          "columns": [
+            "proposal_id",
+            "reviewer"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.assignment": {
+      "name": "assignment",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self": {
+          "name": "self",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_person_bundle_once": {
+          "name": "assignment_person_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_bundle_once": {
+          "name": "assignment_everyone_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_person_channel_once": {
+          "name": "assignment_person_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_channel_once": {
+          "name": "assignment_everyone_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_ws_user_idx": {
+          "name": "assignment_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_bundle_idx": {
+          "name": "assignment_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_channel_idx": {
+          "name": "assignment_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_workspace_id_workspace_id_fk": {
+          "name": "assignment_workspace_id_workspace_id_fk",
+          "tableFrom": "assignment",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_seat_fk": {
+          "name": "assignment_seat_fk",
+          "tableFrom": "assignment",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_bundle_fk": {
+          "name": "assignment_bundle_fk",
+          "tableFrom": "assignment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_channel_fk": {
+          "name": "assignment_channel_fk",
+          "tableFrom": "assignment",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assignment_target_check": {
+          "name": "assignment_target_check",
+          "value": "(\"web\".\"assignment\".\"bundle_id\" is null) <> (\"web\".\"assignment\".\"channel_id\" is null)"
+        },
+        "assignment_self_check": {
+          "name": "assignment_self_check",
+          "value": "\"web\".\"assignment\".\"user_id\" is not null or not \"web\".\"assignment\".\"self\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.audit_event": {
+      "name": "audit_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "audit_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_session_id": {
+          "name": "actor_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display": {
+          "name": "actor_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_ws_time": {
+          "name": "audit_ws_time",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_user": {
+          "name": "audit_actor_user",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_session": {
+          "name": "audit_actor_session",
+          "columns": [
+            {
+              "expression": "actor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_session_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_invite_subject": {
+          "name": "audit_invite_subject",
+          "columns": [
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "kind = 'invitation_created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_event_actor_user_id_user_id_fk": {
+          "name": "audit_event_actor_user_id_user_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_event_actor_session_id_cli_session_id_fk": {
+          "name": "audit_event_actor_session_id_cli_session_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle": {
+      "name": "bundle",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "protection": {
+          "name": "protection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_name": {
+          "name": "base_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundle_workspace_id_workspace_id_fk": {
+          "name": "bundle_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_created_by_user_id_fk": {
+          "name": "bundle_created_by_user_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_workspace_id_name_unique": {
+          "name": "bundle_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "bundle_id_workspace_id_unique": {
+          "name": "bundle_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bundle_name_check": {
+          "name": "bundle_name_check",
+          "value": "\"web\".\"bundle\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"bundle\".\"name\") <= 200"
+        },
+        "bundle_kind_check": {
+          "name": "bundle_kind_check",
+          "value": "\"web\".\"bundle\".\"kind\" in ('skill', 'mcp')"
+        },
+        "bundle_status_check": {
+          "name": "bundle_status_check",
+          "value": "\"web\".\"bundle\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "bundle_protection_check": {
+          "name": "bundle_protection_check",
+          "value": "\"web\".\"bundle\".\"protection\" is null or \"web\".\"bundle\".\"protection\" in ('open', 'reviewed')"
+        },
+        "bundle_deleted_check": {
+          "name": "bundle_deleted_check",
+          "value": "(\"web\".\"bundle\".\"status\" = 'deleted') = (\"web\".\"bundle\".\"deleted_at\" is not null)"
+        },
+        "bundle_archived_check": {
+          "name": "bundle_archived_check",
+          "value": "\"web\".\"bundle\".\"status\" <> 'archived' or \"web\".\"bundle\".\"archived_at\" is not null"
+        },
+        "bundle_base_name_check": {
+          "name": "bundle_base_name_check",
+          "value": "\"web\".\"bundle\".\"base_name\" is null or \"web\".\"bundle\".\"status\" <> 'active'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.bundle_identity": {
+      "name": "bundle_identity",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bundle_identity_bundle_idx": {
+          "name": "bundle_identity_bundle_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_identity_bundle_fk": {
+          "name": "bundle_identity_bundle_fk",
+          "tableFrom": "bundle_identity",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_identity_workspace_id_kind_identity_pk": {
+          "name": "bundle_identity_workspace_id_kind_identity_pk",
+          "columns": [
+            "workspace_id",
+            "kind",
+            "identity"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_name_hint": {
+      "name": "bundle_name_hint",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renamed_by": {
+          "name": "renamed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_name_hint_bundle_idx": {
+          "name": "bundle_name_hint_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_name_hint_workspace_id_workspace_id_fk": {
+          "name": "bundle_name_hint_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_bundle_id_bundle_id_fk": {
+          "name": "bundle_name_hint_bundle_id_bundle_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_renamed_by_user_id_fk": {
+          "name": "bundle_name_hint_renamed_by_user_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "renamed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_name_hint_workspace_id_old_name_pk": {
+          "name": "bundle_name_hint_workspace_id_old_name_pk",
+          "columns": [
+            "workspace_id",
+            "old_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_upstream": {
+      "name": "bundle_upstream",
+      "schema": "web",
+      "columns": {
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_commit": {
+          "name": "last_seen_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bundle_upstream_ws_idx": {
+          "name": "bundle_upstream_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_upstream_bundle_fk": {
+          "name": "bundle_upstream_bundle_fk",
+          "tableFrom": "bundle_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bundle_upstream_repo_check": {
+          "name": "bundle_upstream_repo_check",
+          "value": "\"web\".\"bundle_upstream\".\"repo\" ~ '^[^/]+/[^/]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel": {
+      "name": "channel",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_one_default": {
+          "name": "channel_one_default",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_workspace_id_workspace_id_fk": {
+          "name": "channel_workspace_id_workspace_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_created_by_user_id_fk": {
+          "name": "channel_created_by_user_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "channel_workspace_id_name_unique": {
+          "name": "channel_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "channel_id_workspace_id_unique": {
+          "name": "channel_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "channel_mode_check": {
+          "name": "channel_mode_check",
+          "value": "\"web\".\"channel\".\"mode\" in ('open', 'curated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel_bundle": {
+      "name": "channel_bundle",
+      "schema": "web",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bundle_bundle_idx": {
+          "name": "channel_bundle_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bundle_added_by_user_id_fk": {
+          "name": "channel_bundle_added_by_user_id_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_channel_fk": {
+          "name": "channel_bundle_channel_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_bundle_fk": {
+          "name": "channel_bundle_bundle_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_bundle_channel_id_bundle_id_pk": {
+          "name": "channel_bundle_channel_id_bundle_id_pk",
+          "columns": [
+            "channel_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.cli_session": {
+      "name": "cli_session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_sha256": {
+          "name": "credential_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cli_session_workspace_idx": {
+          "name": "cli_session_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_session_user_idx": {
+          "name": "cli_session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_session_seat_fk": {
+          "name": "cli_session_seat_fk",
+          "tableFrom": "cli_session",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_session_credential_sha256_unique": {
+          "name": "cli_session_credential_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_session_status_check": {
+          "name": "cli_session_status_check",
+          "value": "\"web\".\"cli_session\".\"status\" in ('pending', 'active')"
+        },
+        "cli_session_credential_sha256_check": {
+          "name": "cli_session_credential_sha256_check",
+          "value": "octet_length(\"web\".\"cli_session\".\"credential_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.decline": {
+      "name": "decline",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "decline_ws_user_idx": {
+          "name": "decline_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decline_seat_fk": {
+          "name": "decline_seat_fk",
+          "tableFrom": "decline",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "decline_bundle_fk": {
+          "name": "decline_bundle_fk",
+          "tableFrom": "decline",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decline_user_id_bundle_id_unique": {
+          "name": "decline_user_id_bundle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.invitation": {
+      "name": "invitation",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_sha256": {
+          "name": "token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_bundle_id": {
+          "name": "hint_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_channel_id": {
+          "name": "hint_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_pending_once": {
+          "name": "invitation_pending_once",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_workspace_id_workspace_id_fk": {
+          "name": "invitation_workspace_id_workspace_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitation_accepted_by_user_id_fk": {
+          "name": "invitation_accepted_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_sha256_unique": {
+          "name": "invitation_token_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_email_check": {
+          "name": "invitation_email_check",
+          "value": "\"web\".\"invitation\".\"email\" = lower(\"web\".\"invitation\".\"email\")"
+        },
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"web\".\"invitation\".\"role\" in ('owner', 'reviewer', 'member')"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "\"web\".\"invitation\".\"status\" in ('pending', 'accepted', 'revoked', 'declined')"
+        },
+        "invitation_token_sha256_check": {
+          "name": "invitation_token_sha256_check",
+          "value": "\"web\".\"invitation\".\"token_sha256\" is null or octet_length(\"web\".\"invitation\".\"token_sha256\") = 32"
+        },
+        "invitation_hint_one_check": {
+          "name": "invitation_hint_one_check",
+          "value": "\"web\".\"invitation\".\"hint_bundle_id\" is null or \"web\".\"invitation\".\"hint_channel_id\" is null"
+        },
+        "invitation_accepted_check": {
+          "name": "invitation_accepted_check",
+          "value": "(\"web\".\"invitation\".\"status\" = 'accepted') = (\"web\".\"invitation\".\"accepted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.login_flow": {
+      "name": "login_flow",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_code_sha256": {
+          "name": "flow_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_name": {
+          "name": "requested_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preselect_workspace": {
+          "name": "preselect_workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_workspace_id": {
+          "name": "approved_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token_sha256": {
+          "name": "invite_token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "login_flow_live_code": {
+          "name": "login_flow_live_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "login_flow_expires_idx": {
+          "name": "login_flow_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "login_flow_approved_by_user_id_fk": {
+          "name": "login_flow_approved_by_user_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "login_flow_session_id_cli_session_id_fk": {
+          "name": "login_flow_session_id_cli_session_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "login_flow_flow_code_sha256_unique": {
+          "name": "login_flow_flow_code_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flow_code_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "login_flow_flow_code_sha256_check": {
+          "name": "login_flow_flow_code_sha256_check",
+          "value": "octet_length(\"web\".\"login_flow\".\"flow_code_sha256\") = 32"
+        },
+        "login_flow_invite_token_sha256_check": {
+          "name": "login_flow_invite_token_sha256_check",
+          "value": "\"web\".\"login_flow\".\"invite_token_sha256\" is null or octet_length(\"web\".\"login_flow\".\"invite_token_sha256\") = 32"
+        },
+        "login_flow_status_check": {
+          "name": "login_flow_status_check",
+          "value": "\"web\".\"login_flow\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "login_flow_binding_check": {
+          "name": "login_flow_binding_check",
+          "value": "\"web\".\"login_flow\".\"binding\" in ('device', 'loopback')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mail_event": {
+      "name": "mail_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_event_time_idx": {
+          "name": "mail_event_time_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mail_event_kind_check": {
+          "name": "mail_event_kind_check",
+          "value": "\"web\".\"mail_event\".\"kind\" in ('magic-link', 'invite', 'auth-verify', 'auth-reset')"
+        },
+        "mail_event_outcome_check": {
+          "name": "mail_event_outcome_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" in ('ok', 'failed')"
+        },
+        "mail_event_code_check": {
+          "name": "mail_event_code_check",
+          "value": "\"web\".\"mail_event\".\"code\" is null or \"web\".\"mail_event\".\"code\" in ('unconfigured', 'send_failed')"
+        },
+        "mail_event_code_on_failure_check": {
+          "name": "mail_event_code_on_failure_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" = 'failed' or \"web\".\"mail_event\".\"code\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_probe": {
+      "name": "mcp_probe",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probed_at": {
+          "name": "probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_probe_bundle_fk": {
+          "name": "mcp_probe_bundle_fk",
+          "tableFrom": "mcp_probe",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_probe_bundle_id_version_id_pk": {
+          "name": "mcp_probe_bundle_id_version_id_pk",
+          "columns": [
+            "bundle_id",
+            "version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_probe_outcome_check": {
+          "name": "mcp_probe_outcome_check",
+          "value": "\"web\".\"mcp_probe\".\"outcome\" IN ('responding', 'sign_in_required', 'not_verifiable', 'not_responding')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.notice": {
+      "name": "notice",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notice_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notice_inbox": {
+          "name": "notice_inbox",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "acked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notice_ws_idx": {
+          "name": "notice_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notice_user_id_user_id_fk": {
+          "name": "notice_user_id_user_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notice_workspace_id_workspace_id_fk": {
+          "name": "notice_workspace_id_workspace_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.op_receipt": {
+      "name": "op_receipt",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_id": {
+          "name": "op_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_sha256": {
+          "name": "request_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "op_receipt_retention_idx": {
+          "name": "op_receipt_retention_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "op_receipt_session_id_cli_session_id_fk": {
+          "name": "op_receipt_session_id_cli_session_id_fk",
+          "tableFrom": "op_receipt",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "op_receipt_workspace_id_session_id_op_id_pk": {
+          "name": "op_receipt_workspace_id_session_id_op_id_pk",
+          "columns": [
+            "workspace_id",
+            "session_id",
+            "op_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "op_receipt_request_sha256_check": {
+          "name": "op_receipt_request_sha256_check",
+          "value": "octet_length(\"web\".\"op_receipt\".\"request_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal": {
+      "name": "proposal",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_version_id": {
+          "name": "candidate_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason": {
+          "name": "resolved_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_open": {
+          "name": "proposal_open",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_one_open_per_candidate": {
+          "name": "proposal_one_open_per_candidate",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_proposed_by_user_id_fk": {
+          "name": "proposal_proposed_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_resolved_by_user_id_fk": {
+          "name": "proposal_resolved_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_bundle_fk": {
+          "name": "proposal_bundle_fk",
+          "tableFrom": "proposal",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_status_check": {
+          "name": "proposal_status_check",
+          "value": "\"web\".\"proposal\".\"status\" in ('open', 'approved', 'rejected', 'withdrawn')"
+        },
+        "proposal_resolved_check": {
+          "name": "proposal_resolved_check",
+          "value": "(\"web\".\"proposal\".\"status\" = 'open') = (\"web\".\"proposal\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal_comment": {
+      "name": "proposal_comment",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display": {
+          "name": "author_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_comment_thread_idx": {
+          "name": "proposal_comment_thread_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_comment_author_user_id_user_id_fk": {
+          "name": "proposal_comment_author_user_id_user_id_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_comment_bundle_fk": {
+          "name": "proposal_comment_bundle_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_comment_body_check": {
+          "name": "proposal_comment_body_check",
+          "value": "char_length(\"web\".\"proposal_comment\".\"body\") between 1 and 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.seat": {
+      "name": "seat",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seat_user_idx": {
+          "name": "seat_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seat_workspace_id_workspace_id_fk": {
+          "name": "seat_workspace_id_workspace_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_user_id_user_id_fk": {
+          "name": "seat_user_id_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_invited_by_user_id_fk": {
+          "name": "seat_invited_by_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "seat_workspace_id_user_id_pk": {
+          "name": "seat_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "seat_role_check": {
+          "name": "seat_role_check",
+          "value": "\"web\".\"seat\".\"role\" in ('owner', 'reviewer', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.session_bundle_state": {
+      "name": "session_bundle_state",
+      "schema": "web",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_version_id": {
+          "name": "applied_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_state": {
+          "name": "harness_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_bundle_state_bundle_idx": {
+          "name": "session_bundle_state_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_bundle_state_session_id_cli_session_id_fk": {
+          "name": "session_bundle_state_session_id_cli_session_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_bundle_state_bundle_id_bundle_id_fk": {
+          "name": "session_bundle_state_bundle_id_bundle_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_bundle_state_session_id_bundle_id_pk": {
+          "name": "session_bundle_state_session_id_bundle_id_pk",
+          "columns": [
+            "session_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.version_upstream": {
+      "name": "version_upstream",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "version_upstream_bundle_fk": {
+          "name": "version_upstream_bundle_fk",
+          "tableFrom": "version_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "version_upstream_bundle_id_version_id_pk": {
+          "name": "version_upstream_bundle_id_version_id_pk",
+          "columns": [
+            "bundle_id",
+            "version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.workspace": {
+      "name": "workspace",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_code_sha256": {
+          "name": "claim_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protection_default": {
+          "name": "protection_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "staleness_window_ms": {
+          "name": "staleness_window_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800000
+        },
+        "registration": {
+          "name": "registration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_only'"
+        },
+        "session_approval": {
+          "name": "session_approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "session_max_age_ms": {
+          "name": "session_max_age_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_name_unique": {
+          "name": "workspace_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_name_check": {
+          "name": "workspace_name_check",
+          "value": "\"web\".\"workspace\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"workspace\".\"name\") <= 100"
+        },
+        "workspace_claim_code_sha256_check": {
+          "name": "workspace_claim_code_sha256_check",
+          "value": "\"web\".\"workspace\".\"claim_code_sha256\" is null or octet_length(\"web\".\"workspace\".\"claim_code_sha256\") = 32"
+        },
+        "workspace_protection_default_check": {
+          "name": "workspace_protection_default_check",
+          "value": "\"web\".\"workspace\".\"protection_default\" in ('open', 'reviewed')"
+        },
+        "workspace_registration_check": {
+          "name": "workspace_registration_check",
+          "value": "\"web\".\"workspace\".\"registration\" in ('invite_only', 'open')"
+        },
+        "workspace_session_approval_check": {
+          "name": "workspace_session_approval_check",
+          "value": "\"web\".\"workspace\".\"session_approval\" in ('off', 'on')"
+        },
+        "workspace_session_max_age_check": {
+          "name": "workspace_session_max_age_check",
+          "value": "\"web\".\"workspace\".\"session_max_age_ms\" is null or \"web\".\"workspace\".\"session_max_age_ms\" > 0"
+        },
+        "workspace_claim_state_check": {
+          "name": "workspace_claim_state_check",
+          "value": "(\"web\".\"workspace\".\"claimed_at\" is null) <> (\"web\".\"workspace\".\"claim_code_sha256\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "web": "web"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1786575925888,
       "tag": "0015_mcp-probe",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1786900889478,
+      "tag": "0016_invite-cooldown-index",
+      "breakpoints": true
     }
   ]
 }

--- a/web/scripts/check-boundary.mjs
+++ b/web/scripts/check-boundary.mjs
@@ -345,7 +345,7 @@ const SESSIONLESS_ROUTES = new Set([
 // membership-or-404 resolution the face modules call on their signed-in arm (their anonymous
 // arm resolves the session itself, teaser-or-404, so the require* wrappers cannot front them).
 const GUARD_CALL =
-  /\b(?:require(?:SessionActor|Session|MemberInScope|Member|OwnerInScope|WorkspaceOwner|Reviewer)|memberInScope)\s*\(/;
+  /\b(?:require(?:SessionActorPreBody|SessionActor|Session|MemberInScope|Member|OwnerInScope|WorkspaceOwner|Reviewer)|memberInScope)\s*\(/;
 const READS_DATA = /export\s+(?:async\s+)?(?:function|const)\s+(?:loader|action)\b/;
 for (const { rel, text, base } of files) {
   if (!rel.startsWith(ROUTES_DIR)) {

--- a/web/tests/unit/api-v1-routes.test.ts
+++ b/web/tests/unit/api-v1-routes.test.ts
@@ -628,11 +628,11 @@ const SKILL_LEVEL_MESSAGE = "a skill protection level must be `reviewed` or `ope
 
 const BAD_REQUEST_CASES: BadRequestCase[] = [
   {
-    name: "notices/ack — a non-JSON body is a 400 (before auth)",
+    name: "notices/ack — a non-JSON body is a 400 (authenticated; auth precedes the body)",
     h: noticesAction,
     method: "POST",
     path: "/notices/ack",
-    cred: "unknown",
+    cred: "mem",
     rawBody: "{ not json",
     message: "malformed JSON body",
   },
@@ -653,20 +653,6 @@ const BAD_REQUEST_CASES: BadRequestCase[] = [
     message: SKILL_LEVEL_MESSAGE,
   },
   {
-    ...SKILL_PROT,
-    name: "skill protection — a wrong level is a 400 EVEN with a bad credential (level check precedes auth; a bad level is never a membership signal)",
-    cred: "unknown",
-    body: { level: "bogus" },
-    message: SKILL_LEVEL_MESSAGE,
-  },
-  {
-    ...SKILL_PROT,
-    name: "skill protection — a MALFORMED body with a bad credential is still 400 (body precedes auth)",
-    cred: "unknown",
-    rawBody: "{ not json",
-    message: "malformed JSON body",
-  },
-  {
     name: "channel protection — a wrong level is a 400 with the channel-specific message",
     h: channelProtAction,
     method: "PUT",
@@ -677,20 +663,20 @@ const BAD_REQUEST_CASES: BadRequestCase[] = [
     message: "a channel protection level must be `curated` or `open`",
   },
   {
-    name: "invitations — a body missing `emails` is a 400 (before auth)",
+    name: "invitations — a body missing `emails` is a 400 (authenticated; auth precedes the body)",
     h: invitationsAction,
     method: "POST",
     path: "/invitations",
-    cred: "unknown",
+    cred: "mem",
     body: { channels: [] },
     message: "malformed invitation body: emails",
   },
   {
-    name: "report — a malformed entry is a 400 naming the field (before auth)",
+    name: "report — a malformed entry is a 400 naming the field (authenticated)",
     h: reportAction,
     method: "PUT",
     path: "/report",
-    cred: "unknown",
+    cred: "mem",
     body: { schema_version: 1, applied: [{ skill_id: "s_alpha", version_id: "short" }] },
     message: "malformed report entry: version_id must be 64-char lowercase hex",
   },
@@ -727,6 +713,54 @@ describe("validation 400s", () => {
     );
     expect(token.status).toBe(400);
     expect(await token.json()).toEqual(badRequestBody("malformed login token body"));
+  });
+});
+
+// ── (d′) auth precedes the body — the lane-wide order ────────────────────────────────────────
+
+describe("auth precedes the body (an unknown credential is the uniform 404, whatever the body)", () => {
+  const UNKNOWN_CRED_CASES: LaneCase[] = [
+    {
+      ...SKILL_PROT,
+      name: "skill protection — a wrong level",
+      cred: "unknown",
+      body: { level: "bogus" },
+    },
+    {
+      ...SKILL_PROT,
+      name: "skill protection — a malformed body",
+      cred: "unknown",
+      rawBody: "{ not json",
+    },
+    {
+      name: "invitations — a missing field",
+      h: invitationsAction,
+      method: "POST",
+      path: "/invitations",
+      cred: "unknown",
+      body: { channels: [] },
+    },
+    {
+      name: "report — a malformed entry",
+      h: reportAction,
+      method: "PUT",
+      path: "/report",
+      cred: "unknown",
+      body: { schema_version: 1, applied: [{ skill_id: "s_alpha", version_id: "short" }] },
+    },
+    {
+      name: "notices/ack — a non-JSON body",
+      h: noticesAction,
+      method: "POST",
+      path: "/notices/ack",
+      cred: "unknown",
+      rawBody: "{ not json",
+    },
+  ];
+  it.each(titled(UNKNOWN_CRED_CASES))("%s", async (_name, c) => {
+    const res = await driveCase(c);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual(NOT_FOUND_BODY);
   });
 });
 

--- a/web/tests/unit/auth-before-body.test.ts
+++ b/web/tests/unit/auth-before-body.test.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedSession,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * AUTH BEFORE THE BODY on the session lane's write routes — the memory-amplification fix: an
+ * unauthenticated caller must be refused BEFORE this tier reads (buffers) any of the request
+ * body, publish-sized caps most of all. Proven two ways: the response is the uniform 404, and
+ * the request's own body stream was NEVER PULLED. The workspace bind that replaces the old
+ * body-keyed resolve is pinned too: a valid credential presenting another workspace's id in
+ * the body meets the same uniform 404. The storage quota (`storage-bytes`) rides the same
+ * suite — it refuses AFTER auth and before any vault call, so no vault runs here at all.
+ */
+
+const seam = vi.hoisted(() => ({
+  limits: {} as Record<string, number>,
+  /** What the mocked vault stat answers; null = the stat read failed (fail-open). */
+  storedBytes: 0 as number | null,
+}));
+vi.mock("@/lib/plane/storage.server", () => ({
+  workspaceStoredBytes: async () => seam.storedBytes,
+  storageStats: async () => new Map<string, number>(),
+}));
+vi.mock("@/composition.server", () => ({
+  composition: {
+    tenancy: "single",
+    registration: "gated",
+    reservedWorkspaceNames: [],
+    entitlements: {
+      forWorkspace: async () => ({
+        allows: () => true,
+        limit: (key: string) => seam.limits[key] ?? null,
+      }),
+    },
+  },
+}));
+
+let db: ScratchDb;
+let wsId = "";
+
+type RouteHandler = (a: {
+  request: Request;
+  params: Record<string, string | undefined>;
+}) => Promise<Response> | Response;
+
+async function drive(
+  h: unknown,
+  request: Request,
+  params: Record<string, string | undefined> = {},
+): Promise<Response> {
+  try {
+    return await (h as RouteHandler)({ request, params });
+  } catch (e) {
+    if (e instanceof Response) {
+      return e;
+    }
+    throw e;
+  }
+}
+
+/**
+ * A streaming-body request whose consumption is observable: `request.bodyUsed` flips true the
+ * moment ANY reader touches `request.body` (which is exactly what `readCappedBody` does), and
+ * stays false when the route refused before reading. (The raw source stream cannot be the
+ * probe — undici pre-pumps a half-duplex source at CONSTRUCTION time, before any route runs.)
+ */
+function bodyProbeRequest(path: string, opts: { method?: string; cred?: string } = {}): Request {
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      controller.enqueue(new TextEncoder().encode("{}"));
+      controller.close();
+    },
+  });
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (opts.cred !== undefined) {
+    headers.authorization = `Bearer ${opts.cred}`;
+  }
+  return new Request(`http://x${path}`, {
+    method: opts.method ?? "POST",
+    headers,
+    body: stream,
+    // Node's fetch primitives require this for a streaming body.
+    duplex: "half",
+  } as RequestInit);
+}
+
+function publishBody(workspaceId: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    workspace_id: workspaceId,
+    skill_id: "b_probe",
+    op_id: randomUUID(),
+    expected: 0,
+    candidate: {
+      files: [{ path: "SKILL.md", mode: "100644", content_base64: "aGVsbG8=" }],
+      parents: [],
+      author: "Owner",
+      message: "publish",
+    },
+    ...extra,
+  });
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_authorder", { TOPOS_WEB_RATELIMIT: "off" });
+  wsId = await bootWorkspace();
+  await seedUser(db, "u_owner", "Owner", "owner@example.com");
+  await seatUser(db, wsId, "u_owner", "owner");
+  await seedSession(db, "cred_owner", wsId, "u_owner");
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("unauthenticated writes never buffer a body", () => {
+  it("publish: no credential → the uniform 404, the body stream untouched", async () => {
+    const { action } = await import("@/routes/api.v1.publish");
+    const request = bodyProbeRequest("/api/v1/publish");
+    const res = await drive(action, request);
+    expect(res.status).toBe(404);
+    expect(request.bodyUsed).toBe(false);
+  });
+
+  it("propose, reverts, reviews, report, invitations, protection: same order, same silence", async () => {
+    const routes: [string, unknown, Record<string, string>, string][] = [
+      ["/api/v1/proposals", (await import("@/routes/api.v1.propose")).action, {}, "POST"],
+      ["/api/v1/reverts", (await import("@/routes/api.v1.reverts")).action, {}, "POST"],
+      ["/api/v1/reviews", (await import("@/routes/api.v1.reviews")).action, {}, "POST"],
+      [
+        `/api/v1/workspaces/${wsId}/report`,
+        (await import("@/routes/api.v1.report")).action,
+        { ws: wsId },
+        "PUT",
+      ],
+      [
+        `/api/v1/workspaces/${wsId}/invitations`,
+        (await import("@/routes/api.v1.invitations")).action,
+        { ws: wsId },
+        "POST",
+      ],
+      [
+        `/api/v1/workspaces/${wsId}/skills/b_x/protection`,
+        (await import("@/routes/api.v1.skill-protection")).action,
+        { ws: wsId, skill: "b_x" },
+        "PUT",
+      ],
+      [
+        `/api/v1/workspaces/${wsId}/channels/everyone/protection`,
+        (await import("@/routes/api.v1.channel-protection")).action,
+        { ws: wsId, channel: "everyone" },
+        "PUT",
+      ],
+      [
+        `/api/v1/workspaces/${wsId}/notices/ack`,
+        (await import("@/routes/api.v1.notices-ack")).action,
+        { ws: wsId },
+        "POST",
+      ],
+    ];
+    for (const [path, action, params, method] of routes) {
+      const request = bodyProbeRequest(path, { method });
+      const res = await drive(action, request, params);
+      expect(res.status, path).toBe(404);
+      expect(request.bodyUsed, path).toBe(false);
+    }
+  });
+
+  it("an oversized declared Content-Length from an AUTHENTICATED caller still refuses up front", async () => {
+    const { action } = await import("@/routes/api.v1.publish");
+    const request = new Request("http://x/api/v1/publish", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer cred_owner",
+        "content-type": "application/json",
+        "content-length": String(200 * 1024 * 1024),
+      },
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      duplex: "half",
+    } as RequestInit);
+    const res = await drive(action, request);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("the workspace bind behind the credential-first resolve", () => {
+  it("a live credential naming ANOTHER workspace in the body is the uniform 404", async () => {
+    const { action } = await import("@/routes/api.v1.publish");
+    const res = await drive(
+      action,
+      new Request("http://x/api/v1/publish", {
+        method: "POST",
+        headers: { authorization: "Bearer cred_owner", "content-type": "application/json" },
+        body: publishBody("w_someone_elses"),
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("the storage quota (`storage-bytes`)", () => {
+  it("refuses typed after auth, before any vault call (no vault runs in this suite)", async () => {
+    const { action } = await import("@/routes/api.v1.publish");
+    seam.storedBytes = 90;
+    seam.limits["storage-bytes"] = 100;
+    try {
+      const res = await drive(
+        action,
+        new Request("http://x/api/v1/publish", {
+          method: "POST",
+          headers: { authorization: "Bearer cred_owner", "content-type": "application/json" },
+          body: publishBody(wsId),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const envelope = (await res.json()) as {
+        ok: boolean;
+        error?: { code: string; context: { message?: string } };
+      };
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error?.code).toBe("STORAGE_LIMIT_REACHED");
+      expect(envelope.error?.context.message).toBe("Storage limit reached for this workspace.");
+    } finally {
+      delete seam.limits["storage-bytes"];
+      seam.storedBytes = 0;
+    }
+  });
+
+  it("a failed stat read ALLOWS (fail-open); an absent limit never reads the stat at all", async () => {
+    const { storageQuotaRefusal } = await import("@/lib/api/publish-flow.server");
+    const { asSession } = await import("./helpers/scratch-db");
+    const actor = asSession(wsId, "u_owner", "cred_owner", "owner");
+    // Stat failure under a tight limit: allow (the ingest shares the backend and fails there).
+    seam.storedBytes = null;
+    seam.limits["storage-bytes"] = 1;
+    try {
+      expect(await storageQuotaRefusal(actor, randomUUID(), "publish", 10_000)).toBeNull();
+      // Over the limit with a healthy stat: the typed refusal.
+      seam.storedBytes = 90;
+      const refused = await storageQuotaRefusal(actor, randomUUID(), "publish", 11);
+      expect(refused).not.toBeNull();
+      // Absent limit (the OSS default): a no-op whatever the stat would say.
+      delete seam.limits["storage-bytes"];
+      expect(await storageQuotaRefusal(actor, randomUUID(), "publish", 1e12)).toBeNull();
+    } finally {
+      delete seam.limits["storage-bytes"];
+      seam.storedBytes = 0;
+    }
+  });
+});

--- a/web/tests/unit/auth-before-body.test.ts
+++ b/web/tests/unit/auth-before-body.test.ts
@@ -238,8 +238,38 @@ describe("the storage quota (`storage-bytes`)", () => {
     }
   });
 
+  it("the SHARED GENESIS PATH meets the quota too — the web import doors cannot ingest around it", async () => {
+    const { publishGenesisBundle } = await import("@/lib/api/genesis.server");
+    const { asSession } = await import("./helpers/scratch-db");
+    seam.storedBytes = 8;
+    seam.limits["storage-bytes"] = 10;
+    try {
+      const landed = await publishGenesisBundle({
+        actor: asSession(wsId, "u_owner", "cred_owner", "owner"),
+        kind: "skill",
+        candidate: {
+          // "hello" — 5 decoded bytes: 8 + 5 > 10. No vault runs in this suite, so the typed
+          // refusal PROVES the quota answered before any custody call.
+          files: [{ path: "SKILL.md", mode: "100644", content_base64: "aGVsbG8=" }],
+          attribution: "Owner",
+          message: "genesis",
+        },
+        displayName: "capped-by-storage",
+        destination: null,
+      });
+      expect(landed.kind).toBe("refused");
+      if (landed.kind === "refused") {
+        expect(landed.refusal.code).toBe("STORAGE_LIMIT_REACHED");
+        expect(landed.refusal.message).toBe("Storage limit reached for this workspace.");
+      }
+    } finally {
+      delete seam.limits["storage-bytes"];
+      seam.storedBytes = 0;
+    }
+  });
+
   it("candidateStoredBytes prices the decoded tree, arithmetically", async () => {
-    const { candidateStoredBytes } = await import("@/lib/api/publish-flow.server");
+    const { candidateStoredBytes } = await import("@/lib/api/storage-quota.server");
     const candidate = (contents: string[]) => ({
       files: contents.map((content_base64, i) => ({
         path: `f${i}`,
@@ -259,7 +289,7 @@ describe("the storage quota (`storage-bytes`)", () => {
   });
 
   it("a failed stat read ALLOWS (fail-open); an absent limit never reads the stat at all", async () => {
-    const { storageQuotaRefusal } = await import("@/lib/api/publish-flow.server");
+    const { storageQuotaRefusal } = await import("@/lib/api/storage-quota.server");
     const { asSession } = await import("./helpers/scratch-db");
     const actor = asSession(wsId, "u_owner", "cred_owner", "owner");
     // Stat failure under a tight limit: allow (the ingest shares the backend and fails there).

--- a/web/tests/unit/auth-before-body.test.ts
+++ b/web/tests/unit/auth-before-body.test.ts
@@ -211,7 +211,9 @@ describe("the workspace bind behind the credential-first resolve", () => {
 describe("the storage quota (`storage-bytes`)", () => {
   it("refuses typed after auth, before any vault call (no vault runs in this suite)", async () => {
     const { action } = await import("@/routes/api.v1.publish");
-    seam.storedBytes = 90;
+    // The charge is the candidate's DECODED bytes ("aGVsbG8=" → 5), never the wire framing:
+    // 96 stored + 5 > 100 refuses, while raw-request accounting would refuse far earlier.
+    seam.storedBytes = 96;
     seam.limits["storage-bytes"] = 100;
     try {
       const res = await drive(
@@ -234,6 +236,26 @@ describe("the storage quota (`storage-bytes`)", () => {
       delete seam.limits["storage-bytes"];
       seam.storedBytes = 0;
     }
+  });
+
+  it("candidateStoredBytes prices the decoded tree, arithmetically", async () => {
+    const { candidateStoredBytes } = await import("@/lib/api/publish-flow.server");
+    const candidate = (contents: string[]) => ({
+      files: contents.map((content_base64, i) => ({
+        path: `f${i}`,
+        mode: "100644",
+        content_base64,
+      })),
+      parents: [],
+      author: "a",
+      message: "m",
+    });
+    expect(candidateStoredBytes(candidate([]))).toBe(0);
+    expect(candidateStoredBytes(candidate(["YQ=="]))).toBe(1); // "a"
+    expect(candidateStoredBytes(candidate(["YWI="]))).toBe(2); // "ab"
+    expect(candidateStoredBytes(candidate(["YWJj"]))).toBe(3); // "abc"
+    expect(candidateStoredBytes(candidate(["aGVsbG8="]))).toBe(5); // "hello"
+    expect(candidateStoredBytes(candidate(["YWJj", "aGVsbG8="]))).toBe(8);
   });
 
   it("a failed stat read ALLOWS (fail-open); an absent limit never reads the stat at all", async () => {

--- a/web/tests/unit/bundle-kind.test.ts
+++ b/web/tests/unit/bundle-kind.test.ts
@@ -271,7 +271,7 @@ describe("an existing bundle's kind is fixed at birth", () => {
   });
 });
 
-describe("the door refuses an unknown kind — before the credential resolve", () => {
+describe("the door refuses an unknown kind — before any custody call", () => {
   /** The one refusal an out-of-vocabulary kind earns, whatever made it out of vocabulary. */
   const REFUSAL = "unknown kind — known kinds: 'skill', 'mcp'";
 
@@ -297,7 +297,9 @@ describe("the door refuses an unknown kind — before the credential resolve", (
         : await import("@/routes/api.v1.propose");
     const request = new Request(`http://x/api/v1/${route}`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      // Authenticated: the door resolves the credential FIRST (auth-before-body), so the kind
+      // refusal is a member's 400 — an unauthenticated caller meets only the uniform 404.
+      headers: { "content-type": "application/json", authorization: "Bearer cs_auth" },
       body: JSON.stringify(body(kind)),
     });
     let res: Response;
@@ -341,10 +343,10 @@ describe("the door refuses an unknown kind — before the credential resolve", (
   });
 
   it("an explicit null is ABSENT, not malformed (the wire's optional spelling)", async () => {
-    // A null reaches the guard rather than the 400 — this body carries no credential, so the
-    // uniform miss is the honest proof that the parse let it through.
+    // A null passes the parse and the op proceeds all the way to a landed publish — the
+    // honest proof that null reads as "no kind declared", never as a malformed value.
     const { status } = await post("publish", null);
-    expect(status).not.toBe(400);
+    expect(status).toBe(200);
   });
 });
 

--- a/web/tests/unit/entitlement-gates.test.ts
+++ b/web/tests/unit/entitlement-gates.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  asOwner,
+  asSession,
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedBundle,
+  seedSession,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * The per-workspace entitlement gates against a REAL scratch Postgres, all three consulted
+ * through the mocked composition seam:
+ *  - `reviews` (allows) — ENABLING review protection refuses at every door (the lane's
+ *    skill/channel protect, the web pin, the workspace default); disabling never does, and an
+ *    already-'reviewed' bundle keeps its row (no retroactive strip).
+ *  - `bundles` (limit) — a NEW bundle identity at the cap refuses BEFORE any custody call
+ *    (publishGenesisBundle answers `refused` with no vault in the room at all); absent = no-op.
+ *  - `history-days` (limit) — a version older than the window reads outside it; absent = no-op;
+ *    a version the mirror does not hold is never this check's refusal.
+ */
+
+const seam = vi.hoisted(() => ({
+  limits: {} as Record<string, number>,
+  allows: {} as Record<string, boolean>,
+}));
+vi.mock("@/composition.server", () => ({
+  composition: {
+    tenancy: "single",
+    registration: "gated",
+    reservedWorkspaceNames: [],
+    entitlements: {
+      forWorkspace: async () => ({
+        allows: (key: string) => seam.allows[key] ?? true,
+        limit: (key: string) => seam.limits[key] ?? null,
+      }),
+    },
+  },
+}));
+
+let db: ScratchDb;
+let wsId = "";
+
+beforeAll(async () => {
+  db = await createScratchDb("web_entgates");
+  wsId = await bootWorkspace();
+  await seedUser(db, "u_owner", "Owner", "owner@example.com");
+  await seatUser(db, wsId, "u_owner", "owner");
+  await seedSession(db, "cred_owner", wsId, "u_owner");
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("the reviews gate (`allows('reviews')`)", () => {
+  it("withheld: every ENABLE door refuses; loosening still lands; standing rows keep working", async () => {
+    const lane = await import("@/lib/db/queries.lane.server");
+    const lifecycle = await import("@/lib/db/queries.lifecycle.server");
+    const queries = await import("@/lib/db/queries.server");
+    const owner = asOwner(wsId, "u_owner");
+    const session = asSession(wsId, "u_owner", "cred_owner", "owner");
+    await seedBundle(db, wsId, "b_guarded", "guarded");
+    // A bundle protected BEFORE the entitlement was withdrawn.
+    await db.q(`UPDATE web.bundle SET protection = 'reviewed' WHERE id = 'b_guarded'`);
+
+    seam.allows.reviews = false;
+    try {
+      expect(await lane.laneProtectBundle(session, "b_guarded", "reviewed")).toBe(
+        "reviews_unavailable",
+      );
+      expect(await lane.laneProtectChannel(session, "everyone", "curated")).toBe(
+        "reviews_unavailable",
+      );
+      expect(await lifecycle.setBundleProtection(owner, "b_guarded", "reviewed")).toEqual({
+        outcome: "reviews_unavailable",
+      });
+      expect(await queries.setReviewDefault(owner, true)).toBe("reviews_unavailable");
+      // NO retroactive strip: the standing pin is untouched by the refusals above.
+      const rows = await db.q<{ protection: string | null }>(
+        `SELECT protection FROM web.bundle WHERE id = 'b_guarded'`,
+      );
+      expect(rows[0]?.protection).toBe("reviewed");
+      // Loosening is never gated.
+      expect(await lane.laneProtectBundle(session, "b_guarded", "open")).toBe("set");
+      expect(await queries.setReviewDefault(owner, false)).toBe("set");
+      expect(await lifecycle.setBundleProtection(owner, "b_guarded", null)).toEqual({
+        outcome: "set",
+      });
+    } finally {
+      delete seam.allows.reviews;
+    }
+  });
+
+  it("open (the OSS default): enabling lands as before", async () => {
+    const lane = await import("@/lib/db/queries.lane.server");
+    expect(
+      await lane.laneProtectBundle(
+        asSession(wsId, "u_owner", "cred_owner", "owner"),
+        "b_guarded",
+        "reviewed",
+      ),
+    ).toBe("set");
+  });
+});
+
+describe("the bundle cap (`bundles`)", () => {
+  it("a NEW identity at the cap refuses before any custody call; absent limit is a no-op", async () => {
+    const genesis = await import("@/lib/api/genesis.server");
+    const session = asSession(wsId, "u_owner", "cred_owner", "owner");
+    const candidate = {
+      files: [{ path: "SKILL.md", mode: "100644", content_base64: "aGVsbG8=" }],
+      attribution: "Owner",
+      message: "genesis",
+    };
+    // One active bundle stands (b_guarded). At a limit of 1, a new identity refuses — and no
+    // vault is running in this suite, so the refusal PROVES no custody call was attempted.
+    seam.limits.bundles = 1;
+    try {
+      const refused = await genesis.publishGenesisBundle({
+        actor: session,
+        kind: "skill",
+        candidate,
+        displayName: "capped",
+        destination: null,
+      });
+      expect(refused.kind).toBe("refused");
+      if (refused.kind === "refused") {
+        expect(refused.refusal.code).toBe("BUNDLE_LIMIT_REACHED");
+        expect(refused.refusal.message).toBe("This workspace is at its bundle limit.");
+      }
+      const rows = await db.q<{ n: number }>(
+        `SELECT count(*)::int AS n FROM web.bundle WHERE workspace_id = $1`,
+        [wsId],
+      );
+      expect(rows[0]?.n).toBe(1);
+    } finally {
+      delete seam.limits.bundles;
+    }
+  });
+
+  it("archived bundles do not count against the cap (active rows only)", async () => {
+    const custody = await import("@/lib/db/queries.custody.server");
+    await db.q(
+      `UPDATE web.bundle SET status = 'archived', archived_at = now() WHERE id = 'b_guarded'`,
+    );
+    try {
+      seam.limits.bundles = 1;
+      const session = asSession(wsId, "u_owner", "cred_owner", "owner");
+      expect(await custody.bundleCapRefusal(session)).toBeNull();
+      seam.limits.bundles = 0;
+      const refused = await custody.bundleCapRefusal(session);
+      expect(refused?.code).toBe("BUNDLE_LIMIT_REACHED");
+    } finally {
+      delete seam.limits.bundles;
+      await db.q(
+        `UPDATE web.bundle SET status = 'active', archived_at = NULL WHERE id = 'b_guarded'`,
+      );
+    }
+  });
+});
+
+describe("the history window (`history-days`)", () => {
+  it("older-than-window reads outside; inside and absent-limit do not; unknown versions never do", async () => {
+    const custody = await import("@/lib/db/queries.custody.server");
+    const session = asSession(wsId, "u_owner", "cred_owner", "owner");
+    const oldV = "a1".repeat(32);
+    const newV = "b2".repeat(32);
+    await db.q(
+      `INSERT INTO plane.version (workspace_id, bundle_id, version_id, commit_id, author_display, created_at)
+       VALUES ($1, 'b_guarded', $2, $3, 'Owner', now() - interval '40 days'),
+              ($1, 'b_guarded', $4, $5, 'Owner', now() - interval '5 days')`,
+      [wsId, oldV, "c1".repeat(20), newV, "d1".repeat(20)],
+    );
+    // No window (the OSS default): nothing is outside.
+    expect(await custody.versionOutsideHistoryWindow(session, "b_guarded", oldV)).toBe(false);
+    seam.limits["history-days"] = 30;
+    try {
+      expect(await custody.versionOutsideHistoryWindow(session, "b_guarded", oldV)).toBe(true);
+      expect(await custody.versionOutsideHistoryWindow(session, "b_guarded", newV)).toBe(false);
+      // A version the mirror does not hold is not this check's refusal.
+      expect(await custody.versionOutsideHistoryWindow(session, "b_guarded", "e3".repeat(32))).toBe(
+        false,
+      );
+      // The page's annotation read: creation times for exactly the versions the mirror holds.
+      const map = await custody.versionCreatedAtMap(session, "b_guarded", [
+        oldV,
+        newV,
+        "e3".repeat(32),
+      ]);
+      expect(map.size).toBe(2);
+      expect(map.get(oldV)).toBeInstanceOf(Date);
+    } finally {
+      delete seam.limits["history-days"];
+    }
+  });
+});

--- a/web/tests/unit/entitlement-gates.test.ts
+++ b/web/tests/unit/entitlement-gates.test.ts
@@ -191,6 +191,30 @@ describe("the bundle cap covers UNARCHIVE (archived→active is the same step pa
       delete seam.limits.bundles;
     }
   });
+
+  it("refuses BEFORE the MCP name claim — a capped restore never re-occupies a registry name", async () => {
+    const lifecycle = await import("@/lib/db/queries.lifecycle.server");
+    const owner = asOwner(wsId, "u_owner");
+    await seedBundle(db, wsId, "b_mcp_arch", "held-archived-2026-01-01", {
+      kind: "mcp",
+      status: "archived",
+      baseName: "held",
+    });
+    seam.limits.bundles = 2;
+    try {
+      // The cap answers FIRST: were the claim attempted, this vault-less suite would have
+      // answered `mcp_document_unreadable` instead — and a claim row would have committed
+      // alongside the refusal, an archived bundle monopolizing a name it does not serve.
+      const refused = await lifecycle.unarchiveBundle(owner, "b_mcp_arch");
+      expect(refused.outcome).toBe("bundle_limit");
+      const claims = await db.q<{ n: number }>(
+        `SELECT count(*)::int AS n FROM web.bundle_identity WHERE bundle_id = 'b_mcp_arch'`,
+      );
+      expect(claims[0]?.n).toBe(0);
+    } finally {
+      delete seam.limits.bundles;
+    }
+  });
 });
 
 describe("the history window (`history-days`)", () => {

--- a/web/tests/unit/entitlement-gates.test.ts
+++ b/web/tests/unit/entitlement-gates.test.ts
@@ -142,6 +142,22 @@ describe("the bundle cap (`bundles`)", () => {
     }
   });
 
+  it("a retry naming an id already ACTIVE here is no growth — never refused at the cap", async () => {
+    const custody = await import("@/lib/db/queries.custody.server");
+    const session = asSession(wsId, "u_owner", "cred_owner", "owner");
+    // ONE active bundle (b_guarded) at a limit of 1: a duplicated/lost-ack retry of THAT
+    // bundle's genesis registers nothing new and must not read BUNDLE_LIMIT_REACHED…
+    seam.limits.bundles = 1;
+    try {
+      expect(await custody.bundleCapRefusal(session, "b_guarded")).toBeNull();
+      // …while a genuinely new identity still refuses.
+      const fresh = await custody.bundleCapRefusal(session, "b_new_identity");
+      expect(fresh?.code).toBe("BUNDLE_LIMIT_REACHED");
+    } finally {
+      delete seam.limits.bundles;
+    }
+  });
+
   it("archived bundles do not count against the cap (active rows only)", async () => {
     const custody = await import("@/lib/db/queries.custody.server");
     await db.q(
@@ -150,9 +166,9 @@ describe("the bundle cap (`bundles`)", () => {
     try {
       seam.limits.bundles = 1;
       const session = asSession(wsId, "u_owner", "cred_owner", "owner");
-      expect(await custody.bundleCapRefusal(session)).toBeNull();
+      expect(await custody.bundleCapRefusal(session, "b_fresh")).toBeNull();
       seam.limits.bundles = 0;
-      const refused = await custody.bundleCapRefusal(session);
+      const refused = await custody.bundleCapRefusal(session, "b_fresh");
       expect(refused?.code).toBe("BUNDLE_LIMIT_REACHED");
     } finally {
       delete seam.limits.bundles;

--- a/web/tests/unit/entitlement-gates.test.ts
+++ b/web/tests/unit/entitlement-gates.test.ts
@@ -163,6 +163,36 @@ describe("the bundle cap (`bundles`)", () => {
   });
 });
 
+describe("the bundle cap covers UNARCHIVE (archived→active is the same step past it)", () => {
+  it("restoring at the cap refuses typed; a wider limit restores", async () => {
+    const lifecycle = await import("@/lib/db/queries.lifecycle.server");
+    const owner = asOwner(wsId, "u_owner");
+    // Archive b_guarded by rows (the archive ceremony's resulting shape), then stand up a
+    // replacement — the archive-then-replace-then-unarchive shuffle the cap must refuse.
+    await db.q(
+      `UPDATE web.bundle
+       SET status = 'archived', archived_at = now(), base_name = name,
+           name = name || '-archived-2026-01-01'
+       WHERE id = 'b_guarded'`,
+    );
+    await seedBundle(db, wsId, "b_replacement", "replacement");
+    seam.limits.bundles = 1;
+    try {
+      const refused = await lifecycle.unarchiveBundle(owner, "b_guarded");
+      expect(refused.outcome).toBe("bundle_limit");
+      const rows = await db.q<{ status: string }>(
+        `SELECT status FROM web.bundle WHERE id = 'b_guarded'`,
+      );
+      expect(rows[0]?.status).toBe("archived");
+      seam.limits.bundles = 2;
+      const restored = await lifecycle.unarchiveBundle(owner, "b_guarded");
+      expect(restored.outcome).toBe("unarchived");
+    } finally {
+      delete seam.limits.bundles;
+    }
+  });
+});
+
 describe("the history window (`history-days`)", () => {
   it("older-than-window reads outside; inside and absent-limit do not; unknown versions never do", async () => {
     const custody = await import("@/lib/db/queries.custody.server");

--- a/web/tests/unit/invitation-redemption.test.ts
+++ b/web/tests/unit/invitation-redemption.test.ts
@@ -29,6 +29,11 @@ beforeAll(async () => {
   db = await createScratchDb("invredeem");
   ws = await bootWorkspace();
   await seedUser(db, INVITER, "Inviter", "inviter@acme.test");
+  // Age the inviter past 48h so this suite's many invites ride the 50/day floor, not the
+  // young-account 10/day one (invite-caps.server.ts — that floor has its own suite).
+  await db.q(`UPDATE web."user" SET created_at = now() - interval '3 days' WHERE id = $1`, [
+    INVITER,
+  ]);
   await seatUser(db, ws, INVITER, "owner");
   await seedBundle(db, ws, "s_deploy", "deploy");
   await placeInDefault(db, ws, "s_deploy");

--- a/web/tests/unit/invite-caps.test.ts
+++ b/web/tests/unit/invite-caps.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  asOwner,
+  asSession,
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedSession,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * The invitation caps (invite-caps.server.ts) at BOTH doors — the members-page DAL
+ * (createInvitations) and the session lane's (laneInvite) — against a REAL scratch Postgres:
+ * the per-submission address cap, the member cap (seats + live pending invitations), the
+ * FLOORED rolling-day cap (10 while the account is under 48h, 50 after, a present entitlement
+ * row winning even when lower), and the per-address cooldown that SKIPS rather than refuses.
+ * The entitlements provider is the mocked composition seam; every limit-less default must be
+ * a no-op beyond the floors.
+ */
+
+const seam = vi.hoisted(() => ({
+  limits: {} as Record<string, number>,
+}));
+vi.mock("@/composition.server", () => ({
+  composition: {
+    tenancy: "single",
+    registration: "gated",
+    reservedWorkspaceNames: [],
+    entitlements: {
+      forWorkspace: async () => ({
+        allows: () => true,
+        limit: (key: string) => seam.limits[key] ?? null,
+      }),
+    },
+  },
+}));
+
+let db: ScratchDb;
+let wsId = "";
+
+async function roster() {
+  return import("@/lib/db/queries.roster.server");
+}
+async function lane() {
+  return import("@/lib/db/queries.lane.server");
+}
+
+/** The inviter's invitation_created audit-row count in the rolling day. */
+async function sentToday(userId: string): Promise<number> {
+  const rows = await db.q<{ n: number }>(
+    `SELECT count(*)::int AS n FROM web.audit_event
+     WHERE kind = 'invitation_created' AND outcome = 'ok' AND actor_user_id = $1
+       AND created_at > now() - interval '24 hours'`,
+    [userId],
+  );
+  return rows[0]?.n ?? 0;
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_invcaps");
+  wsId = await bootWorkspace();
+  await seedUser(db, "u_owner", "Owner", "owner@example.com");
+  await seatUser(db, wsId, "u_owner", "owner");
+  await seedSession(db, "cred_owner", wsId, "u_owner");
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("the per-submission cap (10 addresses)", () => {
+  it("refuses the WHOLE submission over the cap, at both doors, writing nothing", async () => {
+    const emails = Array.from({ length: 11 }, (_, i) => `bulk${i}@example.com`);
+    const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), emails);
+    expect(r.outcome).toBe("too_many_addresses");
+    const l = await (await lane()).laneInvite(
+      asSession(wsId, "u_owner", "cred_owner", "owner"),
+      emails,
+      {},
+    );
+    expect(l.outcome).toBe("too_many_addresses");
+    expect(await sentToday("u_owner")).toBe(0);
+    const rows = await db.q<{ n: number }>(`SELECT count(*)::int AS n FROM web.invitation`);
+    expect(rows[0]?.n).toBe(0);
+  });
+
+  it("exactly 10 passes (the cap is at-most, not under)", async () => {
+    const emails = Array.from({ length: 10 }, (_, i) => `ten${i}@example.com`);
+    const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), emails);
+    expect(r.outcome).toBe("invited");
+    if (r.outcome === "invited") {
+      expect(r.minted).toHaveLength(10);
+      expect(r.skipped).toEqual([]);
+    }
+  });
+});
+
+describe("the rolling-day cap (floored: young account 10/day, else 50; a present row wins)", () => {
+  it("a young account hits the 10/day floor prospectively", async () => {
+    // The submission-cap test above already sent 10 today as u_owner (a fresh account).
+    expect(await sentToday("u_owner")).toBe(10);
+    const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+      "eleventh@example.com",
+    ]);
+    expect(r.outcome).toBe("invite_limit");
+    const l = await (await lane()).laneInvite(
+      asSession(wsId, "u_owner", "cred_owner", "owner"),
+      ["eleventh@example.com"],
+      {},
+    );
+    expect(l.outcome).toBe("invite_limit");
+  });
+
+  it("an account past 48 hours rides the 50/day floor", async () => {
+    await db.q(`UPDATE web."user" SET created_at = now() - interval '3 days' WHERE id = $1`, [
+      "u_owner",
+    ]);
+    const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+      "eleventh@example.com",
+    ]);
+    expect(r.outcome).toBe("invited");
+  });
+
+  it("a present `invites-per-day` row wins even when LOWER than the floor", async () => {
+    seam.limits["invites-per-day"] = 5;
+    try {
+      const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "twelfth@example.com",
+      ]);
+      expect(r.outcome).toBe("invite_limit");
+    } finally {
+      delete seam.limits["invites-per-day"];
+    }
+  });
+});
+
+describe("the member cap at invite creation (seats + live pending invitations)", () => {
+  it("refuses at/over the limit, at both doors; absent limit is a no-op", async () => {
+    // Standing state: 1 seat (the owner) + 11 pending invitations. A limit of 12 is met.
+    seam.limits.members = 12;
+    try {
+      const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "overflow@example.com",
+      ]);
+      expect(r.outcome).toBe("member_limit");
+      const l = await (await lane()).laneInvite(
+        asSession(wsId, "u_owner", "cred_owner", "owner"),
+        ["overflow@example.com"],
+        {},
+      );
+      expect(l.outcome).toBe("member_limit");
+      // One more slot → passes.
+      seam.limits.members = 13;
+      const ok = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "overflow@example.com",
+      ]);
+      expect(ok.outcome).toBe("invited");
+    } finally {
+      delete seam.limits.members;
+    }
+  });
+
+  it("an EXPIRED pending invitation does not count against the limit", async () => {
+    await db.q(
+      `UPDATE web.invitation SET expires_at = now() - interval '1 hour' WHERE email = $1`,
+      ["overflow@example.com"],
+    );
+    // 1 seat + 11 LIVE pending (overflow@ is expired) → a limit of 13 has room exactly
+    // because the expired row is not counted (counting it would read 13 and refuse).
+    seam.limits.members = 13;
+    try {
+      const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "roomy@example.com",
+      ]);
+      expect(r.outcome).toBe("invited");
+    } finally {
+      delete seam.limits.members;
+    }
+  });
+});
+
+describe("the per-address cooldown (3 invites in 7 days, server-wide → skip)", () => {
+  it("skips the address without failing the submission; no row, no audit line", async () => {
+    const target = "hammered@example.com";
+    for (let i = 0; i < 3; i++) {
+      const r = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [target]);
+      expect(r.outcome).toBe("invited");
+    }
+    const before = await sentToday("u_owner");
+    const fourth = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+      target,
+      "fresh@example.com",
+    ]);
+    expect(fourth.outcome).toBe("invited");
+    if (fourth.outcome === "invited") {
+      expect(fourth.minted.map((m) => m.email)).toEqual(["fresh@example.com"]);
+      expect(fourth.skipped).toEqual([target]);
+    }
+    // Only the fresh address landed an audit row — a skip never extends its own cooldown.
+    expect(await sentToday("u_owner")).toBe(before + 1);
+  });
+
+  it("the lane door skips identically, and the cooldown reads across workspaces", async () => {
+    const l = await (await lane()).laneInvite(
+      asSession(wsId, "u_owner", "cred_owner", "owner"),
+      ["hammered@example.com"],
+      {},
+    );
+    expect(l.outcome).toBe("invited");
+    if (l.outcome === "invited") {
+      expect(l.minted).toEqual([]);
+      expect(l.skipped).toEqual(["hammered@example.com"]);
+    }
+  });
+});

--- a/web/tests/unit/invite-caps.test.ts
+++ b/web/tests/unit/invite-caps.test.ts
@@ -181,6 +181,38 @@ describe("the member cap at invite creation (seats + live pending invitations)",
   });
 });
 
+describe("the member cap is PROSPECTIVE — batches and resends", () => {
+  it("a batch larger than the remaining room refuses whole; a resend at the limit still works", async () => {
+    // Standing at this point: 1 seat + 12 live pending (ten0–9, eleventh, roomy) = 13.
+    seam.limits.members = 14;
+    try {
+      // Two NEW addresses into one remaining slot: 13 + 2 > 14 → the whole batch refuses.
+      const batch = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "batch-a@example.com",
+        "batch-b@example.com",
+      ]);
+      expect(batch.outcome).toBe("member_limit");
+      // One new address fills the last slot exactly.
+      const one = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "batch-a@example.com",
+      ]);
+      expect(one.outcome).toBe("invited");
+      // AT the limit, a RE-invite adds no live-pending row — resending still works.
+      const resend = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "batch-a@example.com",
+      ]);
+      expect(resend.outcome).toBe("invited");
+      // …while a new address is now over.
+      const over = await (await roster()).createInvitations(asOwner(wsId, "u_owner"), [
+        "batch-c@example.com",
+      ]);
+      expect(over.outcome).toBe("member_limit");
+    } finally {
+      delete seam.limits.members;
+    }
+  });
+});
+
 describe("the per-address cooldown (3 invites in 7 days, server-wide → skip)", () => {
   it("skips the address without failing the submission; no row, no audit line", async () => {
     const target = "hammered@example.com";

--- a/web/tests/unit/invite-mail-hardening.test.ts
+++ b/web/tests/unit/invite-mail-hardening.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Invite-mail HARDENING: every user-influenced value is made mail-safe at COMPOSE time — our
+ * own control-character strip (never a reliance on the mail library's internal header
+ * folding) plus a display-length cut — and the transport wears a second subject strip as a
+ * belt. The load-bearing pin: a `\r\n` smuggled through a workspace name can NEVER reach the
+ * subject line (header injection), and a 10k-character name cannot balloon one.
+ */
+
+const { sendMailSpy, createTransportSpy } = vi.hoisted(() => {
+  const sendMailSpy = vi.fn(async (_message: unknown) => ({}));
+  const createTransportSpy = vi.fn(() => ({ sendMail: sendMailSpy }));
+  return { sendMailSpy, createTransportSpy };
+});
+vi.mock("nodemailer", () => ({ default: { createTransport: createTransportSpy } }));
+vi.mock("@/lib/db/mail-log.server", () => ({ recordMailEvent: vi.fn(async () => {}) }));
+
+const BASE_ENV: Record<string, string> = {
+  DATABASE_URL: "postgres://user:pass@localhost:5439/db",
+  BETTER_AUTH_SECRET: "0123456789abcdef0123456789abcdef",
+  BETTER_AUTH_URL: "http://localhost:3000",
+  PLANE_INTERNAL_URL: "http://vault.internal:8080",
+  PLANE_INTERNAL_TOKEN: "internal-token-value",
+  TOPOS_MAIL_SMTP_HOST: "smtp.example.com",
+  TOPOS_MAIL_SMTP_PORT: "465",
+  TOPOS_MAIL_SMTP_USER: "api_token",
+  TOPOS_MAIL_SMTP_PASS: "relay-secret",
+  TOPOS_MAIL_SMTP_FROM: "Topos <no-reply@example.com>",
+};
+
+async function importArmedProduction() {
+  vi.resetModules();
+  for (const [k, v] of Object.entries(BASE_ENV)) {
+    vi.stubEnv(k, v);
+  }
+  vi.stubEnv("APP_ENV", "production");
+  return {
+    inviteMail: await import("@/lib/mail/invite-mail.server"),
+    transport: await import("@/lib/mail/transport.server"),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  sendMailSpy.mockClear();
+});
+
+type SentMessage = { subject: string; text: string; html?: string };
+
+describe("compose-time strip + cut", () => {
+  it("a CRLF-smuggling workspace name never reaches the subject (or any line raw)", async () => {
+    const { inviteMail } = await importArmedProduction();
+    await inviteMail.sendInviteEmail({
+      to: "victim@example.com",
+      workspaceDisplayName: "Acme\r\nBcc: everyone@example.com\r\nX-Evil: 1",
+      inviteUrl: "https://topos.example/acme/invite/tok-123",
+      agentUrl: "https://topos.example/agent",
+      invitedBy: "owner\r\nReply-To: attacker@evil.example",
+    });
+    expect(sendMailSpy).toHaveBeenCalledTimes(1);
+    const sent = sendMailSpy.mock.calls[0]?.[0] as SentMessage;
+    expect(sent.subject).not.toMatch(/[\r\n]/);
+    expect(sent.subject).toContain("Acme Bcc: everyone@example.com");
+    expect(sent.text).not.toContain("owner\r\nReply-To");
+  });
+
+  it("display fields are cut to 60 chars with an ellipsis; the hint name too", async () => {
+    const { inviteMail } = await importArmedProduction();
+    const longName = "w".repeat(300);
+    await inviteMail.sendInviteEmail({
+      to: "victim@example.com",
+      workspaceDisplayName: longName,
+      inviteUrl: "https://topos.example/acme/invite/tok-123",
+      agentUrl: "https://topos.example/agent",
+      invitedBy: "o".repeat(300),
+      hint: { kind: "skill", name: "h".repeat(300) },
+    });
+    const sent = sendMailSpy.mock.calls[0]?.[0] as SentMessage;
+    expect(sent.subject).toContain(`${"w".repeat(59)}…`);
+    expect(sent.subject).not.toContain("w".repeat(61));
+    expect(sent.text).toContain(`${"o".repeat(59)}…`);
+    expect(sent.subject).toContain(`${"h".repeat(59)}…`);
+  });
+});
+
+describe("the transport-level subject belt", () => {
+  it("sendMail strips control characters from ANY caller's subject", async () => {
+    const { transport } = await importArmedProduction();
+    await transport.sendMail({
+      kind: "invite",
+      to: "victim@example.com",
+      subject: "Hello\r\nBcc: everyone@example.com",
+      text: "body",
+    });
+    const sent = sendMailSpy.mock.calls[0]?.[0] as SentMessage;
+    expect(sent.subject).toBe("Hello Bcc: everyone@example.com");
+  });
+
+  it("stripMailControl collapses control runs to one space", async () => {
+    const { transport } = await importArmedProduction();
+    expect(transport.stripMailControl("a\r\n\tb\x00c")).toBe("a b c");
+    expect(transport.stripMailControl("plain subject")).toBe("plain subject");
+  });
+});

--- a/web/tests/unit/member-cap-mint.test.ts
+++ b/web/tests/unit/member-cap-mint.test.ts
@@ -174,3 +174,39 @@ describe("bindInvitedSeats under a members limit", () => {
     }
   });
 });
+
+describe("approveLoginFlow at a full workspace", () => {
+  it("an invitation-bound approval answers `workspace-full` typed — flow AND invitation stay pending", async () => {
+    const id = await identity();
+    await seedUser(db, "u_eve", "Eve", "eve@example.com");
+    await db.q(`UPDATE web."user" SET email_verified = true WHERE id = 'u_eve'`);
+    await seedInvitation("eve@example.com");
+    const invRows = await db.q<{ id: string }>(
+      `SELECT id FROM web.invitation WHERE email = 'eve@example.com' AND status = 'pending'`,
+    );
+    const invId = invRows[0]?.id ?? "";
+    const flow = await id.startLoginFlow("eve-box", null);
+    // Seats stand at 4 (owner, Bea, Cal, Dee) — a limit of 4 is full.
+    seam.limits.members = 4;
+    try {
+      const refused = await id.approveLoginFlow(
+        flow.userCode,
+        { userId: "u_eve", display: "Eve" },
+        { kind: "invitation", id: invId },
+      );
+      expect(refused).toEqual({ outcome: "workspace-full" });
+      expect(await invitationStatus("eve@example.com")).toBe("pending");
+      expect((await id.pollLoginFlow(flow.flowCode)).status).toBe("pending");
+      // Room opens: the SAME approval completes.
+      seam.limits.members = 10;
+      const approved = await id.approveLoginFlow(
+        flow.userCode,
+        { userId: "u_eve", display: "Eve" },
+        { kind: "invitation", id: invId },
+      );
+      expect(approved?.outcome).toBe("approved");
+    } finally {
+      delete seam.limits.members;
+    }
+  });
+});

--- a/web/tests/unit/member-cap-mint.test.ts
+++ b/web/tests/unit/member-cap-mint.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * The member cap's SEAT-MINT backstop (`members`) — the accept ceremonies against a REAL
+ * scratch Postgres: a full workspace refuses the accept (`workspace_full`) and CONSUMES
+ * NOTHING (the invitation stays pending, so a wider limit lets the same link succeed later);
+ * an accepter who already holds a seat is never refused (nothing grows); the invited sign-up's
+ * binding leg SKIPS a full workspace instead of consuming its invitation. Absent limit — the
+ * OSS default — is a no-op throughout.
+ */
+
+const seam = vi.hoisted(() => ({
+  limits: {} as Record<string, number>,
+}));
+vi.mock("@/composition.server", () => ({
+  composition: {
+    tenancy: "single",
+    registration: "gated",
+    reservedWorkspaceNames: [],
+    entitlements: {
+      forWorkspace: async () => ({
+        allows: () => true,
+        limit: (key: string) => seam.limits[key] ?? null,
+      }),
+    },
+  },
+}));
+
+let db: ScratchDb;
+let wsId = "";
+let tokenCounter = 0;
+
+async function identity() {
+  return import("@/lib/db/identity.server");
+}
+
+/** Seed one live pending invitation; returns the plaintext token the accept presents. */
+async function seedInvitation(email: string): Promise<string> {
+  tokenCounter += 1;
+  const token = `tok-${tokenCounter}-${email}`;
+  await db.q(
+    `INSERT INTO web.invitation (id, workspace_id, email, role, status, expires_at, token_sha256)
+     VALUES ($1, $2, $3, 'member', 'pending', now() + interval '7 days',
+             sha256(convert_to($4, 'UTF8')))`,
+    [`i_${tokenCounter}`, wsId, email, token],
+  );
+  return token;
+}
+
+async function seatCount(): Promise<number> {
+  const rows = await db.q<{ n: number }>(
+    `SELECT count(*)::int AS n FROM web.seat WHERE workspace_id = $1`,
+    [wsId],
+  );
+  return rows[0]?.n ?? 0;
+}
+
+async function invitationStatus(email: string): Promise<string | undefined> {
+  const rows = await db.q<{ status: string }>(
+    `SELECT status FROM web.invitation WHERE email = $1 ORDER BY created_at DESC LIMIT 1`,
+    [email],
+  );
+  return rows[0]?.status;
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_memcap");
+  wsId = await bootWorkspace();
+  await seedUser(db, "u_owner", "Owner", "owner@example.com");
+  await seatUser(db, wsId, "u_owner", "owner");
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("acceptInvitationByToken under a members limit", () => {
+  it("admits while there is room, refuses `workspace_full` at the limit — the row stays pending", async () => {
+    seam.limits.members = 2;
+    try {
+      await seedUser(db, "u_bea", "Bea", "bea@example.com");
+      const tokenBea = await seedInvitation("bea@example.com");
+      const admitted = await (await identity()).acceptInvitationByToken(
+        tokenBea,
+        { userId: "u_bea", display: "Bea" },
+        { mailboxProven: true },
+      );
+      expect(admitted.outcome).toBe("accepted");
+      expect(await seatCount()).toBe(2);
+
+      await seedUser(db, "u_cal", "Cal", "cal@example.com");
+      const tokenCal = await seedInvitation("cal@example.com");
+      const refused = await (await identity()).acceptInvitationByToken(
+        tokenCal,
+        { userId: "u_cal", display: "Cal" },
+        { mailboxProven: true },
+      );
+      expect(refused.outcome).toBe("workspace_full");
+      expect(await seatCount()).toBe(2);
+      // NOTHING consumed: the invitation stands, so a wider limit admits the SAME link.
+      expect(await invitationStatus("cal@example.com")).toBe("pending");
+      seam.limits.members = 3;
+      const admittedLater = await (await identity()).acceptInvitationByToken(
+        tokenCal,
+        { userId: "u_cal", display: "Cal" },
+        { mailboxProven: true },
+      );
+      expect(admittedLater.outcome).toBe("accepted");
+      expect(await seatCount()).toBe(3);
+    } finally {
+      delete seam.limits.members;
+    }
+  });
+
+  it("an accepter who ALREADY holds a seat is never refused at the limit (nothing grows)", async () => {
+    seam.limits.members = 3;
+    try {
+      const token = await seedInvitation("bea@example.com");
+      const again = await (await identity()).acceptInvitationByToken(
+        token,
+        { userId: "u_bea", display: "Bea" },
+        { mailboxProven: true },
+      );
+      expect(again.outcome).toBe("accepted");
+      if (again.outcome === "accepted") {
+        expect(again.alreadyMember).toBe(true);
+      }
+      expect(await seatCount()).toBe(3);
+    } finally {
+      delete seam.limits.members;
+    }
+  });
+});
+
+describe("bindInvitedSeats under a members limit", () => {
+  it("skips a full workspace — the invitation stays pending and binds once there is room", async () => {
+    await seedUser(db, "u_dee", "Dee", "dee@example.com");
+    await seedInvitation("dee@example.com");
+    seam.limits.members = 3;
+    try {
+      const boundAtLimit = await (await identity()).bindInvitedSeats(
+        "u_dee",
+        "dee@example.com",
+        "Dee",
+      );
+      expect(boundAtLimit).toBe(0);
+      expect(await seatCount()).toBe(3);
+      expect(await invitationStatus("dee@example.com")).toBe("pending");
+      seam.limits.members = 10;
+      const boundLater = await (await identity()).bindInvitedSeats(
+        "u_dee",
+        "dee@example.com",
+        "Dee",
+      );
+      expect(boundLater).toBe(1);
+      expect(await seatCount()).toBe(4);
+      expect(await invitationStatus("dee@example.com")).toBe("accepted");
+    } finally {
+      delete seam.limits.members;
+    }
+  });
+});

--- a/web/tests/unit/member-cap-mint.test.ts
+++ b/web/tests/unit/member-cap-mint.test.ts
@@ -106,6 +106,13 @@ describe("acceptInvitationByToken under a members limit", () => {
       expect(await seatCount()).toBe(2);
       // NOTHING consumed: the invitation stands, so a wider limit admits the SAME link.
       expect(await invitationStatus("cal@example.com")).toBe("pending");
+      // The MAILBOX PROOF survives the refusal: possession of the mailed token proved the
+      // address whatever the seat count says, so the account is not a verification
+      // round-trip poorer when it comes back.
+      const verified = await db.q<{ email_verified: boolean }>(
+        `SELECT email_verified FROM web."user" WHERE id = 'u_cal'`,
+      );
+      expect(verified[0]?.email_verified).toBe(true);
       seam.limits.members = 3;
       const admittedLater = await (await identity()).acceptInvitationByToken(
         tokenCal,

--- a/web/tests/unit/registration-gate.test.ts
+++ b/web/tests/unit/registration-gate.test.ts
@@ -28,6 +28,10 @@ vi.mock("@/composition.server", () => ({
     get tenancy() {
       return tenancyMode;
     },
+    // The allow-all default — the seat-binding leg consults the member cap through it.
+    entitlements: {
+      forWorkspace: async () => ({ allows: () => true, limit: () => null }),
+    },
   },
 }));
 

--- a/web/tests/unit/report-harness-state.test.ts
+++ b/web/tests/unit/report-harness-state.test.ts
@@ -132,7 +132,7 @@ describe("the sessions reads carry the block", () => {
   });
 });
 
-describe("the report door shape-checks the block — before the credential resolve", () => {
+describe("the report door shape-checks the block — an authenticated member's 400", () => {
   // The door checks the version spelling too — a REAL 64-hex id, so the harness block is what
   // each case is actually testing.
   const VERSION = "a1".repeat(32);
@@ -141,7 +141,10 @@ describe("the report door shape-checks the block — before the credential resol
     const route = await import("@/routes/api.v1.report");
     const request = new Request(`http://x/api/v1/workspaces/${wsId}/report`, {
       method: "PUT",
-      headers: { "content-type": "application/json" },
+      // Authenticated: the door resolves the credential FIRST (auth-before-body), so the
+      // shape 400s below are a member's answers — an unauthenticated caller meets only the
+      // uniform 404 and never makes the tier buffer a body.
+      headers: { "content-type": "application/json", authorization: "Bearer cs_box" },
       body: JSON.stringify({
         schema_version: 1,
         applied: [{ skill_id: "s_srv", version_id: VERSION, harnesses }],
@@ -191,11 +194,9 @@ describe("the report door shape-checks the block — before the credential resol
     expect(await put(harnesses)).toEqual({ status: 400, message });
   });
 
-  it("a well-shaped block passes the door — the refusal that follows is the guard's, not the parser's", async () => {
-    // No credential rides this request, so a shape-valid body reaches `requireSessionActor` and
-    // gets its uniform miss: proof the parse let the block through.
+  it("a well-shaped block passes the door — the snapshot lands", async () => {
     const { status } = await put([{ slug: "claude-code", state: "current" }]);
-    expect(status).not.toBe(400);
+    expect(status).toBe(204);
   });
 
   /**

--- a/web/tests/unit/verify-action-single.test.ts
+++ b/web/tests/unit/verify-action-single.test.ts
@@ -105,8 +105,7 @@ describe("single tenancy refuses the create arm — route and fence alike", () =
 
   it("the shared precheck reads OFF here — one spelling for /new and this page", async () => {
     const { createWorkspacePrecheck } = await import("@/lib/db/workspace-create.server");
-    const { asUser } = await import("./helpers/scratch-db");
-    expect(await createWorkspacePrecheck(asUser("u_own"))).toBe("off");
+    expect(await createWorkspacePrecheck()).toBe("off");
   });
 
   it("the fence aborts a create choice on its own terms — the uniform null, no row", async () => {

--- a/web/tests/unit/workspace-caps.test.ts
+++ b/web/tests/unit/workspace-caps.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { asUser, createScratchDb, type ScratchDb, seedUser } from "./helpers/scratch-db";
+
+/**
+ * The workspace-creation floors, counted INSIDE `createWorkspaceTx` under the per-person
+ * advisory lock (the TOCTOU fix — both doors share the tx body): the OWNED cap
+ * (`workspaces-owned`, floored at 3 current owner seats; a present row wins even when lower)
+ * and the rolling-day cap (`workspace-create-per-day`, floored at 10). Both refuse TYPED and
+ * honest — never `taken` — and leaving a workspace (the owner seat gone) really frees an
+ * owned slot.
+ */
+
+const seam = vi.hoisted(() => ({
+  limits: {} as Record<string, number>,
+}));
+vi.mock("@/composition.server", () => ({
+  composition: {
+    tenancy: "multi",
+    registration: "open",
+    reservedWorkspaceNames: [],
+    entitlements: {
+      forWorkspace: async () => ({
+        allows: () => true,
+        limit: (key: string) => seam.limits[key] ?? null,
+      }),
+    },
+  },
+}));
+
+let db: ScratchDb;
+
+async function wc() {
+  return import("@/lib/db/workspace-create.server");
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_wscaps");
+  await seedUser(db, "u_maker", "Maker", "maker@example.com");
+  await seedUser(db, "u_low", "Low", "low@example.com");
+  await seedUser(db, "u_daily", "Daily", "daily@example.com");
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("the owned-workspaces floor (3)", () => {
+  it("creates up to the floor, then refuses `owned-limit`; a freed owner seat frees the slot", async () => {
+    const create = (await wc()).createWorkspace;
+    for (const name of ["maker-one", "maker-two", "maker-three"]) {
+      const born = await create(asUser("u_maker", "Maker"), { name, displayName: name });
+      expect(born.outcome).toBe("created");
+    }
+    const fourth = await create(asUser("u_maker", "Maker"), {
+      name: "maker-four",
+      displayName: "maker-four",
+    });
+    expect(fourth.outcome).toBe("owned-limit");
+    // The count is CURRENT owner seats: giving one up frees the slot.
+    await db.q(
+      `DELETE FROM web.seat WHERE user_id = 'u_maker'
+       AND workspace_id = (SELECT id FROM web.workspace WHERE name = 'maker-one')`,
+    );
+    const afterLeave = await create(asUser("u_maker", "Maker"), {
+      name: "maker-four",
+      displayName: "maker-four",
+    });
+    expect(afterLeave.outcome).toBe("created");
+  });
+
+  it("a present `workspaces-owned` row wins even when LOWER than the floor", async () => {
+    seam.limits["workspaces-owned"] = 1;
+    try {
+      const create = (await wc()).createWorkspace;
+      const first = await create(asUser("u_low", "Low"), { name: "low-one", displayName: "one" });
+      expect(first.outcome).toBe("created");
+      const second = await create(asUser("u_low", "Low"), { name: "low-two", displayName: "two" });
+      expect(second.outcome).toBe("owned-limit");
+    } finally {
+      delete seam.limits["workspaces-owned"];
+    }
+  });
+});
+
+describe("the rolling-day floor, now inside the transaction", () => {
+  it("refuses `rate-limited` past the daily cap (audit-counted, so deletes don't reset it)", async () => {
+    seam.limits["workspace-create-per-day"] = 2;
+    try {
+      const create = (await wc()).createWorkspace;
+      const one = await create(asUser("u_daily", "Daily"), { name: "daily-a", displayName: "a" });
+      const two = await create(asUser("u_daily", "Daily"), { name: "daily-b", displayName: "b" });
+      expect([one.outcome, two.outcome]).toEqual(["created", "created"]);
+      // Deleting a workspace does NOT reset the day count — the audit trail is append-only.
+      await db.q(`DELETE FROM web.workspace WHERE name = 'daily-a'`);
+      const third = await create(asUser("u_daily", "Daily"), { name: "daily-c", displayName: "c" });
+      expect(third.outcome).toBe("rate-limited");
+    } finally {
+      delete seam.limits["workspace-create-per-day"];
+    }
+  });
+});


### PR DESCRIPTION
Entitlement-driven, generic workspace limits behind the composition's entitlements seam, plus the abuse-hardening that goes with them. **The OSS default stays allow-all: every check below is a no-op for a self-hosted deployment unless a floor is explicitly stated.** The entitlements seam is the only coupling; refusal copy is neutral. The seam now also states its provider contract: `forWorkspace` may be called while the caller holds an open transaction, so a provider must answer without borrowing the web app's connection pool.

## The keys

| Key | Type | Default (row absent) | Enforced at |
|---|---|---|---|
| `members` | limit | unlimited | invite creation (both DAL doors, in-transaction, prospective for batches — a resend adds no row and still works at the limit) + seat mint (the accept ceremonies refuse a full workspace without consuming the invitation; the login-approval weave answers typed; the workspace-birth owner seat is exempt) |
| `bundles` | limit | unlimited | new bundle identity creation (every genesis door, before any custody call + re-checked in the registration transaction under an advisory lock; an id already active here is no growth, so idempotent retries pass) AND unarchive (archived→active is the same step past the active-row cap, refused before the MCP name claim) |
| `storage-bytes` | limit | unlimited | every custody ingest: the lane's publish/propose, the shared genesis path (GitHub import + MCP import included), and the upstream checker — charged at the candidate's decoded bytes, stat cached a few seconds, fail-open on stat outage (logged) |
| `history-days` | limit | unlimited | revert doors (lane + web, both audit their denials) + a server-computed "Outside history window" row annotation on the history page (nothing deleted — a wider window restores access) |
| `invites-per-day` | limit | **floor: 10/day while the account is under 48h, else 50/day** (a present row wins even when lower) | invite creation, counted in-transaction off the audit trail, prospectively |
| `workspaces-owned` | limit | **floor: 3** (scope `forWorkspace(null)`; present row wins even when lower) | workspace creation, counted inside the birth transaction |
| `reviews` | allows | open | enabling review protection (lane skill/channel protect, the web pin, the workspace default); loosening is never gated, standing protections keep working |

## Security fixes

- **Auth before body read, lane-wide.** Every authenticated `/api/v1` write resolves its credential BEFORE reading the request body. The publish family (whose workspace rides in the body) gets a credential-first session resolve (`requireSessionActorPreBody` — the credential is workspace-scoped and hash-unique, so the session row names its one workspace); the parsed body's workspace is then held against the session's, folding a mismatch into the same uniform 404. An unauthenticated caller can no longer make the tier buffer anything against the 160 MiB publish cap — proven by a test asserting the request body stream is never touched.
- **Invitation hard caps, inside the write transactions and advisory-lock serialized** (route actions bypass every in-process limiter, so the DAL checks ARE the enforcement): at most 10 addresses per submission; the floored rolling-day cap; a per-address server-wide cooldown (3 invites in 7 days) that SKIPS the address rather than failing the submission, reported per address as `already invited recently` — on the web receipts, the wire (`skipped` on the shared invitation DTO, additive), and the CLI receipt. One lock order everywhere (inviter → workspace → addresses sorted; accepts take the workspace lock before their row lock), so the caps hold exactly and cannot deadlock. Migration `0016` adds the partial index the cooldown read rides.
- **Invite-mail hardening**: compose-time control-character strip (our own — never a reliance on the mail library's internal header folding) + 60-char display cut with ellipsis on every user-influenced field, and a transport-level subject strip as a second belt. A `\r\n` smuggled through a workspace name can never reach a subject line (pinned by test).
- **Workspace-create TOCTOU fix**: the daily floor and the new owned-workspaces cap are counted INSIDE the shared birth transaction under `pg_advisory_xact_lock(hashtext(user_id))`, covering both doors (`/new` and the /verify create arm) through the one tx body — two concurrent submits serialize instead of both stepping past the count.
- **Hard caps, not throttles**: the storage admission is deliberately bounded-overshoot (an exact reservation would have to live inside the deliberately policy-free vault); concurrent ingests can exceed the limit by at most their in-flight candidates, and the next stat read enforces again. A workspace-scoped vault accounting read is the named follow-up.
- **Self-host compose**: `mem_limit: 1g` on all three services — a runaway service cannot take the box down with it.

## Test coverage

- `invite-caps.test.ts` — submission cap, prospective member cap (batch overshoot refused whole, resend-at-limit works, live-pending counting, expired rows free their slot), floored daily cap (young/aged accounts + a lower present row winning), per-address cooldown skip at both DAL doors.
- `member-cap-mint.test.ts` — seat-mint backstop: `workspace_full` consumes nothing (the same link admits under a wider limit), the mailbox proof survives the refusal, already-seated accepts never refused, `bindInvitedSeats` skips full workspaces, the login approval answers `workspace-full` typed with the flow and invitation both still pending.
- `workspace-caps.test.ts` — owned floor + freed-slot behavior, lower-row-wins, in-transaction daily floor (deletes don't reset it).
- `auth-before-body.test.ts` — unauthenticated writes across eight routes answer the uniform 404 with the body stream untouched; oversized declared Content-Length refuses up front; the workspace-mismatch bind; the storage refusal envelope; the shared genesis path refusing before any custody call; decoded-byte accounting; fail-open + absent-limit no-op.
- `entitlement-gates.test.ts` — the reviews gate at all four enable doors (no retroactive strip, loosening never gated); the bundle cap refusing before any custody call, ignoring archived rows, passing idempotent retries, covering unarchive, and refusing BEFORE the MCP name claim (a capped restore never re-occupies a registry name); the history window (in/out/absent/unknown-version) + the annotation read.
- `invite-mail-hardening.test.ts` — CRLF-in-workspace-name never reaches the subject; 60-char cut; the transport belt.
- Existing suites updated where they pinned the old body-before-auth order (now: an authenticated member's 400, an unknown credential's uniform 404).

Full matrix green at review close: 94 vitest files / 1191 tests, 152 Playwright, `bun run check`, `cargo xtask ci` (8 gates), `cargo test --workspace` (1894 unit tests + composed e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
