### PR TITLE
The catalog is authoritative; the registry is one input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,18 +273,29 @@ jobs:
         run: bun run build && bun run check:bundle
       - name: unit tests
         run: bunx vitest run
-      # The browser binary comes off a CDN that intermittently stalls a connection open
-      # forever; an unbounded download once wedged a release for over an hour. Bound each try
-      # and retry, so a stalled fetch is killed and restarted instead of hanging the gate.
+      # Two independent flakes live in this one command, so it is split in two. The apt system
+      # deps (install-deps) stall on a slow mirror and MUST NOT be killed mid-run — a timeout that
+      # kills apt orphans its lock and dooms every retry ("Could not get lock"); instead retry and
+      # clear a stale lock between tries. The browser binary (install) comes off a CDN that once
+      # held a connection open for over an hour, so THAT is the part bounded by a timeout and
+      # retried — killing a download is safe, killing apt is not.
       - name: install chromium
         run: |
+          deps_ok=0
           for attempt in 1 2 3; do
-            if timeout 300 bunx playwright install --with-deps chromium; then
-              exit 0
-            fi
-            echo "::warning::chromium install attempt ${attempt} stalled or failed; retrying"
+            if sudo bunx playwright install-deps chromium; then deps_ok=1; break; fi
+            echo "::warning::system-deps attempt ${attempt} failed; clearing apt locks"
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock \
+              /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend 2>/dev/null || true
+            sudo dpkg --configure -a 2>/dev/null || true
+            sleep 20
           done
-          echo "::error::chromium install failed after 3 attempts"
+          [ "$deps_ok" = 1 ] || { echo "::error::playwright system deps failed after 3 attempts"; exit 1; }
+          for attempt in 1 2 3; do
+            if timeout 300 bunx playwright install chromium; then exit 0; fi
+            echo "::warning::browser download attempt ${attempt} stalled or failed; retrying"
+          done
+          echo "::error::chromium browser download failed after 3 attempts"
           exit 1
       # The database must exist BEFORE the suite: Playwright launches the web servers ahead of
       # globalSetup, and the served app's readiness probe is a database-backed /healthz.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
         run: |
           deps_ok=0
           for attempt in 1 2 3; do
-            if sudo bunx playwright install-deps chromium; then deps_ok=1; break; fi
+            if bunx playwright install-deps chromium; then deps_ok=1; break; fi
             echo "::warning::system-deps attempt ${attempt} failed; clearing apt locks"
             sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock \
               /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend 2>/dev/null || true

--- a/web/app/lib/db/queries.mcp-catalog.server.ts
+++ b/web/app/lib/db/queries.mcp-catalog.server.ts
@@ -16,6 +16,11 @@ import {
 } from "@/lib/db/queries.custody.server";
 import { bundleMcp, mcpServer, mcpServerRevision } from "@/lib/db/schema.app";
 import { canonicalServerJson } from "@/lib/mcp/fetch.server";
+import {
+  isStaffAuthoredSource,
+  isStrictlyNewer,
+  type McpPrecedenceFacts,
+} from "@/lib/mcp/precedence.server";
 import type { McpProbeOutcome, McpProbeRecord } from "@/lib/mcp/probe-state";
 import type { McpGateRefusal } from "@/lib/mcp/publish-gate.server";
 import { validateServerJson } from "@/lib/mcp/validate.server";
@@ -53,9 +58,22 @@ type Tx = Parameters<Parameters<ReturnType<typeof getDb>["transaction"]>[0]>[0];
  *
  * A document declaring NO `$schema` is not refused: it is a document that made no claim, which is
  * what a hand-written one and this install's own constructions are.
+ *
+ * THE SCHEMA IS A METADATA FORMAT, NOT A FRESHNESS SIGNAL. Every one of these revisions was read
+ * against the extraction below and changes nothing it reads: the same `name`, `description`,
+ * `version`, remotes and packages, at the same paths. An older revision on this list is not an
+ * older or a worse server — the official registry is stuck on earlier formats, and every server
+ * it serves today declares one of the earlier ones. Accepting them is what lets this catalog SEE
+ * what upstream offers; whether a swept document ever DISPLACES what this install already holds is
+ * decided by precedence on the server version and protocol support, never by the schema string
+ * (see the precedence guard in `@/lib/mcp/precedence`). Still fail-closed: this is an explicit
+ * allowlist of the revisions the registry actually publishes under, not "any official host".
  */
 export const KNOWN_MCP_SCHEMA_VERSIONS: readonly string[] = [
   "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
 ];
 
 /** Where a revision's document came from — the fact the version-uniqueness rule reads. */
@@ -711,14 +729,87 @@ async function auditCatalogInTx(
   });
 }
 
