### PR TITLE
The catalog accept flow: one proposal per server, and a placeholder yields cleanly

### DIFF
--- a/web/app/lib/db/queries.mcp-catalog.server.ts
+++ b/web/app/lib/db/queries.mcp-catalog.server.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
 import type { MemberActor, OwnerActor, SessionActor } from "@/lib/auth/guards.server";
 import {
   auditInTx,
@@ -17,6 +17,7 @@ import {
 import { bundleMcp, mcpServer, mcpServerRevision } from "@/lib/db/schema.app";
 import { canonicalServerJson } from "@/lib/mcp/fetch.server";
 import {
+  isSeedPlaceholder,
   isStaffAuthoredSource,
   isStrictlyNewer,
   type McpPrecedenceFacts,
@@ -754,12 +755,16 @@ async function precedenceReadInTx(
 
 /**
  * THE PRECEDENCE GUARD, at accept. This is what makes reading older-schema upstream documents safe:
- * an UPSTREAM candidate never displaces what this install already offers unless it is strictly
- * newer, and never displaces a version this install AUTHORED (a seed, a staff correction, an
- * owner's edit) at all — a hand-written row is this catalog's own statement, not a slot for
- * upstream to fill. Either bar is cleared only by a deliberate staff override, which the accept
- * records. A candidate this install authored is not "an upstream candidate" and is not guarded
- * here; a server with nothing current yet has nothing to protect.
+ * an UPSTREAM candidate never displaces a version a PERSON authored here (a staff correction, an
+ * owner's edit) at all — a hand-written row is this catalog's own statement, not a slot for upstream
+ * to fill — and never displaces a real non-seed prior it does not better. Either bar is cleared only
+ * by a deliberate staff override, which the accept records.
+ *
+ * A SEED PLACEHOLDER current is neither bar. The migration stamps every curated server with a
+ * placeholder version under `source = 'seed'`, so it is a starting point waiting for a real
+ * document, not a decision to protect or a version to be judged "behind" — the first real candidate
+ * freely supersedes it, with no override. A candidate this install authored is not "an upstream
+ * candidate" and is not guarded here; a server with nothing current yet has nothing to protect.
  *
  * Returns the refusal precedence WOULD raise, or null — the caller both enforces it (absent an
  * override) and, when overridden, records which bar was crossed.
@@ -778,6 +783,10 @@ async function acceptPrecedenceRefusal(
   }
   const current = await precedenceReadInTx(tx, server.currentRevisionId);
   if (current === null) {
+    return null;
+  }
+  // A seed placeholder is freely superseded — no bar, no override, no semver comparison.
+  if (isSeedPlaceholder(current.source)) {
     return null;
   }
   if (isStaffAuthoredSource(current.source)) {
@@ -802,9 +811,15 @@ async function acceptPrecedenceRefusal(
  * people receive — there is no workspace review of a catalog server, by design.
  *
  * PRECEDENCE stands between a candidate and the pointer: an upstream candidate that is not strictly
- * newer than the current, or any upstream candidate over a version this install authored, is
+ * newer than the current, or any upstream candidate over a version a person authored here, is
  * refused unless the caller passes `override` — the deliberate staff act that says "yes, move it
  * anyway", recorded on the audit line so the crossing is never silent.
+ *
+ * THE SERVER'S OTHER CANDIDATES leave with the same act. Once a person has answered this server's
+ * proposal, the versions that were queued behind it — the older ones the sweep filed on earlier
+ * runs — are not still awaiting a decision, so they move to `superseded` in the same transaction: a
+ * terminal state that is neither published nor a candidate. Nobody rejected them, so they are not
+ * `rejected`; they were overtaken, and the accept's own audit line counts them.
  */
 export async function acceptMcpRevision(
   staff: McpCatalogStaff,
@@ -850,9 +865,10 @@ export async function acceptMcpRevision(
       if (precedence !== null && options.override !== true) {
         return refuse({ refusal: precedence });
       }
+      const now = new Date();
       await tx
         .update(mcpServerRevision)
-        .set({ status: "published", publishedAt: new Date(), publishedBy: staff.display })
+        .set({ status: "published", publishedAt: now, publishedBy: staff.display })
         .where(eq(mcpServerRevision.id, revisionId));
       await tx
         .update(mcpServer)
@@ -861,10 +877,26 @@ export async function acceptMcpRevision(
           ...(found.server.status === "candidate" ? { status: "active" as const } : {}),
         })
         .where(eq(mcpServer.id, found.server.id));
+      // The proposals queued behind this one leave the queue: a person answered this server, so the
+      // OTHER candidates on it are `superseded` — overtaken, not rejected, and no longer waiting.
+      // `decided_at` stays null: that column is the mark of a decision ABOUT a revision (a reject),
+      // and being overtaken is not one; who accepted, and when, is on the audit line below.
+      const superseded = await tx
+        .update(mcpServerRevision)
+        .set({ status: "superseded" })
+        .where(
+          and(
+            eq(mcpServerRevision.serverId, found.server.id),
+            eq(mcpServerRevision.status, "candidate"),
+            ne(mcpServerRevision.id, revisionId),
+          ),
+        )
+        .returning({ id: mcpServerRevision.id });
       await auditCatalogInTx(tx, staff, "mcp_revision_published", revisionId, {
         serverId: found.server.id,
         seq: found.revision.seq,
         ...(precedence !== null ? { overrode: precedence.code } : {}),
+        ...(superseded.length > 0 ? { superseded: superseded.length } : {}),
       });
       return { refusal: null, revisionId, serverId: found.server.id };
     },

--- a/web/app/lib/db/queries.mcp-catalog.server.ts
+++ b/web/app/lib/db/queries.mcp-catalog.server.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, lt, or, sql } from "drizzle-orm";
 import type { MemberActor, OwnerActor, SessionActor } from "@/lib/auth/guards.server";
 import {
   auditInTx,
@@ -815,11 +815,12 @@ async function acceptPrecedenceRefusal(
  * refused unless the caller passes `override` — the deliberate staff act that says "yes, move it
  * anyway", recorded on the audit line so the crossing is never silent.
  *
- * THE SERVER'S OTHER CANDIDATES leave with the same act. Once a person has answered this server's
- * proposal, the versions that were queued behind it — the older ones the sweep filed on earlier
- * runs — are not still awaiting a decision, so they move to `superseded` in the same transaction: a
- * terminal state that is neither published nor a candidate. Nobody rejected them, so they are not
- * `rejected`; they were overtaken, and the accept's own audit line counts them.
+ * THE OLDER CANDIDATES leave with the same act. Once a person has answered this server's proposal,
+ * the versions queued BEHIND it — the ones the sweep filed on earlier runs, ordered by `seq` — are
+ * not still awaiting a decision, so they move to `superseded` in the same transaction: a terminal
+ * state that is neither published nor a candidate. Nobody rejected them, so they are not `rejected`;
+ * they were overtaken, and the accept's own audit line counts them. A NEWER candidate — one the
+ * sweep landed after this one was queued — is a live proposal and is left untouched.
  */
 export async function acceptMcpRevision(
   staff: McpCatalogStaff,
@@ -877,10 +878,14 @@ export async function acceptMcpRevision(
           ...(found.server.status === "candidate" ? { status: "active" as const } : {}),
         })
         .where(eq(mcpServer.id, found.server.id));
-      // The proposals queued behind this one leave the queue: a person answered this server, so the
-      // OTHER candidates on it are `superseded` — overtaken, not rejected, and no longer waiting.
-      // `decided_at` stays null: that column is the mark of a decision ABOUT a revision (a reject),
-      // and being overtaken is not one; who accepted, and when, is on the audit line below.
+      // The proposals queued BEHIND this one leave the queue: a person answered this server, so the
+      // OLDER candidates on it are `superseded` — overtaken, not rejected, and no longer waiting.
+      // "Behind" is by `seq` (monotonic per server under this lock), so ONLY candidates filed before
+      // the accepted one go: a NEWER candidate the sweep landed while this was being reviewed is a
+      // live proposal that must survive — superseding it would lose it for good, since the sweep
+      // will not re-file a registry version it already holds. `decided_at` stays null: that column
+      // marks a decision ABOUT a revision (a reject), and being overtaken is not one; who accepted,
+      // and when, is on the audit line below.
       const superseded = await tx
         .update(mcpServerRevision)
         .set({ status: "superseded" })
@@ -888,7 +893,7 @@ export async function acceptMcpRevision(
           and(
             eq(mcpServerRevision.serverId, found.server.id),
             eq(mcpServerRevision.status, "candidate"),
-            ne(mcpServerRevision.id, revisionId),
+            lt(mcpServerRevision.seq, found.revision.seq),
           ),
         )
         .returning({ id: mcpServerRevision.id });

--- a/web/app/lib/db/schema.app.ts
+++ b/web/app/lib/db/schema.app.ts
@@ -643,9 +643,12 @@ export const mcpServerRevision = webSchema.table(
       .on(table.serverId, table.upstreamVersion)
       .where(sql`source = 'registry'`),
     index("mcp_server_revision_server_idx").on(table.serverId, table.status),
+    // `superseded` is a candidate that was overtaken: accepting one version moves the server's other
+    // pending candidates here in the same transaction — terminal, neither published nor a candidate,
+    // and distinct from `rejected` because nobody decided against it.
     check(
       "mcp_server_revision_status_check",
-      sql`${table.status} in ('candidate', 'published', 'rejected', 'revoked')`,
+      sql`${table.status} in ('candidate', 'published', 'rejected', 'revoked', 'superseded')`,
     ),
     check(
       "mcp_server_revision_source_check",

--- a/web/app/lib/mcp/precedence.server.ts
+++ b/web/app/lib/mcp/precedence.server.ts
@@ -16,7 +16,8 @@
  * This module is PURE comparison, shared by the two places precedence is decided: the upstream
  * sweep (which files a version it cannot better than ours as informational, never as a downgrade)
  * and the accept door (which refuses to move the pointer onto one that is not strictly newer, or
- * onto anything at all over a version this install authored, without a deliberate override).
+ * onto anything at all over a version a PERSON authored here, without a deliberate override — a
+ * seed PLACEHOLDER is neither, and any candidate freely supersedes it).
  */
 
 /** The facts precedence reads off one revision — nothing about its schema or its prose. */
@@ -31,15 +32,31 @@ export interface McpPrecedenceFacts {
 }
 
 /**
- * The sources a current revision can carry that this install AUTHORED — a hand-seeded catalog
- * entry, a staff correction, an owner's private edit. Upstream never supersedes one of these on
- * its own; that is a deliberate act with a person's name on it.
+ * The sources a current revision can carry that a PERSON authored — a staff correction, an owner's
+ * private edit. Upstream never supersedes one of these on its own; that is a deliberate act with a
+ * person's name on it, and displacing it takes a deliberate override.
+ *
+ * A `seed` is deliberately NOT here. The catalog's migration stamps every curated server with a
+ * placeholder version under `source = 'seed'` — a starting point, not a decision somebody made — so
+ * it is a thing to be replaced the moment a real upstream document arrives, never a statement to
+ * protect. `isSeedPlaceholder` names that case for the two callers that must let any candidate pass.
  */
-const STAFF_AUTHORED_SOURCES: ReadonlySet<string> = new Set(["staff", "owner", "seed"]);
+const STAFF_AUTHORED_SOURCES: ReadonlySet<string> = new Set(["staff", "owner"]);
 
-/** Was this revision written by this install rather than pulled from upstream? */
+/** Was this revision written by a PERSON here, rather than pulled from upstream or seeded? */
 export function isStaffAuthoredSource(source: string): boolean {
   return STAFF_AUTHORED_SOURCES.has(source);
+}
+
+/**
+ * Is this current a SEED PLACEHOLDER — the version the catalog's migration stamped on a curated
+ * server before any real document arrived? Such a current is freely superseded by any candidate: it
+ * never requires an override and never causes an upstream version to be judged "behind", because
+ * there is no real prior to move backward from. The accept guard and the upstream sweep both read
+ * this to let a first real document land.
+ */
+export function isSeedPlaceholder(source: string): boolean {
+  return source === "seed";
 }
 
 interface ParsedVersion {

--- a/web/drizzle/0024_mcp-revision-superseded.sql
+++ b/web/drizzle/0024_mcp-revision-superseded.sql
@@ -1,0 +1,10 @@
+-- A REVISION MAY BE SUPERSEDED — overtaken, not decided against.
+--
+-- Accepting one version of a server publishes it and, in the same transaction, moves the server's
+-- OTHER pending candidate revisions out of the queue. They were never rejected — nobody looked at
+-- them and said no — so reusing `rejected` would put words in a person's mouth. `superseded` is the
+-- honest terminal state: neither published nor a candidate, so the feed, the versions history and
+-- delivery (all of which filter on `published`/`candidate`) skip it, while the staff history still
+-- shows it as superseded. This widens the status CHECK to admit it.
+ALTER TABLE "web"."mcp_server_revision" DROP CONSTRAINT "mcp_server_revision_status_check";--> statement-breakpoint
+ALTER TABLE "web"."mcp_server_revision" ADD CONSTRAINT "mcp_server_revision_status_check" CHECK ("web"."mcp_server_revision"."status" in ('candidate', 'published', 'rejected', 'revoked', 'superseded'));

--- a/web/drizzle/meta/0024_snapshot.json
+++ b/web/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,3873 @@
+{
+  "id": "59f57eeb-f5b2-4162-8307-f6b1bac26b8c",
+  "prevId": "c820a974-0c84-4937-9a08-e786dc1d7973",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "web.account": {
+      "name": "account",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.session": {
+      "name": "session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_idx": {
+          "name": "session_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.user": {
+      "name": "user",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_email_lowercase": {
+          "name": "user_email_lowercase",
+          "value": "\"web\".\"user\".\"email\" = lower(\"web\".\"user\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.verification": {
+      "name": "verification",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expires_idx": {
+          "name": "verification_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.approval": {
+      "name": "approval",
+      "schema": "web",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer": {
+          "name": "reviewer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_reviewer_idx": {
+          "name": "approval_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_proposal_id_proposal_id_fk": {
+          "name": "approval_proposal_id_proposal_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "proposal",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_reviewer_user_id_fk": {
+          "name": "approval_reviewer_user_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "reviewer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "approval_proposal_id_reviewer_pk": {
+          "name": "approval_proposal_id_reviewer_pk",
+          "columns": [
+            "proposal_id",
+            "reviewer"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.assignment": {
+      "name": "assignment",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self": {
+          "name": "self",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_person_bundle_once": {
+          "name": "assignment_person_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_bundle_once": {
+          "name": "assignment_everyone_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_person_channel_once": {
+          "name": "assignment_person_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_channel_once": {
+          "name": "assignment_everyone_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_ws_user_idx": {
+          "name": "assignment_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_bundle_idx": {
+          "name": "assignment_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_channel_idx": {
+          "name": "assignment_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_workspace_id_workspace_id_fk": {
+          "name": "assignment_workspace_id_workspace_id_fk",
+          "tableFrom": "assignment",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_seat_fk": {
+          "name": "assignment_seat_fk",
+          "tableFrom": "assignment",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_bundle_fk": {
+          "name": "assignment_bundle_fk",
+          "tableFrom": "assignment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_channel_fk": {
+          "name": "assignment_channel_fk",
+          "tableFrom": "assignment",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assignment_target_check": {
+          "name": "assignment_target_check",
+          "value": "(\"web\".\"assignment\".\"bundle_id\" is null) <> (\"web\".\"assignment\".\"channel_id\" is null)"
+        },
+        "assignment_self_check": {
+          "name": "assignment_self_check",
+          "value": "\"web\".\"assignment\".\"user_id\" is not null or not \"web\".\"assignment\".\"self\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.audit_event": {
+      "name": "audit_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "audit_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_session_id": {
+          "name": "actor_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display": {
+          "name": "actor_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_ws_time": {
+          "name": "audit_ws_time",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_user": {
+          "name": "audit_actor_user",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_session": {
+          "name": "audit_actor_session",
+          "columns": [
+            {
+              "expression": "actor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_session_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_invite_subject": {
+          "name": "audit_invite_subject",
+          "columns": [
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "kind = 'invitation_created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_event_actor_user_id_user_id_fk": {
+          "name": "audit_event_actor_user_id_user_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_event_actor_session_id_cli_session_id_fk": {
+          "name": "audit_event_actor_session_id_cli_session_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle": {
+      "name": "bundle",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "protection": {
+          "name": "protection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_name": {
+          "name": "base_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundle_workspace_id_workspace_id_fk": {
+          "name": "bundle_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_created_by_user_id_fk": {
+          "name": "bundle_created_by_user_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_workspace_id_name_unique": {
+          "name": "bundle_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "bundle_id_workspace_id_unique": {
+          "name": "bundle_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bundle_name_check": {
+          "name": "bundle_name_check",
+          "value": "\"web\".\"bundle\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"bundle\".\"name\") <= 200"
+        },
+        "bundle_kind_check": {
+          "name": "bundle_kind_check",
+          "value": "\"web\".\"bundle\".\"kind\" in ('skill', 'mcp')"
+        },
+        "bundle_status_check": {
+          "name": "bundle_status_check",
+          "value": "\"web\".\"bundle\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "bundle_protection_check": {
+          "name": "bundle_protection_check",
+          "value": "\"web\".\"bundle\".\"protection\" is null or \"web\".\"bundle\".\"protection\" in ('open', 'reviewed')"
+        },
+        "bundle_deleted_check": {
+          "name": "bundle_deleted_check",
+          "value": "(\"web\".\"bundle\".\"status\" = 'deleted') = (\"web\".\"bundle\".\"deleted_at\" is not null)"
+        },
+        "bundle_archived_check": {
+          "name": "bundle_archived_check",
+          "value": "\"web\".\"bundle\".\"status\" <> 'archived' or \"web\".\"bundle\".\"archived_at\" is not null"
+        },
+        "bundle_base_name_check": {
+          "name": "bundle_base_name_check",
+          "value": "\"web\".\"bundle\".\"base_name\" is null or \"web\".\"bundle\".\"status\" <> 'active'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.bundle_mcp": {
+      "name": "bundle_mcp",
+      "schema": "web",
+      "columns": {
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_revision_id": {
+          "name": "pinned_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_mcp_server_idx": {
+          "name": "bundle_mcp_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_mcp_server_id_mcp_server_id_fk": {
+          "name": "bundle_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "mcp_server",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_created_by_user_id_fk": {
+          "name": "bundle_mcp_created_by_user_id_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_bundle_fk": {
+          "name": "bundle_mcp_bundle_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_pinned_revision_fk": {
+          "name": "bundle_mcp_pinned_revision_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "mcp_server_revision",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "pinned_revision_id",
+            "server_id"
+          ],
+          "columnsTo": [
+            "id",
+            "server_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_mcp_workspace_server_unique": {
+          "name": "bundle_mcp_workspace_server_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_name_hint": {
+      "name": "bundle_name_hint",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renamed_by": {
+          "name": "renamed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_name_hint_bundle_idx": {
+          "name": "bundle_name_hint_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_name_hint_workspace_id_workspace_id_fk": {
+          "name": "bundle_name_hint_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_bundle_id_bundle_id_fk": {
+          "name": "bundle_name_hint_bundle_id_bundle_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_renamed_by_user_id_fk": {
+          "name": "bundle_name_hint_renamed_by_user_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "renamed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_name_hint_workspace_id_old_name_pk": {
+          "name": "bundle_name_hint_workspace_id_old_name_pk",
+          "columns": [
+            "workspace_id",
+            "old_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_upstream": {
+      "name": "bundle_upstream",
+      "schema": "web",
+      "columns": {
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_commit": {
+          "name": "last_seen_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bundle_upstream_ws_idx": {
+          "name": "bundle_upstream_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_upstream_bundle_fk": {
+          "name": "bundle_upstream_bundle_fk",
+          "tableFrom": "bundle_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bundle_upstream_repo_check": {
+          "name": "bundle_upstream_repo_check",
+          "value": "\"web\".\"bundle_upstream\".\"repo\" ~ '^[^/]+/[^/]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel": {
+      "name": "channel",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_one_default": {
+          "name": "channel_one_default",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_workspace_id_workspace_id_fk": {
+          "name": "channel_workspace_id_workspace_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_created_by_user_id_fk": {
+          "name": "channel_created_by_user_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "channel_workspace_id_name_unique": {
+          "name": "channel_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "channel_id_workspace_id_unique": {
+          "name": "channel_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "channel_mode_check": {
+          "name": "channel_mode_check",
+          "value": "\"web\".\"channel\".\"mode\" in ('open', 'curated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel_bundle": {
+      "name": "channel_bundle",
+      "schema": "web",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bundle_bundle_idx": {
+          "name": "channel_bundle_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bundle_added_by_user_id_fk": {
+          "name": "channel_bundle_added_by_user_id_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_channel_fk": {
+          "name": "channel_bundle_channel_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_bundle_fk": {
+          "name": "channel_bundle_bundle_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_bundle_channel_id_bundle_id_pk": {
+          "name": "channel_bundle_channel_id_bundle_id_pk",
+          "columns": [
+            "channel_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.cli_session": {
+      "name": "cli_session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_sha256": {
+          "name": "credential_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cli_session_workspace_idx": {
+          "name": "cli_session_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_session_user_idx": {
+          "name": "cli_session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_session_seat_fk": {
+          "name": "cli_session_seat_fk",
+          "tableFrom": "cli_session",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_session_credential_sha256_unique": {
+          "name": "cli_session_credential_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_session_status_check": {
+          "name": "cli_session_status_check",
+          "value": "\"web\".\"cli_session\".\"status\" in ('pending', 'active')"
+        },
+        "cli_session_credential_sha256_check": {
+          "name": "cli_session_credential_sha256_check",
+          "value": "octet_length(\"web\".\"cli_session\".\"credential_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.decline": {
+      "name": "decline",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "decline_ws_user_idx": {
+          "name": "decline_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decline_seat_fk": {
+          "name": "decline_seat_fk",
+          "tableFrom": "decline",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "decline_bundle_fk": {
+          "name": "decline_bundle_fk",
+          "tableFrom": "decline",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decline_user_id_bundle_id_unique": {
+          "name": "decline_user_id_bundle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.invitation": {
+      "name": "invitation",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_sha256": {
+          "name": "token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_bundle_id": {
+          "name": "hint_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_channel_id": {
+          "name": "hint_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_pending_once": {
+          "name": "invitation_pending_once",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_workspace_id_workspace_id_fk": {
+          "name": "invitation_workspace_id_workspace_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitation_accepted_by_user_id_fk": {
+          "name": "invitation_accepted_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_sha256_unique": {
+          "name": "invitation_token_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_email_check": {
+          "name": "invitation_email_check",
+          "value": "\"web\".\"invitation\".\"email\" = lower(\"web\".\"invitation\".\"email\")"
+        },
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"web\".\"invitation\".\"role\" in ('owner', 'reviewer', 'member')"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "\"web\".\"invitation\".\"status\" in ('pending', 'accepted', 'revoked', 'declined')"
+        },
+        "invitation_token_sha256_check": {
+          "name": "invitation_token_sha256_check",
+          "value": "\"web\".\"invitation\".\"token_sha256\" is null or octet_length(\"web\".\"invitation\".\"token_sha256\") = 32"
+        },
+        "invitation_hint_one_check": {
+          "name": "invitation_hint_one_check",
+          "value": "\"web\".\"invitation\".\"hint_bundle_id\" is null or \"web\".\"invitation\".\"hint_channel_id\" is null"
+        },
+        "invitation_accepted_check": {
+          "name": "invitation_accepted_check",
+          "value": "(\"web\".\"invitation\".\"status\" = 'accepted') = (\"web\".\"invitation\".\"accepted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.login_flow": {
+      "name": "login_flow",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_code_sha256": {
+          "name": "flow_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_name": {
+          "name": "requested_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preselect_workspace": {
+          "name": "preselect_workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_workspace_id": {
+          "name": "approved_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token_sha256": {
+          "name": "invite_token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "login_flow_live_code": {
+          "name": "login_flow_live_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "login_flow_expires_idx": {
+          "name": "login_flow_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "login_flow_approved_by_user_id_fk": {
+          "name": "login_flow_approved_by_user_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "login_flow_session_id_cli_session_id_fk": {
+          "name": "login_flow_session_id_cli_session_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "login_flow_flow_code_sha256_unique": {
+          "name": "login_flow_flow_code_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flow_code_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "login_flow_flow_code_sha256_check": {
+          "name": "login_flow_flow_code_sha256_check",
+          "value": "octet_length(\"web\".\"login_flow\".\"flow_code_sha256\") = 32"
+        },
+        "login_flow_invite_token_sha256_check": {
+          "name": "login_flow_invite_token_sha256_check",
+          "value": "\"web\".\"login_flow\".\"invite_token_sha256\" is null or octet_length(\"web\".\"login_flow\".\"invite_token_sha256\") = 32"
+        },
+        "login_flow_status_check": {
+          "name": "login_flow_status_check",
+          "value": "\"web\".\"login_flow\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "login_flow_binding_check": {
+          "name": "login_flow_binding_check",
+          "value": "\"web\".\"login_flow\".\"binding\" in ('device', 'loopback')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mail_event": {
+      "name": "mail_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_event_time_idx": {
+          "name": "mail_event_time_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mail_event_kind_check": {
+          "name": "mail_event_kind_check",
+          "value": "\"web\".\"mail_event\".\"kind\" in ('magic-link', 'invite', 'auth-verify', 'auth-reset')"
+        },
+        "mail_event_outcome_check": {
+          "name": "mail_event_outcome_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" in ('ok', 'failed')"
+        },
+        "mail_event_code_check": {
+          "name": "mail_event_code_check",
+          "value": "\"web\".\"mail_event\".\"code\" is null or \"web\".\"mail_event\".\"code\" in ('unconfigured', 'send_failed')"
+        },
+        "mail_event_code_on_failure_check": {
+          "name": "mail_event_code_on_failure_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" = 'failed' or \"web\".\"mail_event\".\"code\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_server": {
+      "name": "mcp_server",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registry_name": {
+          "name": "registry_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_note": {
+          "name": "auth_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_menu": {
+          "name": "scope_menu",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_server_global_registry_name": {
+          "name": "mcp_server_global_registry_name",
+          "columns": [
+            {
+              "expression": "registry_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "workspace_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_private_registry_name": {
+          "name": "mcp_server_private_registry_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registry_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "workspace_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_workspace_idx": {
+          "name": "mcp_server_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_workspace_id_workspace_id_fk": {
+          "name": "mcp_server_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_current_revision_fk": {
+          "name": "mcp_server_current_revision_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "mcp_server_revision",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "current_revision_id",
+            "id"
+          ],
+          "columnsTo": [
+            "id",
+            "server_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_server_auth_mode_check": {
+          "name": "mcp_server_auth_mode_check",
+          "value": "\"web\".\"mcp_server\".\"auth_mode\" is null or \"web\".\"mcp_server\".\"auth_mode\" in ('none', 'oauth', 'manual')"
+        },
+        "mcp_server_status_check": {
+          "name": "mcp_server_status_check",
+          "value": "\"web\".\"mcp_server\".\"status\" in ('candidate', 'active', 'delisted')"
+        },
+        "mcp_server_registry_name_check": {
+          "name": "mcp_server_registry_name_check",
+          "value": "\"web\".\"mcp_server\".\"registry_name\" is null or \"web\".\"mcp_server\".\"registry_name\" ~ '^[^/]+/[^/]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_server_revision": {
+      "name": "mcp_server_revision",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "upstream_version": {
+          "name": "upstream_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probe_outcome": {
+          "name": "probe_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probed_at": {
+          "name": "probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_versions": {
+          "name": "protocol_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification": {
+          "name": "verification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_server_revision_upstream_version": {
+          "name": "mcp_server_revision_upstream_version",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upstream_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'registry'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_revision_server_idx": {
+          "name": "mcp_server_revision_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_revision_server_id_mcp_server_id_fk": {
+          "name": "mcp_server_revision_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_server_revision",
+          "tableTo": "mcp_server",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_revision_seq_unique": {
+          "name": "mcp_server_revision_seq_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "server_id",
+            "seq"
+          ]
+        },
+        "mcp_server_revision_id_server_unique": {
+          "name": "mcp_server_revision_id_server_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mcp_server_revision_id_shape_check": {
+          "name": "mcp_server_revision_id_shape_check",
+          "value": "\"web\".\"mcp_server_revision\".\"id\" ~ '^mcpr_[0-9a-f]{32}$'"
+        },
+        "mcp_server_revision_status_check": {
+          "name": "mcp_server_revision_status_check",
+          "value": "\"web\".\"mcp_server_revision\".\"status\" in ('candidate', 'published', 'rejected', 'revoked', 'superseded')"
+        },
+        "mcp_server_revision_source_check": {
+          "name": "mcp_server_revision_source_check",
+          "value": "\"web\".\"mcp_server_revision\".\"source\" in ('registry', 'staff', 'owner', 'seed')"
+        },
+        "mcp_server_revision_seq_check": {
+          "name": "mcp_server_revision_seq_check",
+          "value": "\"web\".\"mcp_server_revision\".\"seq\" >= 1"
+        },
+        "mcp_server_revision_probe_outcome_check": {
+          "name": "mcp_server_revision_probe_outcome_check",
+          "value": "\"web\".\"mcp_server_revision\".\"probe_outcome\" is null or \"web\".\"mcp_server_revision\".\"probe_outcome\" in ('responding', 'sign_in_required', 'not_verifiable', 'not_responding')"
+        },
+        "mcp_server_revision_probed_check": {
+          "name": "mcp_server_revision_probed_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"probe_outcome\" is null) = (\"web\".\"mcp_server_revision\".\"probed_at\" is null)"
+        },
+        "mcp_server_revision_remote_check": {
+          "name": "mcp_server_revision_remote_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"url\" is null) = (\"web\".\"mcp_server_revision\".\"transport\" is null)"
+        },
+        "mcp_server_revision_url_check": {
+          "name": "mcp_server_revision_url_check",
+          "value": "\"web\".\"mcp_server_revision\".\"url\" is null or \"web\".\"mcp_server_revision\".\"url\" ~ '^https://'"
+        },
+        "mcp_server_revision_published_check": {
+          "name": "mcp_server_revision_published_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"status\" in ('published', 'revoked')) = (\"web\".\"mcp_server_revision\".\"published_at\" is not null)"
+        },
+        "mcp_server_revision_published_by_check": {
+          "name": "mcp_server_revision_published_by_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"published_at\" is null) = (\"web\".\"mcp_server_revision\".\"published_by\" is null)"
+        },
+        "mcp_server_revision_rejected_check": {
+          "name": "mcp_server_revision_rejected_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"status\" = 'rejected') = (\"web\".\"mcp_server_revision\".\"decided_at\" is not null)"
+        },
+        "mcp_server_revision_decided_by_check": {
+          "name": "mcp_server_revision_decided_by_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"decided_at\" is null) = (\"web\".\"mcp_server_revision\".\"decided_by\" is null)"
+        },
+        "mcp_server_revision_revoked_check": {
+          "name": "mcp_server_revision_revoked_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"status\" = 'revoked') = (\"web\".\"mcp_server_revision\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.notice": {
+      "name": "notice",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notice_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notice_inbox": {
+          "name": "notice_inbox",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "acked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notice_ws_idx": {
+          "name": "notice_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notice_user_id_user_id_fk": {
+          "name": "notice_user_id_user_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notice_workspace_id_workspace_id_fk": {
+          "name": "notice_workspace_id_workspace_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.op_receipt": {
+      "name": "op_receipt",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_id": {
+          "name": "op_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_sha256": {
+          "name": "request_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "op_receipt_retention_idx": {
+          "name": "op_receipt_retention_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "op_receipt_session_id_cli_session_id_fk": {
+          "name": "op_receipt_session_id_cli_session_id_fk",
+          "tableFrom": "op_receipt",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "op_receipt_workspace_id_session_id_op_id_pk": {
+          "name": "op_receipt_workspace_id_session_id_op_id_pk",
+          "columns": [
+            "workspace_id",
+            "session_id",
+            "op_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "op_receipt_request_sha256_check": {
+          "name": "op_receipt_request_sha256_check",
+          "value": "octet_length(\"web\".\"op_receipt\".\"request_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal": {
+      "name": "proposal",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_version_id": {
+          "name": "candidate_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason": {
+          "name": "resolved_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_open": {
+          "name": "proposal_open",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_one_open_per_candidate": {
+          "name": "proposal_one_open_per_candidate",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_proposed_by_user_id_fk": {
+          "name": "proposal_proposed_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_resolved_by_user_id_fk": {
+          "name": "proposal_resolved_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_bundle_fk": {
+          "name": "proposal_bundle_fk",
+          "tableFrom": "proposal",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_status_check": {
+          "name": "proposal_status_check",
+          "value": "\"web\".\"proposal\".\"status\" in ('open', 'approved', 'rejected', 'withdrawn')"
+        },
+        "proposal_resolved_check": {
+          "name": "proposal_resolved_check",
+          "value": "(\"web\".\"proposal\".\"status\" = 'open') = (\"web\".\"proposal\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal_comment": {
+      "name": "proposal_comment",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display": {
+          "name": "author_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_comment_thread_idx": {
+          "name": "proposal_comment_thread_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_comment_author_user_id_user_id_fk": {
+          "name": "proposal_comment_author_user_id_user_id_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_comment_bundle_fk": {
+          "name": "proposal_comment_bundle_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_comment_body_check": {
+          "name": "proposal_comment_body_check",
+          "value": "char_length(\"web\".\"proposal_comment\".\"body\") between 1 and 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.seat": {
+      "name": "seat",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seat_user_idx": {
+          "name": "seat_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seat_workspace_id_workspace_id_fk": {
+          "name": "seat_workspace_id_workspace_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_user_id_user_id_fk": {
+          "name": "seat_user_id_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_invited_by_user_id_fk": {
+          "name": "seat_invited_by_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "seat_workspace_id_user_id_pk": {
+          "name": "seat_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "seat_role_check": {
+          "name": "seat_role_check",
+          "value": "\"web\".\"seat\".\"role\" in ('owner', 'reviewer', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.session_bundle_state": {
+      "name": "session_bundle_state",
+      "schema": "web",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_version_id": {
+          "name": "applied_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_state": {
+          "name": "harness_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_bundle_state_bundle_idx": {
+          "name": "session_bundle_state_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_bundle_state_session_id_cli_session_id_fk": {
+          "name": "session_bundle_state_session_id_cli_session_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_bundle_state_bundle_id_bundle_id_fk": {
+          "name": "session_bundle_state_bundle_id_bundle_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_bundle_state_session_id_bundle_id_pk": {
+          "name": "session_bundle_state_session_id_bundle_id_pk",
+          "columns": [
+            "session_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.version_upstream": {
+      "name": "version_upstream",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "version_upstream_bundle_fk": {
+          "name": "version_upstream_bundle_fk",
+          "tableFrom": "version_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "version_upstream_bundle_id_version_id_pk": {
+          "name": "version_upstream_bundle_id_version_id_pk",
+          "columns": [
+            "bundle_id",
+            "version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.workspace": {
+      "name": "workspace",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_code_sha256": {
+          "name": "claim_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protection_default": {
+          "name": "protection_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "staleness_window_ms": {
+          "name": "staleness_window_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800000
+        },
+        "registration": {
+          "name": "registration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_only'"
+        },
+        "session_approval": {
+          "name": "session_approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "session_max_age_ms": {
+          "name": "session_max_age_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_name_unique": {
+          "name": "workspace_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_name_check": {
+          "name": "workspace_name_check",
+          "value": "\"web\".\"workspace\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"workspace\".\"name\") <= 100"
+        },
+        "workspace_claim_code_sha256_check": {
+          "name": "workspace_claim_code_sha256_check",
+          "value": "\"web\".\"workspace\".\"claim_code_sha256\" is null or octet_length(\"web\".\"workspace\".\"claim_code_sha256\") = 32"
+        },
+        "workspace_protection_default_check": {
+          "name": "workspace_protection_default_check",
+          "value": "\"web\".\"workspace\".\"protection_default\" in ('open', 'reviewed')"
+        },
+        "workspace_registration_check": {
+          "name": "workspace_registration_check",
+          "value": "\"web\".\"workspace\".\"registration\" in ('invite_only', 'open')"
+        },
+        "workspace_session_approval_check": {
+          "name": "workspace_session_approval_check",
+          "value": "\"web\".\"workspace\".\"session_approval\" in ('off', 'on')"
+        },
+        "workspace_session_max_age_check": {
+          "name": "workspace_session_max_age_check",
+          "value": "\"web\".\"workspace\".\"session_max_age_ms\" is null or \"web\".\"workspace\".\"session_max_age_ms\" > 0"
+        },
+        "workspace_claim_state_check": {
+          "name": "workspace_claim_state_check",
+          "value": "(\"web\".\"workspace\".\"claimed_at\" is null) <> (\"web\".\"workspace\".\"claim_code_sha256\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "web": "web"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1787200100000,
       "tag": "0023_mcp-revision-id-shape",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1787200200000,
+      "tag": "0024_mcp-revision-superseded",
+      "breakpoints": true
     }
   ]
 }

--- a/web/tests/unit/mcp-catalog.test.ts
+++ b/web/tests/unit/mcp-catalog.test.ts
@@ -537,17 +537,45 @@ describe("precedence guards the accept", () => {
     expect(await currentRevisionOf(serverId)).toBe(newer.revisionId);
   });
 
-  it("never auto-supersedes a version this install authored, even by a newer upstream one", async () => {
+  it("never auto-supersedes a version a PERSON authored here, even by a newer upstream one", async () => {
+    const serverId = await seedGlobalServer("mcps_prec_staff", "com.example/prec-staff");
+    // The current is a staff correction — this install's own hand-authored statement.
+    const authored = await addRevision(serverId, {
+      document: serverDocument("com.example/prec-staff", "1.0.0"),
+      source: "staff",
+      publish: true,
+    });
+    const upstream = await addRevision(serverId, {
+      // Strictly newer by version — and still not enough to move the pointer on its own.
+      document: serverDocument("com.example/prec-staff", "2.0.0"),
+      source: "registry",
+      publish: false,
+    });
+    if (authored.refusal !== null || upstream.refusal !== null) {
+      throw new Error("the fixture revisions did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    const refused = await acceptMcpRevision(staff, upstream.revisionId);
+    expect(refused.refusal?.code).toBe("MCP_PRECEDENCE_PROTECTED");
+    expect(await currentRevisionOf(serverId)).toBe(authored.revisionId);
+    // Staff may still take it, deliberately.
+    const overridden = await acceptMcpRevision(staff, upstream.revisionId, { override: true });
+    expect(overridden.refusal).toBeNull();
+    expect(await currentRevisionOf(serverId)).toBe(upstream.revisionId);
+  });
+
+  it("lets any candidate freely supersede a SEED placeholder current — no override, even older", async () => {
     const serverId = await seedGlobalServer("mcps_prec_seed", "com.example/prec-seed");
-    // The current is this install's own editorial statement about the server.
+    // The current is a SEED placeholder — the version the migration stamped, not a decision.
     const seeded = await addRevision(serverId, {
       document: serverDocument("com.example/prec-seed", "1.0.0"),
       source: "seed",
       publish: true,
     });
+    // Upstream's real version is OLDER by semver, yet it still moves the pointer: a seed is a
+    // placeholder to be replaced the moment a real document arrives, never a prior to move back from.
     const upstream = await addRevision(serverId, {
-      // Strictly newer by version — and still not enough to move the pointer on its own.
-      document: serverDocument("com.example/prec-seed", "2.0.0"),
+      document: serverDocument("com.example/prec-seed", "0.0.1"),
       source: "registry",
       publish: false,
     });
@@ -555,13 +583,101 @@ describe("precedence guards the accept", () => {
       throw new Error("the fixture revisions did not land");
     }
     const { acceptMcpRevision } = await catalog();
-    const refused = await acceptMcpRevision(staff, upstream.revisionId);
-    expect(refused.refusal?.code).toBe("MCP_PRECEDENCE_PROTECTED");
-    expect(await currentRevisionOf(serverId)).toBe(seeded.revisionId);
-    // Staff may still take it, deliberately.
-    const overridden = await acceptMcpRevision(staff, upstream.revisionId, { override: true });
-    expect(overridden.refusal).toBeNull();
+    // A plain accept — no override — succeeds, and the candidate becomes what the catalog offers.
+    const accepted = await acceptMcpRevision(staff, upstream.revisionId);
+    expect(accepted.refusal, accepted.refusal?.message).toBeNull();
     expect(await currentRevisionOf(serverId)).toBe(upstream.revisionId);
+    // The audit line records no override, because none was needed.
+    const audit = await db.q<{ details: { overrode?: string } }>(
+      `SELECT details FROM web.audit_event WHERE kind = 'mcp_revision_published' AND subject = $1`,
+      [upstream.revisionId],
+    );
+    expect(audit[0]?.details.overrode).toBeUndefined();
+  });
+});
+
+/**
+ * ACCEPTING ONE CANDIDATE CLEARS THE SERVER'S OTHERS. A person answered this server's proposal, so
+ * the versions the sweep filed behind it are not still awaiting a decision — they move to
+ * `superseded` in the same act: gone from the queue, but not `rejected`, because nobody said no.
+ */
+describe("accepting one candidate clears the server's other candidates", () => {
+  const staff = { display: "Staff" } as const;
+
+  it("supersedes the accepted server's other pending candidates, and only that server's", async () => {
+    const serverId = await seedGlobalServer("mcps_super", "com.example/super", {
+      status: "candidate",
+    });
+    // Three candidates the sweep filed on successive runs — oldest first.
+    const v1 = await addRevision(serverId, {
+      document: serverDocument("com.example/super", "1.0.1"),
+      source: "registry",
+      publish: false,
+    });
+    const v2 = await addRevision(serverId, {
+      document: serverDocument("com.example/super", "1.0.2"),
+      source: "registry",
+      publish: false,
+    });
+    const v3 = await addRevision(serverId, {
+      document: serverDocument("com.example/super", "1.0.3"),
+      source: "registry",
+      publish: false,
+    });
+    // A second server's candidate must be untouched: supersession is scoped to the accepted server.
+    const otherId = await seedGlobalServer("mcps_super_other", "com.example/super-other", {
+      status: "candidate",
+    });
+    const other = await addRevision(otherId, {
+      document: serverDocument("com.example/super-other", "1.0.0"),
+      source: "registry",
+      publish: false,
+    });
+    if (
+      v1.refusal !== null ||
+      v2.refusal !== null ||
+      v3.refusal !== null ||
+      other.refusal !== null
+    ) {
+      throw new Error("the fixture revisions did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    const accepted = await acceptMcpRevision(staff, v3.revisionId);
+    expect(accepted.refusal, accepted.refusal?.message).toBeNull();
+    // The accepted one is published and current; the two behind it are superseded — not rejected.
+    expect(await revisionStatus(v3.revisionId)).toBe("published");
+    expect(await currentRevisionOf(serverId)).toBe(v3.revisionId);
+    expect(await revisionStatus(v1.revisionId)).toBe("superseded");
+    expect(await revisionStatus(v2.revisionId)).toBe("superseded");
+    // The other server's candidate is left exactly where it was.
+    expect(await revisionStatus(other.revisionId)).toBe("candidate");
+    // The accept's audit line counts the two it overtook.
+    const audit = await db.q<{ details: { superseded?: number } }>(
+      `SELECT details FROM web.audit_event WHERE kind = 'mcp_revision_published' AND subject = $1`,
+      [v3.revisionId],
+    );
+    expect(audit[0]?.details.superseded).toBe(2);
+  });
+
+  it("counts nothing when the accepted revision was the only candidate", async () => {
+    const serverId = await seedGlobalServer("mcps_super_solo", "com.example/super-solo", {
+      status: "candidate",
+    });
+    const only = await addRevision(serverId, {
+      document: serverDocument("com.example/super-solo", "1.0.0"),
+      source: "registry",
+      publish: false,
+    });
+    if (only.refusal !== null) {
+      throw new Error("the fixture revision did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    expect((await acceptMcpRevision(staff, only.revisionId)).refusal).toBeNull();
+    const audit = await db.q<{ details: { superseded?: number } }>(
+      `SELECT details FROM web.audit_event WHERE kind = 'mcp_revision_published' AND subject = $1`,
+      [only.revisionId],
+    );
+    expect(audit[0]?.details.superseded).toBeUndefined();
   });
 });
 

--- a/web/tests/unit/mcp-catalog.test.ts
+++ b/web/tests/unit/mcp-catalog.test.ts
@@ -659,6 +659,46 @@ describe("accepting one candidate clears the server's other candidates", () => {
     expect(audit[0]?.details.superseded).toBe(2);
   });
 
+  it("leaves a candidate NEWER than the accepted one untouched — only older ones are superseded", async () => {
+    const serverId = await seedGlobalServer("mcps_super_race", "com.example/super-race", {
+      status: "candidate",
+    });
+    // v1 (oldest), v2, then v3 — as though the sweep landed v3 while v2 was under review.
+    const v1 = await addRevision(serverId, {
+      document: serverDocument("com.example/super-race", "1.0.1"),
+      source: "registry",
+      publish: false,
+    });
+    const v2 = await addRevision(serverId, {
+      document: serverDocument("com.example/super-race", "1.0.2"),
+      source: "registry",
+      publish: false,
+    });
+    const v3 = await addRevision(serverId, {
+      document: serverDocument("com.example/super-race", "1.0.3"),
+      source: "registry",
+      publish: false,
+    });
+    if (v1.refusal !== null || v2.refusal !== null || v3.refusal !== null) {
+      throw new Error("the fixture revisions did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    // Accept the MIDDLE one — a stale accept, or a deliberate pick of a version that is not newest.
+    const accepted = await acceptMcpRevision(staff, v2.revisionId);
+    expect(accepted.refusal, accepted.refusal?.message).toBeNull();
+    expect(await revisionStatus(v2.revisionId)).toBe("published");
+    expect(await currentRevisionOf(serverId)).toBe(v2.revisionId);
+    // The older one is superseded; the NEWER one stays a live candidate — losing it would be
+    // permanent, since the sweep never re-files a registry version it already holds.
+    expect(await revisionStatus(v1.revisionId)).toBe("superseded");
+    expect(await revisionStatus(v3.revisionId)).toBe("candidate");
+    const audit = await db.q<{ details: { superseded?: number } }>(
+      `SELECT details FROM web.audit_event WHERE kind = 'mcp_revision_published' AND subject = $1`,
+      [v2.revisionId],
+    );
+    expect(audit[0]?.details.superseded).toBe(1);
+  });
+
   it("counts nothing when the accepted revision was the only candidate", async () => {
     const serverId = await seedGlobalServer("mcps_super_solo", "com.example/super-solo", {
       status: "candidate",

--- a/web/tests/unit/mcp-precedence.test.ts
+++ b/web/tests/unit/mcp-precedence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   compareServerVersion,
+  isSeedPlaceholder,
   isStaffAuthoredSource,
   isStrictlyNewer,
   type McpPrecedenceFacts,
@@ -94,11 +95,22 @@ describe("strictly newer", () => {
   });
 });
 
-describe("which sources this install authored", () => {
-  it("a seed, a staff correction and an owner's edit are protected; upstream is not", () => {
-    expect(isStaffAuthoredSource("seed")).toBe(true);
+describe("which sources a person authored", () => {
+  it("a staff correction and an owner's edit are protected; upstream and a seed are not", () => {
     expect(isStaffAuthoredSource("staff")).toBe(true);
     expect(isStaffAuthoredSource("owner")).toBe(true);
     expect(isStaffAuthoredSource("registry")).toBe(false);
+    // A seed is a placeholder the migration stamped, not a decision a person made — so it does not
+    // stand between upstream and the pointer, and any candidate freely supersedes it.
+    expect(isStaffAuthoredSource("seed")).toBe(false);
+  });
+});
+
+describe("which current is a seed placeholder", () => {
+  it("only a seed is one — a staff, owner or upstream current is a real prior", () => {
+    expect(isSeedPlaceholder("seed")).toBe(true);
+    expect(isSeedPlaceholder("staff")).toBe(false);
+    expect(isSeedPlaceholder("owner")).toBe(false);
+    expect(isSeedPlaceholder("registry")).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes surfaced by the first real staff use of the MCP catalog panel.

- The candidate queue collapses to one proposal per server (its newest), instead of a row per intermediate version.
- A seeded placeholder version is no longer treated as a human decision: accepting a real upstream version over it needs no override, and the sweep files a real-but-lower-numbered version as a candidate rather than "behind". Override and version-behind semantics remain for human-authored currents and genuine downgrades.
- Accepting a version supersedes the server's other pending candidates in the same transaction (new terminal 'superseded' status), so an accepted server stops showing stale proposals.

Web-only; no CLI or wire-floor change. Gates: bun run check, vitest 1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)