### PR TITLE
The pricing band leads with the free tier

### DIFF
--- a/web/app/components/landing/landing-page.tsx
+++ b/web/app/components/landing/landing-page.tsx
@@ -304,8 +304,8 @@ export function LandingPage({
         <div className={WRAP}>
           <SectionHeading>Setting this up for a team? Email me.</SectionHeading>
           <p className="mt-4 max-w-[62ch] text-dim">
-            I set up the first teams personally. Tell me how your team works with agents and I’ll
-            get your first shared skills flowing. Your feedback shapes what gets built next.
+            I’d love to hear how your team works with agents, and I’m happy to help with the setup.
+            Your feedback shapes what gets built next.
           </p>
           <p className="mt-3 text-[13px] text-faint">Robert, founder</p>
           <div className="mt-5">

--- a/web/app/components/landing/pricing-band.tsx
+++ b/web/app/components/landing/pricing-band.tsx
@@ -3,10 +3,10 @@ import { MicroLabel, SectionHeading, WRAP } from "@/components/landing/landing-k
 
 /**
  * The pricing band: three tiers standing on three steps of the neutral ramp, so the hierarchy is
- * carried by the paper rather than by colour. The free self-hosted tier sits at GROUND level — an
- * outline on the page, not a card raised off it — which keeps it present and honest without
- * competing for the eye; the hosted tier is the only one raised onto `panel` with the card shadow,
- * and it holds the band's two placed objects: the chip and the one accent button.
+ * carried by the paper rather than by colour. The free tier sits at GROUND level — an outline on
+ * the page, not a card raised off it — and carries the one accent button, the page's entry action;
+ * the Team tier is the only one raised onto `panel` with the card shadow and holds the chip.
+ * Self-hosting is a posture, not a plan: it lives in the one line under the card row.
  *
  * A seat is a person, not a machine and not an agent: the number a buyer can count without
  * inspecting anything.
@@ -26,15 +26,15 @@ type Tier = {
 
 const TIERS: Tier[] = [
   {
-    label: "Self-hosted",
+    label: "Free",
     price: "$0",
-    per: "forever",
-    desc: "Apache-2.0. Your machines, your git, your data. Unlimited people.",
+    per: "",
+    desc: "For small teams.",
     feats: [
-      "The complete product",
-      "Unlimited skills and versions",
-      "Contribute-back review",
-      "Community support",
+      "Up to 3 people, unlimited agents and machines",
+      "20 shared bundles, 250 MB of storage",
+      "30 days of version history",
+      "Automatic updates and contribute-back",
     ],
     surface: "ground",
   },
@@ -44,10 +44,10 @@ const TIERS: Tier[] = [
     per: "/ seat / month",
     desc: "Hosted by us. Nothing to run, nothing to keep patched.",
     feats: [
-      "Everything in self-hosted",
-      "Hosted by us, backed up daily",
-      "Zero-downtime updates",
-      "Email support",
+      "Unlimited people",
+      "Unlimited bundles",
+      "Unlimited version history",
+      "Review and approval workflow",
     ],
     surface: "lead",
   },
@@ -77,8 +77,6 @@ const BUTTON_BASE =
   "mt-6 inline-flex h-9 items-center justify-center rounded-md font-mono text-[12.5px] transition-colors focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 active:scale-[0.98]";
 const BUTTON_PRIMARY = `${BUTTON_BASE} bg-accent text-on-accent hover:bg-accent-deep`;
 const BUTTON_QUIET = `${BUTTON_BASE} border border-line bg-panel text-dim hover:bg-panel2`;
-/** On the ground card the quiet button drops its fill too, or it reads as the raised one. */
-const BUTTON_QUIET_ON_GROUND = `${BUTTON_BASE} border border-line-soft text-dim hover:bg-panel`;
 
 function Figure({ price, per }: { price: string; per: string }) {
   return (
@@ -106,11 +104,11 @@ export function PricingBand({
       <div className={WRAP}>
         <MicroLabel>Pricing</MicroLabel>
         <SectionHeading className="max-w-[44ch]">
-          Free to run yourself. Paid when you want it hosted.
+          Start free. Pay when your team grows.
         </SectionHeading>
         <p className="mt-4 max-w-[58ch] text-dim">
-          A seat is anyone who works with an AI agent. Skills, versions, history and contribute-back
-          are unlimited on every tier.
+          A seat is anyone who works with an AI agent. One seat covers all of that person's agents
+          and machines.
         </p>
 
         <div className="mt-6 grid gap-4 lg:grid-cols-3">
@@ -147,14 +145,10 @@ export function PricingBand({
 
               {/* The action sits on the card's floor, so three cards of unequal copy still line up. */}
               <div className="mt-auto flex flex-col">
-                {tier.surface === "lead" ? (
+                {tier.surface === "ground" ? (
                   <Link to={ctaTo} className={BUTTON_PRIMARY}>
                     {ctaLabel}
                   </Link>
-                ) : tier.surface === "ground" ? (
-                  <a href={`${docsHref}/install`} className={BUTTON_QUIET_ON_GROUND}>
-                    Read the install guide
-                  </a>
                 ) : (
                   <a href="#contact" className={BUTTON_QUIET}>
                     Talk to us
@@ -164,6 +158,18 @@ export function PricingBand({
             </div>
           ))}
         </div>
+
+        {/* Self-hosting left the card row deliberately: it is a posture, not a plan. */}
+        <p className="mt-5 text-[13.5px] text-faint">
+          Prefer your own servers? Topos is Apache-2.0, and self-hosting is free.{" "}
+          <a
+            href={`${docsHref}/install`}
+            className="text-dim underline decoration-line underline-offset-[3px] transition-colors hover:text-ink"
+          >
+            Read the install guide
+          </a>
+          .
+        </p>
       </div>
     </section>
   );

--- a/web/tests/e2e/landing.spec.ts
+++ b/web/tests/e2e/landing.spec.ts
@@ -81,18 +81,25 @@ test.describe("the public landing page", () => {
     // figures are asserted as text because the hierarchy between the three cards is carried by the
     // neutral ramp, which the DOM does not spell.
     const pricing = page.locator("#pricing");
-    await expect(pricing).toContainText("Self-hosted");
+    await expect(pricing).toContainText("Free");
     await expect(pricing).toContainText("$0");
     await expect(pricing).toContainText("Team");
     await expect(pricing).toContainText("$20");
     await expect(pricing).toContainText("Enterprise");
     await expect(pricing).toContainText("$40");
     await expect(pricing).toContainText("A seat is anyone who works with an AI agent");
-    // The Team card's hosted-tier lines say only what is true today, in plain words.
-    await expect(pricing).toContainText("Hosted by us, backed up daily");
-    await expect(pricing).toContainText("Zero-downtime updates");
-    await expect(pricing.getByText("Fleet visibility and one-click revert")).toHaveCount(0);
-    await expect(pricing.getByRole("link", { name: "Talk to us" })).toHaveAttribute(
+    // The Free card promises only what the hosted free plan enforces, in plain words.
+    await expect(pricing).toContainText("Up to 3 people, unlimited agents and machines");
+    await expect(pricing).toContainText("30 days of version history");
+    // The Team card's lines say only what is true today.
+    await expect(pricing).toContainText("Unlimited people");
+    await expect(pricing).toContainText("Unlimited version history");
+    await expect(pricing).toContainText("Review and approval workflow");
+    // Self-hosting is the one line under the card row, not a tier.
+    await expect(pricing.getByText("Self-hosted")).toHaveCount(0);
+    await expect(pricing).toContainText("Topos is Apache-2.0, and self-hosting is free");
+    await expect(pricing.getByRole("link", { name: "Read the install guide" })).toBeVisible();
+    await expect(pricing.getByRole("link", { name: "Talk to us" }).first()).toHaveAttribute(
       "href",
       "#contact",
     );
@@ -104,7 +111,7 @@ test.describe("the public landing page", () => {
     await expect(
       page.getByRole("heading", { name: "Setting this up for a team? Email me." }),
     ).toBeVisible();
-    await expect(contact).toContainText("I set up the first teams personally.");
+    await expect(contact).toContainText("love to hear how your team works with agents");
     await expect(contact.getByText("Design partners")).toHaveCount(0);
     await expect(contact.getByText(/closed beta/i)).toHaveCount(0);
     // The order is the contract, not an accident of authoring: the band that answers the pricing


### PR DESCRIPTION
The hosted free tier is now enforced server-side, so the landing shows it: the pricing band becomes Free ($0: up to 3 people with unlimited agents and machines, 20 bundles, 250 MB, 30 days of version history) / Team ($20/seat: unlimited people, bundles, and version history, review and approval workflow) / Enterprise ($40, unchanged). The Self-hosted card leaves the row and becomes one line under it with the install-guide link. Headline: "Start free. Pay when your team grows." The Free card carries the create CTA; Team and Enterprise route to the contact band, whose copy is reworked. The pinned landing spec asserts the new band verbatim.

Suites: check green, vitest 1192/1192, Playwright 152/152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)