+/** One revision's precedence facts and its source, read under the accept lock. */
+async function precedenceReadInTx(
+  tx: Tx,
+  revisionId: string,
+): Promise<{ facts: McpPrecedenceFacts; source: string } | null> {
+  const rows = await tx
+    .select({
+      upstreamVersion: mcpServerRevision.upstreamVersion,
+      protocolVersions: mcpServerRevision.protocolVersions,
+      source: mcpServerRevision.source,
+    })
+    .from(mcpServerRevision)
+    .where(eq(mcpServerRevision.id, revisionId))
+    .limit(1);
+  const row = rows[0];
+  return row === undefined
+    ? null
+    : {
+        facts: { version: row.upstreamVersion, protocolVersions: row.protocolVersions },
+        source: row.source,
+      };
+}
+
+/**
+ * THE PRECEDENCE GUARD, at accept. This is what makes reading older-schema upstream documents safe:
+ * an UPSTREAM candidate never displaces what this install already offers unless it is strictly
+ * newer, and never displaces a version this install AUTHORED (a seed, a staff correction, an
+ * owner's edit) at all — a hand-written row is this catalog's own statement, not a slot for
+ * upstream to fill. Either bar is cleared only by a deliberate staff override, which the accept
+ * records. A candidate this install authored is not "an upstream candidate" and is not guarded
+ * here; a server with nothing current yet has nothing to protect.
+ *
+ * Returns the refusal precedence WOULD raise, or null — the caller both enforces it (absent an
+ * override) and, when overridden, records which bar was crossed.
+ */
+async function acceptPrecedenceRefusal(
+  tx: Tx,
+  server: LockedServer,
+  candidateRevisionId: string,
+): Promise<McpGateRefusal | null> {
+  if (server.currentRevisionId === null) {
+    return null;
+  }
+  const candidate = await precedenceReadInTx(tx, candidateRevisionId);
+  if (candidate === null || candidate.source !== "registry") {
+    return null;
+  }
+  const current = await precedenceReadInTx(tx, server.currentRevisionId);
+  if (current === null) {
+    return null;
+  }
+  if (isStaffAuthoredSource(current.source)) {
+    return {
+      code: "MCP_PRECEDENCE_PROTECTED",
+      message:
+        "this server's current version is one this catalog maintains, not one it took from upstream — replacing it with an upstream document is a deliberate override",
+    };
+  }
+  if (!isStrictlyNewer(candidate.facts, current.facts)) {
+    return {
+      code: "MCP_PRECEDENCE_NOT_NEWER",
+      message: `this upstream version (${candidate.facts.version}) is not newer than the one on offer (${current.facts.version}) — accepting it would move the catalog backward, which is a deliberate override`,
+    };
+  }
+  return null;
+}
+
 /**
  * ACCEPT a candidate: it becomes published and the server's `current` in one transaction, and the
  * server itself stops being a candidate. This is the only way a global revision becomes something
  * people receive — there is no workspace review of a catalog server, by design.
+ *
+ * PRECEDENCE stands between a candidate and the pointer: an upstream candidate that is not strictly
+ * newer than the current, or any upstream candidate over a version this install authored, is
+ * refused unless the caller passes `override` — the deliberate staff act that says "yes, move it
+ * anyway", recorded on the audit line so the crossing is never silent.
  */
 export async function acceptMcpRevision(
   staff: McpCatalogStaff,
   revisionId: string,
+  options: { override?: boolean } = {},
 ): Promise<McpDecisionOutcome> {
   const landed = await inFinalTxOrRefusal<McpDecisionOutcome, McpDecisionOutcome>(
     async (tx, refuse) => {
@@ -753,6 +844,12 @@ export async function acceptMcpRevision(
       if (chore !== null) {
         return refuse({ refusal: chore });
       }
+      // NEVER A DOWNGRADE, and never a silent supersession of a hand-authored row — unless a staff
+      // override says so, in which case the bar it crossed is on the audit line.
+      const precedence = await acceptPrecedenceRefusal(tx, found.server, revisionId);
+      if (precedence !== null && options.override !== true) {
+        return refuse({ refusal: precedence });
+      }
       await tx
         .update(mcpServerRevision)
         .set({ status: "published", publishedAt: new Date(), publishedBy: staff.display })
@@ -767,6 +864,7 @@ export async function acceptMcpRevision(
       await auditCatalogInTx(tx, staff, "mcp_revision_published", revisionId, {
         serverId: found.server.id,
         seq: found.revision.seq,
+        ...(precedence !== null ? { overrode: precedence.code } : {}),
       });
       return { refusal: null, revisionId, serverId: found.server.id };
     },
@@ -1086,7 +1184,9 @@ export async function mcpServerFace(
  */
 export interface McpRegistryRow {
   serverId: string;
-  registryName: string;
+  /** The upstream name, or null for a self-maintained row the feed addresses by its document
+   *  name. Absent from the wire either way — the serializer reads the name off the document. */
+  registryName: string | null;
   authMode: string | null;
   authNote: string | null;
   scopeMenu: unknown;
@@ -1122,7 +1222,7 @@ export function mcpRegistryLimit(raw: string | null): number {
 function registryRowsOf(rows: Record<string, unknown>[]): McpRegistryRow[] {
   return rows.map((row) => ({
     serverId: row.server_id as string,
-    registryName: row.registry_name as string,
+    registryName: (row.registry_name as string | null) ?? null,
     authMode: (row.auth_mode as string | null) ?? null,
     authNote: (row.auth_note as string | null) ?? null,
     scopeMenu: row.scope_menu ?? null,
@@ -1147,6 +1247,12 @@ function paged(rows: McpRegistryRow[], limit: number): McpRegistryPage {
  * A private server is nobody else's business and is not here; neither is a candidate, a delisted
  * row, or a revision staff pulled back. What this returns is exactly what this install stands
  * behind, which is the only thing another install should be able to sync.
+ *
+ * A SELF-MAINTAINED SERVER (`registry_name IS NULL`) is a first-class member of this shelf. A
+ * subregistry offering servers the official registry lacks is the whole value this feed adds, so
+ * the predicate is on being a PUBLISHED GLOBAL row — never on carrying an upstream name. Such a
+ * row is addressed in the feed by the name inside its own document (see below); the serializer
+ * already serves that document verbatim, so nothing else about the answer changes.
  */
 export async function publishedCatalogServers(page: {
   cursor?: string | null;
@@ -1160,7 +1266,7 @@ export async function publishedCatalogServers(page: {
     FROM web.mcp_server ms
     JOIN web.mcp_server_revision r ON r.id = ms.current_revision_id
     WHERE ms.workspace_id IS NULL AND ms.status = 'active'
-      AND ms.registry_name IS NOT NULL AND r.status = 'published'
+      AND r.status = 'published'
       AND (${cursor}::text IS NULL OR ms.id > ${cursor})
     ORDER BY ms.id
     LIMIT ${limit + 1}
@@ -1171,16 +1277,24 @@ export async function publishedCatalogServers(page: {
 /**
  * ONE GLOBAL SERVER'S PUBLISHED HISTORY, newest first — the feed's versions answer. A revision
  * that was rejected, never decided, or pulled back is absent: the feed lists what is on offer.
+ *
+ * THE KEY THE FEED URL CARRIES is the server's upstream `registry_name` where it has one, and the
+ * name inside its CURRENT document where it does not — a self-maintained server is addressed by
+ * the same name the list answer shows for it (`server.name`). The current revision is joined for
+ * exactly that fallback; a self-maintained row with nothing published has no current and so is
+ * unaddressable here, which is the same as saying the feed offers no such server.
  */
-export async function publishedCatalogVersions(registryName: string): Promise<McpRegistryRow[]> {
+export async function publishedCatalogVersions(name: string): Promise<McpRegistryRow[]> {
   const rows = await getDb().execute(sql`
     SELECT ms.id AS server_id, ms.registry_name, ms.auth_mode, ms.auth_note, ms.scope_menu,
            r.id AS revision_id, r.document, r.status, r.published_at,
            (r.id = ms.current_revision_id) AS is_latest
     FROM web.mcp_server ms
+    JOIN web.mcp_server_revision cur ON cur.id = ms.current_revision_id
     JOIN web.mcp_server_revision r ON r.server_id = ms.id
     WHERE ms.workspace_id IS NULL AND ms.status = 'active'
-      AND ms.registry_name = ${registryName} AND r.status = 'published'
+      AND COALESCE(ms.registry_name, cur.document->>'name') = ${name}
+      AND r.status = 'published'
     ORDER BY r.seq DESC
   `);
   return registryRowsOf(rows.rows as Record<string, unknown>[]);
@@ -1194,6 +1308,9 @@ export interface McpTrackedVersion {
   upstreamVersion: string;
   source: string;
   status: string;
+  /** The MCP protocol revisions a probe captured for this version — the precedence tie-break's
+   *  input, null when none was captured. */
+  protocolVersions: unknown;
   /**
    * The stored document, but ONLY for a revision that came FROM upstream. A seed row and a staff
    * correction are this install's own statements about a server — comparing them with upstream's
@@ -1203,11 +1320,23 @@ export interface McpTrackedVersion {
   document: Record<string, unknown> | null;
 }
 
+/** The revision a tracked server currently offers — what an upstream candidate is weighed against
+ *  by precedence, so the sweep never files a downgrade as if it were an update. Null when the
+ *  server has published nothing yet. */
+export interface McpTrackedCurrent {
+  revisionId: string;
+  upstreamVersion: string;
+  protocolVersions: unknown;
+  source: string;
+}
+
 /** One global catalog entry a sweep may ask upstream about, with everything it already holds. */
 export interface McpTrackedServer {
   serverId: string;
   registryName: string;
   status: string;
+  /** The version on offer right now — precedence weighs an upstream candidate against this. */
+  current: McpTrackedCurrent | null;
   /** Every version this catalog holds for the server, newest revision first. */
   held: McpTrackedVersion[];
 }
@@ -1232,8 +1361,9 @@ export interface McpTrackedServer {
  */
 export async function trackedCatalogServers(): Promise<McpTrackedServer[]> {
   const rows = await getDb().execute(sql`
-    SELECT ms.id AS server_id, ms.registry_name, ms.status,
+    SELECT ms.id AS server_id, ms.registry_name, ms.status, ms.current_revision_id,
            r.id AS revision_id, r.upstream_version, r.source, r.status AS revision_status, r.seq,
+           r.protocol_versions,
            CASE WHEN r.source = 'registry' THEN r.document END AS document
     FROM web.mcp_server ms
     LEFT JOIN web.mcp_server_revision r ON r.server_id = ms.id
@@ -1243,6 +1373,7 @@ export async function trackedCatalogServers(): Promise<McpTrackedServer[]> {
     ORDER BY ms.registry_name, r.seq DESC
   `);
   const byServer = new Map<string, McpTrackedServer>();
+  const currentRevisionOf = new Map<string, string | null>();
   for (const raw of rows.rows as Record<string, unknown>[]) {
     const serverId = raw.server_id as string;
     let entry = byServer.get(serverId);
@@ -1251,9 +1382,11 @@ export async function trackedCatalogServers(): Promise<McpTrackedServer[]> {
         serverId,
         registryName: raw.registry_name as string,
         status: raw.status as string,
+        current: null,
         held: [],
       };
       byServer.set(serverId, entry);
+      currentRevisionOf.set(serverId, (raw.current_revision_id as string | null) ?? null);
     }
     // The LEFT JOIN answers one all-null revision for a server that has none yet — a row pulled in
     // whose first candidate has not landed. That is a tracked server with an empty history, not a
@@ -1264,9 +1397,26 @@ export async function trackedCatalogServers(): Promise<McpTrackedServer[]> {
         upstreamVersion: raw.upstream_version as string,
         source: raw.source as string,
         status: raw.revision_status as string,
+        protocolVersions: raw.protocol_versions ?? null,
         document: (raw.document as Record<string, unknown> | null) ?? null,
       });
     }
+  }
+  // The current revision is one of the held ones (the pointer names a revision of this server), so
+  // precedence's input is read out of what is already loaded rather than a second query.
+  for (const entry of byServer.values()) {
+    const currentId = currentRevisionOf.get(entry.serverId) ?? null;
+    const held =
+      currentId === null ? undefined : entry.held.find((v) => v.revisionId === currentId);
+    entry.current =
+      held === undefined
+        ? null
+        : {
+            revisionId: held.revisionId,
+            upstreamVersion: held.upstreamVersion,
+            protocolVersions: held.protocolVersions,
+            source: held.source,
+          };
   }
   return [...byServer.values()];
 }

--- a/web/app/lib/db/queries.mcp-catalog.server.ts
+++ b/web/app/lib/db/queries.mcp-catalog.server.ts
@@ -1285,16 +1285,25 @@ export async function publishedCatalogServers(page: {
  * unaddressable here, which is the same as saying the feed offers no such server.
  */
 export async function publishedCatalogVersions(name: string): Promise<McpRegistryRow[]> {
+  // ONE SERVER, then its history — never a predicate that could match two. A named row is preferred
+  // over a self-maintained one that derives the same name from its document, so a single coherent
+  // history (and a single `isLatest`) is returned even if a name ever resolved to both.
   const rows = await getDb().execute(sql`
+    WITH target AS (
+      SELECT ms.id
+      FROM web.mcp_server ms
+      JOIN web.mcp_server_revision cur ON cur.id = ms.current_revision_id
+      WHERE ms.workspace_id IS NULL AND ms.status = 'active'
+        AND COALESCE(ms.registry_name, cur.document->>'name') = ${name}
+      ORDER BY (ms.registry_name IS NULL), ms.id
+      LIMIT 1
+    )
     SELECT ms.id AS server_id, ms.registry_name, ms.auth_mode, ms.auth_note, ms.scope_menu,
            r.id AS revision_id, r.document, r.status, r.published_at,
            (r.id = ms.current_revision_id) AS is_latest
     FROM web.mcp_server ms
-    JOIN web.mcp_server_revision cur ON cur.id = ms.current_revision_id
     JOIN web.mcp_server_revision r ON r.server_id = ms.id
-    WHERE ms.workspace_id IS NULL AND ms.status = 'active'
-      AND COALESCE(ms.registry_name, cur.document->>'name') = ${name}
-      AND r.status = 'published'
+    WHERE ms.id = (SELECT id FROM target) AND r.status = 'published'
     ORDER BY r.seq DESC
   `);
   return registryRowsOf(rows.rows as Record<string, unknown>[]);
@@ -1454,7 +1463,7 @@ export async function workspaceRegistryServer(
 ): Promise<McpRegistryRow | null> {
   const rows = await getDb().execute(sql`
     ${workspaceRegistrySelect(actor.workspaceId)}
-      AND ms.registry_name = ${registryName}
+      AND COALESCE(ms.registry_name, r.document->>'name') = ${registryName}
     ORDER BY (ms.workspace_id IS NULL), ms.id
     LIMIT 1
   `);
@@ -1462,10 +1471,14 @@ export async function workspaceRegistryServer(
 }
 
 /**
- * WHICH SERVER a registry name names for this workspace, when one is connectable: the
- * workspace's OWN row first, then the global catalog's — the same precedence the registry lane's
- * single-name read keeps, because inside a workspace the workspace's answer is the answer. A
- * name that resolves to two rows must never be a coin flip between two documents.
+ * WHICH SERVER a name names for this workspace, when one is connectable: the workspace's OWN row
+ * first, then the global catalog's — the same precedence the registry lane's single-name read
+ * keeps, because inside a workspace the workspace's answer is the answer. A name that resolves to
+ * two rows must never be a coin flip between two documents.
+ *
+ * A SELF-MAINTAINED global row (no `registry_name`) is addressed by the name inside its current
+ * document, exactly as the feed addresses it — so a catalog server stays connectable by the name a
+ * person knows it by even once it has no upstream name.
  */
 export async function connectableMcpServerByName(
   actor: MemberActor | SessionActor,
@@ -1474,7 +1487,8 @@ export async function connectableMcpServerByName(
   const rows = await getDb().execute(sql`
     SELECT ms.id AS server_id, ms.display_name
     FROM web.mcp_server ms
-    WHERE ms.registry_name = ${registryName}
+    LEFT JOIN web.mcp_server_revision cur ON cur.id = ms.current_revision_id
+    WHERE COALESCE(ms.registry_name, cur.document->>'name') = ${registryName}
       AND ms.status = 'active'
       AND (ms.workspace_id IS NULL OR ms.workspace_id = ${actor.workspaceId})
     ORDER BY (ms.workspace_id IS NULL), ms.id
@@ -1500,7 +1514,8 @@ export async function connectedMcpBundle(
     FROM web.mcp_server ms
     JOIN web.bundle_mcp bm ON bm.server_id = ms.id AND bm.workspace_id = ${actor.workspaceId}
     JOIN web.bundle b ON b.id = bm.bundle_id AND b.workspace_id = bm.workspace_id
-    WHERE ms.registry_name = ${registryName}
+    LEFT JOIN web.mcp_server_revision cur ON cur.id = ms.current_revision_id
+    WHERE COALESCE(ms.registry_name, cur.document->>'name') = ${registryName}
       AND (ms.workspace_id IS NULL OR ms.workspace_id = ${actor.workspaceId})
       AND b.status = 'active'
     ORDER BY (ms.workspace_id IS NULL), ms.id
@@ -1525,8 +1540,7 @@ function workspaceRegistrySelect(workspaceId: string) {
       WHERE c.workspace_id = ${workspaceId}
     ) bm ON bm.server_id = ms.id
     JOIN web.mcp_server_revision r ON r.id = ${MCP_RESOLVED_REVISION}
-    WHERE ms.registry_name IS NOT NULL
-      AND (bm.server_id IS NOT NULL
+    WHERE (bm.server_id IS NOT NULL
            OR (ms.workspace_id = ${workspaceId} AND ms.status = 'active'))
   `;
 }

--- a/web/app/lib/mcp/precedence.server.ts
+++ b/web/app/lib/mcp/precedence.server.ts
@@ -1,0 +1,194 @@
+/**
+ * PRECEDENCE — which of two revisions of one server is the one to hold on to.
+ *
+ * The catalog treats the official registry as ONE INPUT, never the authority. A swept document is
+ * READ so this install can see what upstream offers — even when it declares an older `$schema`
+ * than the canonical one — but it DISPLACES what this install already holds only when it is
+ * STRICTLY NEWER by the signals that describe a server's capability: the server's own `version`,
+ * and, to break a version tie, the MCP protocol revisions its endpoint answered a probe on.
+ *
+ * The `$schema` string never factors in. It is the document's metadata FORMAT, not a freshness
+ * signal: an older-schema document carrying a newer server version is a real update; a newer-schema
+ * document carrying the same or an older server version is not. When two revisions cannot be
+ * ordered — an unparseable version, a missing probe on either side — ours stands. A catalog never
+ * moves backward, or sideways, on a guess.
+ *
+ * This module is PURE comparison, shared by the two places precedence is decided: the upstream
+ * sweep (which files a version it cannot better than ours as informational, never as a downgrade)
+ * and the accept door (which refuses to move the pointer onto one that is not strictly newer, or
+ * onto anything at all over a version this install authored, without a deliberate override).
+ */
+
+/** The facts precedence reads off one revision — nothing about its schema or its prose. */
+export interface McpPrecedenceFacts {
+  /** The `version` string inside the document — the server's own version. */
+  version: string;
+  /**
+   * The MCP protocol revisions this endpoint answered a probe with (an array of revision strings),
+   * or anything else when none was captured. Read defensively: absent is an ambiguity, not a zero.
+   */
+  protocolVersions: unknown;
+}
+
+/**
+ * The sources a current revision can carry that this install AUTHORED — a hand-seeded catalog
+ * entry, a staff correction, an owner's private edit. Upstream never supersedes one of these on
+ * its own; that is a deliberate act with a person's name on it.
+ */
+const STAFF_AUTHORED_SOURCES: ReadonlySet<string> = new Set(["staff", "owner", "seed"]);
+
+/** Was this revision written by this install rather than pulled from upstream? */
+export function isStaffAuthoredSource(source: string): boolean {
+  return STAFF_AUTHORED_SOURCES.has(source);
+}
+
+interface ParsedVersion {
+  /** The dotted numeric release identifiers, e.g. `1.2.3` → `[1, 2, 3]`. */
+  release: number[];
+  /** The dot-separated pre-release identifiers, or null for a plain release. */
+  prerelease: string[] | null;
+}
+
+/**
+ * Parse the subset of the version grammar the registry publishes under — a `vX.Y.Z` release with
+ * an optional `-prerelease`, build metadata (`+…`) discarded as semver says it must be. A version
+ * whose release core is not numeric is not one this can order, and returns null so the caller
+ * keeps what it already holds rather than guessing.
+ */
+function parseVersion(raw: string): ParsedVersion | null {
+  let text = raw.trim();
+  if (text.startsWith("v") || text.startsWith("V")) {
+    text = text.slice(1);
+  }
+  const plus = text.indexOf("+");
+  if (plus >= 0) {
+    text = text.slice(0, plus);
+  }
+  const dash = text.indexOf("-");
+  const core = dash >= 0 ? text.slice(0, dash) : text;
+  const pre = dash >= 0 ? text.slice(dash + 1) : "";
+  const parts = core.split(".");
+  const release: number[] = [];
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) {
+      return null;
+    }
+    release.push(Number(part));
+  }
+  if (release.length === 0) {
+    return null;
+  }
+  return { release, prerelease: pre.length === 0 ? null : pre.split(".") };
+}
+
+/** Compare two release cores, padding the shorter with zeros — `1.2` and `1.2.0` are one. */
+function compareRelease(a: number[], b: number[]): number {
+  const width = Math.max(a.length, b.length);
+  for (let i = 0; i < width; i += 1) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/** Semver pre-release ordering: a release outranks any pre-release of it; identifiers compare
+ * numerically when both are numeric, and a shorter run of identifiers is the smaller one. */
+function comparePrerelease(a: string[] | null, b: string[] | null): number {
+  if (a === null && b === null) {
+    return 0;
+  }
+  if (a === null) {
+    return 1;
+  }
+  if (b === null) {
+    return -1;
+  }
+  const width = Math.max(a.length, b.length);
+  for (let i = 0; i < width; i += 1) {
+    const x = a[i];
+    const y = b[i];
+    if (x === undefined) {
+      return -1;
+    }
+    if (y === undefined) {
+      return 1;
+    }
+    const xNum = /^\d+$/.test(x);
+    const yNum = /^\d+$/.test(y);
+    if (xNum && yNum) {
+      const diff = Number(x) - Number(y);
+      if (diff !== 0) {
+        return diff < 0 ? -1 : 1;
+      }
+    } else if (xNum) {
+      return -1;
+    } else if (yNum) {
+      return 1;
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Order two server versions: -1 / 0 / 1, or NULL when either is not a version this can read. The
+ * null is load-bearing — every caller reads it as "cannot say", and cannot-say keeps ours.
+ */
+export function compareServerVersion(a: string, b: string): number | null {
+  const parsedA = parseVersion(a);
+  const parsedB = parseVersion(b);
+  if (parsedA === null || parsedB === null) {
+    return null;
+  }
+  const byRelease = compareRelease(parsedA.release, parsedB.release);
+  return byRelease !== 0 ? byRelease : comparePrerelease(parsedA.prerelease, parsedB.prerelease);
+}
+
+/**
+ * The newest MCP protocol revision a probe captured, or null. The revisions are date-shaped
+ * strings (`2025-06-18`), which sort chronologically as they sort lexically, so the max string is
+ * the newest revision the endpoint reached.
+ */
+function newestProtocol(protocolVersions: unknown): string | null {
+  if (!Array.isArray(protocolVersions)) {
+    return null;
+  }
+  let newest: string | null = null;
+  for (const entry of protocolVersions) {
+    if (typeof entry === "string" && entry.length > 0 && (newest === null || entry > newest)) {
+      newest = entry;
+    }
+  }
+  return newest;
+}
+
+/**
+ * Is `candidate` strictly newer than `current` — the one question every precedence decision asks?
+ *
+ * A strictly greater server version wins outright; an older one never does. On an EQUAL server
+ * version the tie-break is protocol support: the candidate wins only if its endpoint reached a
+ * strictly newer MCP revision than ours did, and a tie or an unknown on either side is an
+ * ambiguity that keeps ours. The `$schema` is not consulted anywhere in here.
+ */
+export function isStrictlyNewer(
+  candidate: McpPrecedenceFacts,
+  current: McpPrecedenceFacts,
+): boolean {
+  const byVersion = compareServerVersion(candidate.version, current.version);
+  if (byVersion === null) {
+    return false;
+  }
+  if (byVersion !== 0) {
+    return byVersion > 0;
+  }
+  const theirs = newestProtocol(candidate.protocolVersions);
+  const ours = newestProtocol(current.protocolVersions);
+  if (theirs === null || ours === null) {
+    return false;
+  }
+  return theirs > ours;
+}

--- a/web/app/lib/mcp/precedence.server.ts
+++ b/web/app/lib/mcp/precedence.server.ts
@@ -43,20 +43,32 @@ export function isStaffAuthoredSource(source: string): boolean {
 }
 
 interface ParsedVersion {
-  /** The dotted numeric release identifiers, e.g. `1.2.3` → `[1, 2, 3]`. */
-  release: number[];
+  /** The dotted numeric release identifiers, kept as decimal STRINGS so an identifier past the
+   *  safe-integer range still orders losslessly — e.g. `1.2.3` → `["1", "2", "3"]`. */
+  release: string[];
   /** The dot-separated pre-release identifiers, or null for a plain release. */
   prerelease: string[] | null;
 }
 
+/** A run of one or more decimal digits, nothing else. */
+const NUMERIC = /^\d+$/;
+/** One pre-release identifier's alphabet — the semver set, and non-empty. */
+const PRERELEASE_ID = /^[0-9A-Za-z-]+$/;
+
 /**
  * Parse the subset of the version grammar the registry publishes under — a `vX.Y.Z` release with
- * an optional `-prerelease`, build metadata (`+…`) discarded as semver says it must be. A version
- * whose release core is not numeric is not one this can order, and returns null so the caller
- * keeps what it already holds rather than guessing.
+ * an optional `-prerelease`, build metadata (`+…`) discarded as semver says it must be.
+ *
+ * MALFORMED IS AMBIGUOUS, NOT A RELEASE. A non-numeric release identifier, a trailing dash with no
+ * pre-release after it (`2.0.0-`), or a pre-release with an empty/illegal identifier all return
+ * null — the caller reads that as "cannot say" and keeps what it already holds rather than letting
+ * a broken label read as a clean release that could supersede a real one.
  */
 function parseVersion(raw: string): ParsedVersion | null {
   let text = raw.trim();
+  if (text === "") {
+    return null;
+  }
   if (text.startsWith("v") || text.startsWith("V")) {
     text = text.slice(1);
   }
@@ -66,36 +78,60 @@ function parseVersion(raw: string): ParsedVersion | null {
   }
   const dash = text.indexOf("-");
   const core = dash >= 0 ? text.slice(0, dash) : text;
-  const pre = dash >= 0 ? text.slice(dash + 1) : "";
-  const parts = core.split(".");
-  const release: number[] = [];
-  for (const part of parts) {
-    if (!/^\d+$/.test(part)) {
+  // `null` = no pre-release at all; `""` = a dash with nothing after it, which is malformed.
+  const pre = dash >= 0 ? text.slice(dash + 1) : null;
+  const release: string[] = [];
+  for (const part of core.split(".")) {
+    if (!NUMERIC.test(part)) {
       return null;
     }
-    release.push(Number(part));
+    release.push(part);
   }
   if (release.length === 0) {
     return null;
   }
-  return { release, prerelease: pre.length === 0 ? null : pre.split(".") };
+  let prerelease: string[] | null = null;
+  if (pre !== null) {
+    if (pre.length === 0) {
+      return null;
+    }
+    const ids = pre.split(".");
+    for (const id of ids) {
+      if (!PRERELEASE_ID.test(id)) {
+        return null;
+      }
+    }
+    prerelease = ids;
+  }
+  return { release, prerelease };
+}
+
+/** Order two non-negative decimal strings by MAGNITUDE, losslessly — no `Number`, so identifiers
+ * past `Number.MAX_SAFE_INTEGER` still compare correctly. */
+function compareNumeric(a: string, b: string): number {
+  const x = a.replace(/^0+(?=\d)/, "");
+  const y = b.replace(/^0+(?=\d)/, "");
+  if (x.length !== y.length) {
+    return x.length < y.length ? -1 : 1;
+  }
+  return x === y ? 0 : x < y ? -1 : 1;
 }
 
 /** Compare two release cores, padding the shorter with zeros — `1.2` and `1.2.0` are one. */
-function compareRelease(a: number[], b: number[]): number {
+function compareRelease(a: string[], b: string[]): number {
   const width = Math.max(a.length, b.length);
   for (let i = 0; i < width; i += 1) {
-    const x = a[i] ?? 0;
-    const y = b[i] ?? 0;
-    if (x !== y) {
-      return x < y ? -1 : 1;
+    const cmp = compareNumeric(a[i] ?? "0", b[i] ?? "0");
+    if (cmp !== 0) {
+      return cmp;
     }
   }
   return 0;
 }
 
-/** Semver pre-release ordering: a release outranks any pre-release of it; identifiers compare
- * numerically when both are numeric, and a shorter run of identifiers is the smaller one. */
+/** Semver pre-release ordering: a release outranks any pre-release of it; numeric identifiers
+ * compare by magnitude (losslessly), numeric outranks nothing and is outranked by alphanumeric,
+ * and a shorter run of identifiers is the smaller one. */
 function comparePrerelease(a: string[] | null, b: string[] | null): number {
   if (a === null && b === null) {
     return 0;
@@ -116,12 +152,12 @@ function comparePrerelease(a: string[] | null, b: string[] | null): number {
     if (y === undefined) {
       return 1;
     }
-    const xNum = /^\d+$/.test(x);
-    const yNum = /^\d+$/.test(y);
+    const xNum = NUMERIC.test(x);
+    const yNum = NUMERIC.test(y);
     if (xNum && yNum) {
-      const diff = Number(x) - Number(y);
-      if (diff !== 0) {
-        return diff < 0 ? -1 : 1;
+      const cmp = compareNumeric(x, y);
+      if (cmp !== 0) {
+        return cmp;
       }
     } else if (xNum) {
       return -1;

--- a/web/tests/fixtures/mcp/valid/registry-2025-10-17.json
+++ b/web/tests/fixtures/mcp/valid/registry-2025-10-17.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "ai.exa/exa",
+  "description": "Fast, intelligent web search and web crawling.\n\nNew mcp tool: Exa-code is a context tool for coding ",
+  "repository": {
+    "url": "https://github.com/exa-labs/exa-mcp-server",
+    "source": "github"
+  },
+  "version": "3.1.3",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.exa.ai/mcp"
+    }
+  ]
+}

--- a/web/tests/unit/mcp-catalog-feed.test.ts
+++ b/web/tests/unit/mcp-catalog-feed.test.ts
@@ -141,6 +141,30 @@ beforeAll(async () => {
     document("io.github.acme/private", "1.0.0"),
     { current: true },
   );
+
+  // A SELF-MAINTAINED global server: staff maintain it, the official registry has no such name, so
+  // its `registry_name` is null. It is a first-class member of the feed, addressed by the name
+  // inside its own document.
+  await db.q(
+    `INSERT INTO web.mcp_server (id, workspace_id, registry_name, display_name, auth_mode, status)
+     VALUES ('mcps_e_self', NULL, NULL, 'Internal Notes', 'manual', 'active')`,
+  );
+  await db.q(
+    `UPDATE web.mcp_server SET auth_note = 'Ask ops for a token.' WHERE id = 'mcps_e_self'`,
+  );
+  await seedRevision(
+    "mcps_e_self",
+    mcpRevisionId("self_1"),
+    1,
+    document("sh.topos/internal-notes", "0.9.0"),
+  );
+  await seedRevision(
+    "mcps_e_self",
+    mcpRevisionId("self_2"),
+    2,
+    document("sh.topos/internal-notes", "1.0.0"),
+    { current: true },
+  );
 }, 60000);
 
 afterAll(async () => {
@@ -252,6 +276,45 @@ describe("one server's history", () => {
     const res = await get("/mcp-catalog/v0.1/servers/io.github.acme/nope/versions");
     expect(res.status).toBe(404);
     expect(await res.json()).toMatchObject({ title: "Not Found", status: 404 });
+  });
+});
+
+describe("a self-maintained server (no upstream name)", () => {
+  const ENCODED = encodeURIComponent("sh.topos/internal-notes");
+
+  it("appears in the feed, addressed by the name inside its own document", async () => {
+    const res = await get("/mcp-catalog/v0.1/servers?limit=100");
+    const body = (await res.json()) as {
+      servers: { server: { name: string; version: string }; _meta: Record<string, unknown> }[];
+    };
+    const self = body.servers.find((s) => s.server.name === "sh.topos/internal-notes");
+    // A subregistry offering what the official registry lacks is the value-add — it is on the shelf.
+    expect(self).toBeDefined();
+    expect(self?.server.version).toBe("1.0.0");
+    // The curation this catalog adds still rides under our namespace, upstream name or not.
+    const meta = self?._meta as { "sh.topos/catalog": Record<string, unknown> };
+    expect(meta["sh.topos/catalog"]).toMatchObject({ status: "published", isLatest: true });
+  });
+
+  it("resolves its /versions by that document name, newest first", async () => {
+    const res = await get(`/mcp-catalog/v0.1/servers/${ENCODED}/versions`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      servers: {
+        server: { version: string };
+        _meta: { "sh.topos/catalog": { isLatest: boolean } };
+      }[];
+    };
+    expect(body.servers.map((s) => s.server.version)).toEqual(["1.0.0", "0.9.0"]);
+    expect(body.servers[0]?._meta["sh.topos/catalog"].isLatest).toBe(true);
+    expect(body.servers[1]?._meta["sh.topos/catalog"].isLatest).toBe(false);
+  });
+
+  it("`latest` and a named version both resolve by that document name", async () => {
+    const latest = await get(`/mcp-catalog/v0.1/servers/${ENCODED}/versions/latest`);
+    expect(((await latest.json()) as { server: { version: string } }).server.version).toBe("1.0.0");
+    const named = await get(`/mcp-catalog/v0.1/servers/${ENCODED}/versions/0.9.0`);
+    expect(((await named.json()) as { server: { version: string } }).server.version).toBe("0.9.0");
   });
 });
 

--- a/web/tests/unit/mcp-catalog.test.ts
+++ b/web/tests/unit/mcp-catalog.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { canonicalServerJson } from "@/lib/mcp/fetch.server";
 import { validateCandidateFiles } from "@/lib/mcp/validate.server";
@@ -422,6 +424,144 @@ describe("the schema a document declares", () => {
       [serverId],
     );
     expect(rows.map((r) => r.schema_version)).toEqual([known, null]);
+  });
+
+  it("accepts the earlier official revisions the registry actually serves", async () => {
+    const { KNOWN_MCP_SCHEMA_VERSIONS } = await catalog();
+    const url = (rev: string) =>
+      `https://static.modelcontextprotocol.io/schemas/${rev}/server.schema.json`;
+    // Every official revision the registry publishes under is on the allowlist. Reading them is the
+    // point: the registry is stuck on old formats, and refusing them would make the sweep see zero.
+    for (const rev of ["2025-09-16", "2025-09-29", "2025-10-17", "2025-12-11"]) {
+      expect(KNOWN_MCP_SCHEMA_VERSIONS).toContain(url(rev));
+    }
+  });
+
+  it("stores a VERBATIM registry document declaring an older schema, and remembers the schema", async () => {
+    // A real entry fetched from registry.modelcontextprotocol.io, `$schema` 2025-10-17 — older than
+    // this build's canonical 2025-12-11. Its structural shape is one this gate already accepts, so
+    // only the allowlist ever stood between it and the catalog. Filed against a self-maintained row
+    // (null registry_name) so the document's own name governs, and nothing collides with the seed.
+    const doc = JSON.parse(
+      readFileSync(
+        resolve(__dirname, "..", "fixtures", "mcp", "valid", "registry-2025-10-17.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    await db.q(
+      `INSERT INTO web.mcp_server (id, registry_name, display_name, auth_mode, status)
+       VALUES ('mcps_real_1017', NULL, 'Exa', 'none', 'active')`,
+    );
+    const added = await addRevision("mcps_real_1017", {
+      document: doc,
+      source: "registry",
+      publish: false,
+    });
+    expect(added.refusal, added.refusal?.message).toBeNull();
+    const rows = await db.q<{ schema_version: string | null; upstream_version: string }>(
+      `SELECT schema_version, upstream_version FROM web.mcp_server_revision WHERE server_id = $1`,
+      ["mcps_real_1017"],
+    );
+    expect(rows[0]?.schema_version).toBe(
+      "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+    );
+    expect(rows[0]?.upstream_version).toBe("3.1.3");
+  });
+});
+
+/**
+ * PRECEDENCE AT ACCEPT — the guarantee that makes reading older-schema upstream documents safe: an
+ * upstream candidate moves the pointer only when it is strictly newer, and never displaces a version
+ * this install authored without a deliberate override. Capability (server version, protocol) is what
+ * counts; the `$schema` string never is.
+ */
+describe("precedence guards the accept", () => {
+  const staff = { display: "Staff" } as const;
+
+  it("refuses an upstream candidate that is not newer than the current, then honors an override", async () => {
+    const serverId = await seedGlobalServer("mcps_prec_older", "com.example/prec-older");
+    const current = await addRevision(serverId, {
+      document: serverDocument("com.example/prec-older", "2.0.0"),
+      source: "registry",
+      publish: true,
+    });
+    const older = await addRevision(serverId, {
+      document: serverDocument("com.example/prec-older", "1.5.0"),
+      source: "registry",
+      publish: false,
+    });
+    if (current.refusal !== null || older.refusal !== null) {
+      throw new Error("the fixture revisions did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    const refused = await acceptMcpRevision(staff, older.revisionId);
+    expect(refused.refusal?.code).toBe("MCP_PRECEDENCE_NOT_NEWER");
+    // The pointer did not move — a downgrade is not accepted by asking.
+    expect(await currentRevisionOf(serverId)).toBe(current.revisionId);
+    // A deliberate override moves it, and the audit line remembers what bar it crossed.
+    const overridden = await acceptMcpRevision(staff, older.revisionId, { override: true });
+    expect(overridden.refusal).toBeNull();
+    expect(await currentRevisionOf(serverId)).toBe(older.revisionId);
+    const audit = await db.q<{ details: { overrode?: string } }>(
+      `SELECT details FROM web.audit_event WHERE kind = 'mcp_revision_published' AND subject = $1`,
+      [older.revisionId],
+    );
+    expect(audit[0]?.details.overrode).toBe("MCP_PRECEDENCE_NOT_NEWER");
+  });
+
+  it("accepts a strictly-newer upstream version even on an OLDER schema — the schema never blocks it", async () => {
+    const schema = (rev: string) =>
+      `https://static.modelcontextprotocol.io/schemas/${rev}/server.schema.json`;
+    const serverId = await seedGlobalServer("mcps_prec_newer", "com.example/prec-newer");
+    const current = await addRevision(serverId, {
+      document: serverDocument("com.example/prec-newer", "1.0.0", {
+        $schema: schema("2025-12-11"),
+      }),
+      source: "registry",
+      publish: true,
+    });
+    const newer = await addRevision(serverId, {
+      // A newer server version carried on an OLDER schema revision — still a real update.
+      document: serverDocument("com.example/prec-newer", "2.0.0", {
+        $schema: schema("2025-09-16"),
+      }),
+      source: "registry",
+      publish: false,
+    });
+    if (current.refusal !== null || newer.refusal !== null) {
+      throw new Error("the fixture revisions did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    const accepted = await acceptMcpRevision(staff, newer.revisionId);
+    expect(accepted.refusal, accepted.refusal?.message).toBeNull();
+    expect(await currentRevisionOf(serverId)).toBe(newer.revisionId);
+  });
+
+  it("never auto-supersedes a version this install authored, even by a newer upstream one", async () => {
+    const serverId = await seedGlobalServer("mcps_prec_seed", "com.example/prec-seed");
+    // The current is this install's own editorial statement about the server.
+    const seeded = await addRevision(serverId, {
+      document: serverDocument("com.example/prec-seed", "1.0.0"),
+      source: "seed",
+      publish: true,
+    });
+    const upstream = await addRevision(serverId, {
+      // Strictly newer by version — and still not enough to move the pointer on its own.
+      document: serverDocument("com.example/prec-seed", "2.0.0"),
+      source: "registry",
+      publish: false,
+    });
+    if (seeded.refusal !== null || upstream.refusal !== null) {
+      throw new Error("the fixture revisions did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    const refused = await acceptMcpRevision(staff, upstream.revisionId);
+    expect(refused.refusal?.code).toBe("MCP_PRECEDENCE_PROTECTED");
+    expect(await currentRevisionOf(serverId)).toBe(seeded.revisionId);
+    // Staff may still take it, deliberately.
+    const overridden = await acceptMcpRevision(staff, upstream.revisionId, { override: true });
+    expect(overridden.refusal).toBeNull();
+    expect(await currentRevisionOf(serverId)).toBe(upstream.revisionId);
   });
 });
 
@@ -941,6 +1081,10 @@ describe("the tracked set an upstream sweep reads", () => {
     expect(entry?.held[0]?.status).toBe("candidate");
     // What came from upstream carries its document, so a sweep can see whether upstream changed it.
     expect((entry?.held[0]?.document as { version?: string } | null)?.version).toBe("2.0.0");
+    // The version ON OFFER is the published one — what precedence weighs an upstream candidate
+    // against, so the sweep never files a downgrade as if it were an update.
+    expect(entry?.current?.upstreamVersion).toBe("1.0.0");
+    expect(entry?.current?.source).toBe("registry");
   });
 
   it("carries no document for a version this install wrote itself", async () => {

--- a/web/tests/unit/mcp-catalog.test.ts
+++ b/web/tests/unit/mcp-catalog.test.ts
@@ -1054,6 +1054,41 @@ describe("the list a workspace may connect from", () => {
   });
 });
 
+describe("a self-maintained catalog server (no upstream name)", () => {
+  it("stays connectable and served in the workspace lane, keyed by its document name", async () => {
+    const { connectMcpServer, connectableMcpServerByName, workspaceRegistryServer } =
+      await catalog();
+    // The shape reconciliation leaves behind: a global catalog row with no registry_name.
+    await db.q(
+      `INSERT INTO web.mcp_server (id, registry_name, display_name, auth_mode, status)
+       VALUES ('mcps_selfmaint', NULL, 'Self Maintained', 'none', 'active')`,
+    );
+    const published = await addRevision("mcps_selfmaint", {
+      document: serverDocument("com.example/self-maintained", "1.0.0"),
+      source: "staff",
+      publish: true,
+    });
+    if (published.refusal !== null) {
+      throw new Error(published.refusal.message);
+    }
+    const member = asMember(wsId, "u_mem", "member", "Member");
+    // Resolvable by the name inside its document, though it carries no upstream name.
+    const resolved = await connectableMcpServerByName(member, "com.example/self-maintained");
+    expect(resolved?.serverId).toBe("mcps_selfmaint");
+    const connected = await connectMcpServer(member, {
+      serverId: "mcps_selfmaint",
+      displayName: "Self Maintained",
+      to: null,
+    });
+    expect(connected.refusal).toBeNull();
+    // And the workspace's own registry lane serves it under that same name.
+    const inLane = await workspaceRegistryServer(member, "com.example/self-maintained");
+    expect((inLane?.document as { name?: string } | undefined)?.name).toBe(
+      "com.example/self-maintained",
+    );
+  });
+});
+
 describe("the tracked set an upstream sweep reads", () => {
   it("is the global rows that exist upstream, with everything already held", async () => {
     const { trackedCatalogServers } = await catalog();

--- a/web/tests/unit/mcp-precedence.test.ts
+++ b/web/tests/unit/mcp-precedence.test.ts
@@ -39,6 +39,22 @@ describe("ordering server versions", () => {
     expect(compareServerVersion("nightly", "1.0.0")).toBeNull();
     expect(compareServerVersion("1.0.0", "")).toBeNull();
   });
+
+  it("treats a malformed label as ambiguous, never as a clean release", () => {
+    // A trailing dash is an empty pre-release — not `2.0.0`, and it must not be able to supersede.
+    expect(compareServerVersion("2.0.0-", "1.0.0")).toBeNull();
+    expect(compareServerVersion("1.0.0-", "1.0.0")).toBeNull();
+    // An empty pre-release identifier is malformed too.
+    expect(compareServerVersion("1.0.0-rc.", "1.0.0")).toBeNull();
+    expect(compareServerVersion("1.0.0-a..b", "1.0.0")).toBeNull();
+  });
+
+  it("orders identifiers past the safe-integer range losslessly", () => {
+    // 20 digits vs 19 — `Number` would collapse both, this compares by magnitude.
+    expect(compareServerVersion("1.0.10000000000000000000", "1.0.9999999999999999999")).toBe(1);
+    expect(compareServerVersion("1.0.99999999999999999999", "1.0.99999999999999999998")).toBe(1);
+    expect(compareServerVersion("1.0.99999999999999999999", "1.0.99999999999999999999")).toBe(0);
+  });
 });
 
 describe("strictly newer", () => {
@@ -70,6 +86,11 @@ describe("strictly newer", () => {
     expect(isStrictlyNewer(facts("1.0.0", null), facts("1.0.0", ["2025-06-18"]))).toBe(false);
     expect(isStrictlyNewer(facts("1.0.0", ["2025-06-18"]), facts("1.0.0", null))).toBe(false);
     expect(isStrictlyNewer(facts("rolling"), facts("1.0.0"))).toBe(false);
+  });
+
+  it("a malformed candidate label never supersedes a real release", () => {
+    expect(isStrictlyNewer(facts("2.0.0-"), facts("1.0.0"))).toBe(false);
+    expect(isStrictlyNewer(facts("1.0.0-rc."), facts("1.0.0"))).toBe(false);
   });
 });
 

--- a/web/tests/unit/mcp-precedence.test.ts
+++ b/web/tests/unit/mcp-precedence.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareServerVersion,
+  isStaffAuthoredSource,
+  isStrictlyNewer,
+  type McpPrecedenceFacts,
+} from "@/lib/mcp/precedence.server";
+
+/**
+ * PRECEDENCE — the pure comparison that decides whether an upstream document is worth more than the
+ * one this install already holds. No database: the whole point of the module is that the rule is a
+ * function of two revisions' facts and nothing else, and the `$schema` string is never one of them.
+ */
+
+function facts(version: string, protocolVersions: unknown = null): McpPrecedenceFacts {
+  return { version, protocolVersions };
+}
+
+describe("ordering server versions", () => {
+  it("orders the release core numerically, not lexically", () => {
+    expect(compareServerVersion("2.0.0", "10.0.0")).toBe(-1);
+    expect(compareServerVersion("1.2.0", "1.10.0")).toBe(-1);
+    expect(compareServerVersion("1.2.3", "1.2.3")).toBe(0);
+    expect(compareServerVersion("2.0.0", "1.9.9")).toBe(1);
+  });
+
+  it("treats a missing patch as a zero, and tolerates a leading v", () => {
+    expect(compareServerVersion("1.2", "1.2.0")).toBe(0);
+    expect(compareServerVersion("v1.3.0", "1.2.9")).toBe(1);
+  });
+
+  it("ranks a pre-release below its release, per semver", () => {
+    expect(compareServerVersion("1.0.0-rc.1", "1.0.0")).toBe(-1);
+    expect(compareServerVersion("1.0.0-rc.2", "1.0.0-rc.10")).toBe(-1);
+    expect(compareServerVersion("1.0.0-alpha", "1.0.0-beta")).toBe(-1);
+  });
+
+  it("says it cannot order a version it does not read, rather than guessing", () => {
+    expect(compareServerVersion("nightly", "1.0.0")).toBeNull();
+    expect(compareServerVersion("1.0.0", "")).toBeNull();
+  });
+});
+
+describe("strictly newer", () => {
+  it("a greater server version is strictly newer, whatever the schema might be", () => {
+    expect(isStrictlyNewer(facts("2.0.0"), facts("1.0.0"))).toBe(true);
+  });
+
+  it("an older or equal server version is not", () => {
+    expect(isStrictlyNewer(facts("1.0.0"), facts("2.0.0"))).toBe(false);
+    expect(isStrictlyNewer(facts("1.0.0"), facts("1.0.0"))).toBe(false);
+  });
+
+  it("breaks a version tie on protocol support — but only for the candidate, never a tie", () => {
+    // Equal server version, the candidate's endpoint reaches a newer MCP revision → strictly newer.
+    expect(isStrictlyNewer(facts("1.0.0", ["2025-06-18"]), facts("1.0.0", ["2025-03-26"]))).toBe(
+      true,
+    );
+    // Ours reaches the newer revision → keep ours.
+    expect(isStrictlyNewer(facts("1.0.0", ["2025-03-26"]), facts("1.0.0", ["2025-06-18"]))).toBe(
+      false,
+    );
+    // Same protocol on both → a tie keeps ours.
+    expect(isStrictlyNewer(facts("1.0.0", ["2025-06-18"]), facts("1.0.0", ["2025-06-18"]))).toBe(
+      false,
+    );
+  });
+
+  it("keeps ours on any ambiguity — a missing probe or an unreadable version", () => {
+    expect(isStrictlyNewer(facts("1.0.0", null), facts("1.0.0", ["2025-06-18"]))).toBe(false);
+    expect(isStrictlyNewer(facts("1.0.0", ["2025-06-18"]), facts("1.0.0", null))).toBe(false);
+    expect(isStrictlyNewer(facts("rolling"), facts("1.0.0"))).toBe(false);
+  });
+});
+
+describe("which sources this install authored", () => {
+  it("a seed, a staff correction and an owner's edit are protected; upstream is not", () => {
+    expect(isStaffAuthoredSource("seed")).toBe(true);
+    expect(isStaffAuthoredSource("staff")).toBe(true);
+    expect(isStaffAuthoredSource("owner")).toBe(true);
+    expect(isStaffAuthoredSource("registry")).toBe(false);
+  });
+});

--- a/web/tests/unit/mcp-validate.test.ts
+++ b/web/tests/unit/mcp-validate.test.ts
@@ -210,6 +210,23 @@ describe("the accepted summary", () => {
   });
 });
 
+describe("a real document on an older official schema", () => {
+  /**
+   * A verbatim registry entry declaring `$schema` `2025-10-17` — an older revision than this build's
+   * canonical `2025-12-11`. The structural gate reads the same fields at the same paths whatever the
+   * schema line says, so this document passes it UNCHANGED. That the catalog also stores such a
+   * document (its `$schema` is on the allowlist) is proved database-side; here we prove the gate the
+   * allowlist sits in front of never needed loosening to admit it.
+   */
+  it("passes the structural gate unchanged — the schema line is not a structural rule", () => {
+    const result = validateServerJson(bytesOf("valid/registry-2025-10-17.json"));
+    expect(result.ok, result.ok === false ? `${result.code} ${result.message}` : "").toBe(true);
+    expect(result.ok === true && result.summary.name).toBe("ai.exa/exa");
+    expect(result.ok === true && result.summary.transport).toBe("streamable-http");
+    expect(result.ok === true && result.summary.url).toBe("https://mcp.exa.ai/mcp");
+  });
+});
+
 describe("the exact-version grammars", () => {
   /**
    * Probe for probe, the SAME table the client's suite drives. A grammar that answered differently


### PR DESCRIPTION
Follow-up to the MCP-servers-as-rows work. The first production sweep showed the official registry is sparse (missing ~half our curated servers) and behind (its entries declare earlier schema revisions). This makes Topos authoritative and treats the registry as one input we reconcile against, never as something that can overwrite or downgrade us.

- Self-maintained servers (no registry name) are first-class: served in the public feed and addressable by their own document name.
- The sweep accepts the earlier official schema revisions the registry actually serves (2025-09-16/09-29/10-17) — reading a document is not adopting it.
- Never-downgrade precedence at candidate-filing and at accept: capability (server version, then protocol) decides; the schema string never does; a staff/owner-authored current is only replaced by an explicit, audited override.
- An audited, idempotent, staff-runnable job re-verifies "gone" servers against the live registry and detaches only the ones that are truly absent.

Web-only; no CLI or wire-floor change. Gates green: bun run check, vitest 1146/1146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)