### PR TITLE
A server with no known version carries none

### DIFF
--- a/bins/topos/src/mcp_render.rs
+++ b/bins/topos/src/mcp_render.rs
@@ -57,7 +57,9 @@ pub(crate) struct ServerDoc {
     pub name: String,
     /// The one-line description the document states.
     pub description: String,
-    /// The version string the document states.
+    /// The version string the document states — EMPTY when it names none (an editorial or
+    /// self-maintained server we never stamped a fake version on). A receipt reads the empty as
+    /// "no version" and prints none, rather than a bare `v` in front of nothing.
     pub version: String,
     /// The FIRST `streamable-http` remote with a url, and its literal headers.
     pub remote: Option<RemoteEndpoint>,
@@ -223,6 +225,8 @@ pub(crate) fn parse_server_json(bytes: &[u8]) -> Result<ServerDoc, String> {
     Ok(ServerDoc {
         name: text("name"),
         description: text("description"),
+        // A missing `version` reads as empty — a server that names none. The receipt renders the
+        // empty as no version at all, never a bare `v`; nothing here fabricates a stand-in.
         version: text("version"),
         remote,
         packages,

--- a/bins/topos/src/ops/add_mcp.rs
+++ b/bins/topos/src/ops/add_mcp.rs
@@ -481,6 +481,17 @@ fn what_it_is(doc: &ServerDoc) -> String {
     }
 }
 
+/// The ` v<version>` a receipt prints for the server's own version — an empty string for a server
+/// that names none, so the line reads `MCP server <name> — …` rather than a bare `v` in front of
+/// nothing. A fabricated version was never the honest answer; its absence is.
+fn version_note(doc: &ServerDoc) -> String {
+    if doc.version.is_empty() {
+        String::new()
+    } else {
+        format!(" v{}", doc.version)
+    }
+}
+
 /// Fold what landed into the add receipt: the typed `mcp` block, then the prose note — WHAT this
 /// row now points at. Where the entries went is the converge's own answer, and the add's receipt
 /// already carries it per surface; this adds the one thing that answer cannot: which server.
@@ -492,9 +503,9 @@ fn fold_receipt(data: &mut AddData, doc: &ServerDoc, agents: Vec<String>) {
     medit::push_note_line(
         data,
         format!(
-            "MCP server {} v{} — {}{auth}",
+            "MCP server {}{} — {}{auth}",
             doc.name,
-            doc.version,
+            version_note(doc),
             what_it_is(doc)
         ),
     );
@@ -661,6 +672,20 @@ mod tests {
             classify_mcp_source("topos.sh/acme", Some("example.com"), &nothing_exists),
             McpSourceShape::RegistryName
         );
+    }
+
+    /// A server that names no version is rendered without one — the receipt reads its name straight
+    /// into the em-dash, never a bare `v` in front of nothing.
+    #[test]
+    fn a_versionless_server_is_rendered_without_a_version() {
+        let versioned = doc_with(vec![package("npm", "@acme/x", "stdio")]);
+        assert_eq!(version_note(&versioned), " v1.0.0");
+        assert_eq!(summarize(&versioned, Vec::new()).version, "1.0.0");
+
+        let mut versionless = doc_with(vec![package("npm", "@acme/x", "stdio")]);
+        versionless.version = String::new();
+        // The receipt line shows the name straight into the em-dash, never `<name> v — …`.
+        assert_eq!(version_note(&versionless), "");
     }
 
     /// A bare word names neither a server nor a link; so does nothing at all.

--- a/contracts/schemas/add-data.schema.json
+++ b/contracts/schemas/add-data.schema.json
@@ -430,7 +430,7 @@
           "type": "string"
         },
         "version": {
-          "description": "The version the document declares.",
+          "description": "The version the document declares, or EMPTY for a server that names none — an editorial or\nself-maintained one. Never a fabricated stand-in: a receipt renders the empty as no version\nat all (`what_it_is` beside it), rather than printing a bare `v`.",
           "type": "string"
         }
       },

--- a/crates/topos-types/src/results.rs
+++ b/crates/topos-types/src/results.rs
@@ -1389,7 +1389,9 @@ pub struct McpServerSummary {
     pub server: String,
     /// The publisher's one-line summary (the registry caps it at 100 characters).
     pub description: String,
-    /// The version the document declares.
+    /// The version the document declares, or EMPTY for a server that names none — an editorial or
+    /// self-maintained one. Never a fabricated stand-in: a receipt renders the empty as no version
+    /// at all (`what_it_is` beside it), rather than printing a bare `v`.
     pub version: String,
     /// The endpoint an agent will call — always `https`, never a template. EMPTY when the bundle
     /// offers no address at all: a server may be a package every machine runs instead (see

--- a/web/app/components/skill/mcp-server.tsx
+++ b/web/app/components/skill/mcp-server.tsx
@@ -27,7 +27,8 @@ export interface McpServerView {
   currentRevisionId: string | null;
   resolved: {
     revisionId: string;
-    upstreamVersion: string;
+    /** The version delivered here, or NULL when the revision names none (shown as "unversioned"). */
+    upstreamVersion: string | null;
     status: string;
     url: string | null;
     transport: string | null;
@@ -37,7 +38,8 @@ export interface McpServerView {
   revisions: {
     revisionId: string;
     seq: number;
-    upstreamVersion: string;
+    /** The revision's version, or NULL when it named none (shown as "unversioned"). */
+    upstreamVersion: string | null;
     status: string;
     source: string;
     publishedAt: string | null;
@@ -59,6 +61,19 @@ function AuthChip({ auth }: { auth: McpServerView["authMode"] }) {
   ) : (
     <Chip tone="neutral">no sign-in</Chip>
   );
+}
+
+/**
+ * The one line saying which version this workspace receives. A versionless revision is named
+ * honestly — "the current version" / "this version" — never a fabricated number.
+ */
+function followingLine(pinnedRevisionId: string | null, version: string | null): string {
+  if (pinnedRevisionId === null) {
+    return version === null
+      ? "Following the current version."
+      : `Following the current version, ${version}.`;
+  }
+  return version === null ? "Pinned to this version." : `Pinned to ${version}.`;
 }
 
 export function McpServerPanel({ server, isOwner }: { server: McpServerView; isOwner: boolean }) {
@@ -113,9 +128,7 @@ export function McpServerPanel({ server, isOwner }: { server: McpServerView; isO
             ) : (
               <>
                 <p className="text-dim text-sm">
-                  {server.pinnedRevisionId === null
-                    ? `Following the current version, ${server.resolved.upstreamVersion}.`
-                    : `Pinned to ${server.resolved.upstreamVersion}.`}
+                  {followingLine(server.pinnedRevisionId, server.resolved.upstreamVersion)}
                 </p>
                 {server.resolved.status === "revoked" && (
                   <p className="text-amber-800 text-sm" data-testid="mcp-revoked">
@@ -151,7 +164,13 @@ function RevisionList({ server }: { server: McpServerView }) {
               key={revision.revisionId}
               className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2.5"
             >
-              <span className="font-mono text-[13px] text-ink">{revision.upstreamVersion}</span>
+              {revision.upstreamVersion === null ? (
+                // A versionless revision reads as a LABEL, not a fake number — set apart from a
+                // real, mono-spaced version string so nobody mistakes the word for one.
+                <span className="text-[13px] text-faint italic">unversioned</span>
+              ) : (
+                <span className="font-mono text-[13px] text-ink">{revision.upstreamVersion}</span>
+              )}
               {revision.revisionId === server.resolved?.revisionId && (
                 <Chip tone="accent">delivered here</Chip>
               )}

--- a/web/app/lib/db/queries.mcp-catalog.server.ts
+++ b/web/app/lib/db/queries.mcp-catalog.server.ts
@@ -17,7 +17,6 @@ import {
 import { bundleMcp, mcpServer, mcpServerRevision } from "@/lib/db/schema.app";
 import { canonicalServerJson } from "@/lib/mcp/fetch.server";
 import {
-  isSeedPlaceholder,
   isStaffAuthoredSource,
   isStrictlyNewer,
   type McpPrecedenceFacts,
@@ -89,8 +88,9 @@ export type McpAuthMode = "none" | "oauth" | "manual";
 export interface McpRevisionFacts {
   /** The embedded registry name — the server's identity upstream and here. */
   registryName: string;
-  /** The `version` inside the document. */
-  upstreamVersion: string;
+  /** The `version` inside the document, or NULL when it names none (an editorial/self-maintained
+   *  server we never stamped a fake version on). Registry documents always carry a real one. */
+  upstreamVersion: string | null;
   /** The declared `$schema`, or null when the document declared none. */
   schemaVersion: string | null;
   /** The placed remote's transport, null for a document that offers only packages. */
@@ -111,9 +111,22 @@ export type McpFactsOutcome =
  * placed one (first `streamable-http` wins — the client's own selection order). A document that
  * cannot be shared at all — no credential, no unpinned package, nothing to run — is refused here
  * for exactly the reason it would be refused anywhere else, in the same words.
+ *
+ * `requireVersion` carries the ONE rule that differs by provenance: a REGISTRY document must name a
+ * version (the official registry mandates it, and we ingest what it gives), while an editorial or
+ * self-maintained document may carry none — in which case `upstreamVersion` comes back NULL, and
+ * we never fabricate a number to fill it. A document that DECLARES one of the known official
+ * `$schema`s still needs a version whatever its provenance: every one of those schemas requires the
+ * field, so a document claiming a schema while omitting it is self-contradictory, and we would be
+ * storing (and serving verbatim) something no schema-aware reader would accept. The honest shape of
+ * a version-less server is to make NO schema claim — exactly what a hand-written document does.
  */
-export function mcpRevisionFacts(document: Record<string, unknown>): McpFactsOutcome {
+export function mcpRevisionFacts(
+  document: Record<string, unknown>,
+  options: { requireVersion: boolean },
+): McpFactsOutcome {
   const declared = document.$schema;
+  const declaresKnownSchema = typeof declared === "string";
   if (declared !== undefined && declared !== null) {
     if (typeof declared !== "string" || !KNOWN_MCP_SCHEMA_VERSIONS.includes(declared)) {
       return {
@@ -125,7 +138,9 @@ export function mcpRevisionFacts(document: Record<string, unknown>): McpFactsOut
       };
     }
   }
-  const validated = validateServerJson(new TextEncoder().encode(canonicalServerJson(document)));
+  const validated = validateServerJson(new TextEncoder().encode(canonicalServerJson(document)), {
+    requireVersion: options.requireVersion || declaresKnownSchema,
+  });
   if (!validated.ok) {
     return { refusal: { code: validated.code, message: validated.message } };
   }
@@ -239,7 +254,12 @@ export async function addMcpRevisionInTx(
   if (server === undefined) {
     return { refusal: SERVER_NOT_FOUND };
   }
-  const read = mcpRevisionFacts(write.document);
+  // Only a REGISTRY document is held to carrying a version — upstream mandates one, and a missing
+  // version there is upstream giving us less than it promised. Everything we author ourselves may
+  // honestly have none.
+  const read = mcpRevisionFacts(write.document, {
+    requireVersion: write.source === "registry",
+  });
   if (read.refusal !== null) {
     return { refusal: read.refusal };
   }
@@ -262,14 +282,17 @@ export async function addMcpRevisionInTx(
       return { refusal: chore };
     }
   }
-  if (write.source === "registry") {
+  // A registry document always carries a version (required above), so the one-document-per-version
+  // rule has a real key to compare — the `!== null` both narrows the type and states that fact.
+  const registryVersion = read.facts.upstreamVersion;
+  if (write.source === "registry" && registryVersion !== null) {
     const held = await tx
       .select({ id: mcpServerRevision.id })
       .from(mcpServerRevision)
       .where(
         and(
           eq(mcpServerRevision.serverId, serverId),
-          eq(mcpServerRevision.upstreamVersion, read.facts.upstreamVersion),
+          eq(mcpServerRevision.upstreamVersion, registryVersion),
           eq(mcpServerRevision.source, "registry"),
         ),
       )
@@ -278,7 +301,7 @@ export async function addMcpRevisionInTx(
       return {
         refusal: {
           code: "MCP_VERSION_HELD",
-          message: `version ${read.facts.upstreamVersion} of this server is already recorded from upstream`,
+          message: `version ${registryVersion} of this server is already recorded from upstream`,
         },
       };
     }
@@ -358,7 +381,9 @@ export async function createPrivateMcpServer(
   details: McpServerDetails,
   document: Record<string, unknown>,
 ): Promise<McpServerOutcome> {
-  const read = mcpRevisionFacts(document);
+  // A workspace's OWN server is ours to author — its document may name no version, and we store
+  // that truthfully rather than stamp a placeholder on it.
+  const read = mcpRevisionFacts(document, { requireVersion: false });
   if (read.refusal !== null) {
     return { refusal: read.refusal };
   }
@@ -757,14 +782,16 @@ async function precedenceReadInTx(
  * THE PRECEDENCE GUARD, at accept. This is what makes reading older-schema upstream documents safe:
  * an UPSTREAM candidate never displaces a version a PERSON authored here (a staff correction, an
  * owner's edit) at all — a hand-written row is this catalog's own statement, not a slot for upstream
- * to fill — and never displaces a real non-seed prior it does not better. Either bar is cleared only
- * by a deliberate staff override, which the accept records.
+ * to fill — and never displaces a real prior it does not better. Either bar is cleared only by a
+ * deliberate staff override, which the accept records.
  *
- * A SEED PLACEHOLDER current is neither bar. The migration stamps every curated server with a
- * placeholder version under `source = 'seed'`, so it is a starting point waiting for a real
- * document, not a decision to protect or a version to be judged "behind" — the first real candidate
- * freely supersedes it, with no override. A candidate this install authored is not "an upstream
- * candidate" and is not guarded here; a server with nothing current yet has nothing to protect.
+ * A CURRENT WITH NO COMPARABLE VERSION is neither bar. A seed placeholder — or any editorial row
+ * this catalog holds without a real version — carries a NULL version, which is a starting point
+ * waiting for a real document, not a decision to protect or a number to be judged "behind": the
+ * first real candidate freely supersedes it, with no override and no comparison. (This is the
+ * general rule the old seed special-case falls out of, now that a seed row honestly carries no
+ * version.) A candidate this install authored is not "an upstream candidate" and is not guarded
+ * here; a server with nothing current yet has nothing to protect.
  *
  * Returns the refusal precedence WOULD raise, or null — the caller both enforces it (absent an
  * override) and, when overridden, records which bar was crossed.
@@ -785,10 +812,8 @@ async function acceptPrecedenceRefusal(
   if (current === null) {
     return null;
   }
-  // A seed placeholder is freely superseded — no bar, no override, no semver comparison.
-  if (isSeedPlaceholder(current.source)) {
-    return null;
-  }
+  // A person's own statement is protected whatever its version — provenance, not a number, is the
+  // bar; upstream displaces it only by a deliberate override.
   if (isStaffAuthoredSource(current.source)) {
     return {
       code: "MCP_PRECEDENCE_PROTECTED",
@@ -796,6 +821,13 @@ async function acceptPrecedenceRefusal(
         "this server's current version is one this catalog maintains, not one it took from upstream — replacing it with an upstream document is a deliberate override",
     };
   }
+  // No comparable version to move backward from — a seed placeholder, or any versionless editorial
+  // current — is freely superseded: no bar, no override, no semver comparison.
+  if (current.facts.version === null) {
+    return null;
+  }
+  // Two real versions: an upstream candidate must be strictly newer, or moving the pointer is a
+  // downgrade, which is a deliberate override.
   if (!isStrictlyNewer(candidate.facts, current.facts)) {
     return {
       code: "MCP_PRECEDENCE_NOT_NEWER",
@@ -1062,7 +1094,8 @@ export interface McpCatalogRow {
   url: string | null;
   transport: string | null;
   revisionId: string;
-  upstreamVersion: string;
+  /** The version the current revision offers, or NULL when it names none. */
+  upstreamVersion: string | null;
   /** The catalog name of the ACTIVE bundle this workspace connected it as, or null. One
    *  connection per server per workspace, so this is the answer, not one of several. */
   connectedAs: string | null;
@@ -1078,7 +1111,8 @@ export interface McpCatalogRow {
 export interface McpRevisionRow {
   revisionId: string;
   seq: number;
-  upstreamVersion: string;
+  /** The `version` this revision stored, or NULL when it named none. */
+  upstreamVersion: string | null;
   status: string;
   source: string;
   publishedAt: Date | null;
@@ -1105,7 +1139,8 @@ export interface McpServerFace {
   /** What this workspace's machines receive — null when the server has published nothing. */
   resolved: {
     revisionId: string;
-    upstreamVersion: string;
+    /** The version this workspace's machines receive, or NULL when the revision names none. */
+    upstreamVersion: string | null;
     status: string;
     url: string | null;
     transport: string | null;
@@ -1187,7 +1222,7 @@ export async function mcpServerFace(
         ? null
         : {
             revisionId: row.revision_id as string,
-            upstreamVersion: row.upstream_version as string,
+            upstreamVersion: (row.upstream_version as string | null) ?? null,
             status: row.status as string,
             url: (row.url as string | null) ?? null,
             transport: (row.transport as string | null) ?? null,
@@ -1203,7 +1238,7 @@ export async function mcpServerFace(
     revisions: (history.rows as Record<string, unknown>[]).map((rev) => ({
       revisionId: rev.revision_id as string,
       seq: Number(rev.seq),
-      upstreamVersion: rev.upstream_version as string,
+      upstreamVersion: (rev.upstream_version as string | null) ?? null,
       status: rev.status as string,
       source: rev.source as string,
       publishedAt: rev.published_at === null ? null : new Date(rev.published_at as string),
@@ -1351,7 +1386,8 @@ export async function publishedCatalogVersions(name: string): Promise<McpRegistr
 /** One version of a tracked server, as the sweep compares it against upstream's listing. */
 export interface McpTrackedVersion {
   revisionId: string;
-  upstreamVersion: string;
+  /** The stored `version`, or NULL when this revision named none. */
+  upstreamVersion: string | null;
   source: string;
   status: string;
   /** The MCP protocol revisions a probe captured for this version — the precedence tie-break's
@@ -1371,7 +1407,8 @@ export interface McpTrackedVersion {
  *  server has published nothing yet. */
 export interface McpTrackedCurrent {
   revisionId: string;
-  upstreamVersion: string;
+  /** The version on offer, or NULL when the current revision names none. */
+  upstreamVersion: string | null;
   protocolVersions: unknown;
   source: string;
 }
@@ -1440,7 +1477,7 @@ export async function trackedCatalogServers(): Promise<McpTrackedServer[]> {
     if (raw.revision_id !== null && raw.revision_id !== undefined) {
       entry.held.push({
         revisionId: raw.revision_id as string,
-        upstreamVersion: raw.upstream_version as string,
+        upstreamVersion: (raw.upstream_version as string | null) ?? null,
         source: raw.source as string,
         status: raw.revision_status as string,
         protocolVersions: raw.protocol_versions ?? null,
@@ -1616,7 +1653,7 @@ export async function connectableMcpServers(
     url: (row.url as string | null) ?? null,
     transport: (row.transport as string | null) ?? null,
     revisionId: row.revision_id as string,
-    upstreamVersion: row.upstream_version as string,
+    upstreamVersion: (row.upstream_version as string | null) ?? null,
     connectedAs: (row.connected_as as string | null) ?? null,
     inArchive: row.in_archive === true,
   }));

--- a/web/app/lib/db/schema.app.ts
+++ b/web/app/lib/db/schema.app.ts
@@ -574,11 +574,15 @@ export const mcpServer = webSchema.table(
  * the decision was made and what it was, and `revoked` is the pull-back of something that was
  * published — pinned connections are flagged in the UI rather than silently moved off it.
  *
- * `upstream_version` is the version string inside the document, and its uniqueness is PARTIAL —
- * `source = 'registry'` only. Upstream promises one document per version and a second one under
- * the same number is upstream contradicting itself, which this refuses; a staff correction or an
- * owner's edit of a private server is a NEW revision of the same version string by design, and
- * would have nothing to gain from a fresh number nobody upstream would recognize.
+ * `upstream_version` is the version string inside the document, and it is NULLABLE — null means
+ * "no known version", the honest state of an editorial or self-maintained server whose document
+ * carries no `version` field (we never fabricate one just to fill the column). Its uniqueness is
+ * PARTIAL — `source = 'registry'` only. Upstream promises one document per version and a second
+ * one under the same number is upstream contradicting itself, which this refuses; a registry
+ * revision therefore always carries a real version, and Postgres treats nulls as distinct anyway,
+ * so a versionless editorial row never trips the index. A staff correction or an owner's edit of a
+ * private server is a NEW revision of the same version string (or of none) by design, and would
+ * have nothing to gain from a fresh number nobody upstream would recognize.
  *
  * `schema_version` is the document's own `$schema`. The vocabulary of the ones this tier
  * understands lives in CODE, not in a CHECK here, and deliberately: supporting a newer schema is
@@ -603,8 +607,9 @@ export const mcpServerRevision = webSchema.table(
     /** Monotonic per server, from 1 — the history's reading order, minted under the row lock. */
     seq: integer("seq").notNull(),
     status: text("status").default("candidate").notNull(),
-    /** The `version` inside the document (never this row's own numbering). */
-    upstreamVersion: text("upstream_version").notNull(),
+    /** The `version` inside the document (never this row's own numbering); NULL when the document
+     *  names none — an editorial or self-maintained server we never stamped a fake version on. */
+    upstreamVersion: text("upstream_version"),
     schemaVersion: text("schema_version"),
     /** The `server.json` verbatim, in the official registry format. */
     document: jsonb("document").notNull(),

--- a/web/app/lib/mcp/catalog.server.ts
+++ b/web/app/lib/mcp/catalog.server.ts
@@ -64,8 +64,10 @@ export async function serverDocumentOf(
     return null;
   }
   // Re-validated on the way OUT, not just on the way in: the gate's rules can tighten between
-  // a publish and a read, and the lane must never serve a document today's rules would refuse.
-  const validated = validateServerJson(blob.data);
+  // a publish and a read, and the lane must never serve a document today's rules would refuse. A
+  // missing version is NOT such a refusal — the backfill files these as our own (`owner`) rows, and
+  // a self-authored document may honestly carry none.
+  const validated = validateServerJson(blob.data, { requireVersion: false });
   if (!validated.ok) {
     return null;
   }

--- a/web/app/lib/mcp/precedence.server.ts
+++ b/web/app/lib/mcp/precedence.server.ts
@@ -16,14 +16,18 @@
  * This module is PURE comparison, shared by the two places precedence is decided: the upstream
  * sweep (which files a version it cannot better than ours as informational, never as a downgrade)
  * and the accept door (which refuses to move the pointer onto one that is not strictly newer, or
- * onto anything at all over a version a PERSON authored here, without a deliberate override — a
- * seed PLACEHOLDER is neither, and any candidate freely supersedes it).
+ * onto anything at all over a version a PERSON authored here, without a deliberate override). A
+ * current with NO comparable version — a null `version`, which is what a seed placeholder or any
+ * versionless editorial row now carries — is freely superseded by any candidate; that rule lives
+ * with the callers (which hold the current's provenance too), and here it shows up as a null
+ * `version` this comparison simply cannot order.
  */
 
 /** The facts precedence reads off one revision — nothing about its schema or its prose. */
 export interface McpPrecedenceFacts {
-  /** The `version` string inside the document — the server's own version. */
-  version: string;
+  /** The `version` string inside the document — the server's own version — or NULL when it names
+   *  none. A null cannot be ordered, so `compareServerVersion` answers "cannot say" for it. */
+  version: string | null;
   /**
    * The MCP protocol revisions this endpoint answered a probe with (an array of revision strings),
    * or anything else when none was captured. Read defensively: absent is an ambiguity, not a zero.
@@ -36,27 +40,16 @@ export interface McpPrecedenceFacts {
  * private edit. Upstream never supersedes one of these on its own; that is a deliberate act with a
  * person's name on it, and displacing it takes a deliberate override.
  *
- * A `seed` is deliberately NOT here. The catalog's migration stamps every curated server with a
- * placeholder version under `source = 'seed'` — a starting point, not a decision somebody made — so
- * it is a thing to be replaced the moment a real upstream document arrives, never a statement to
- * protect. `isSeedPlaceholder` names that case for the two callers that must let any candidate pass.
+ * A `seed` is deliberately NOT here. A seeded row is a starting point the catalog stood up before
+ * any real document arrived, not a decision somebody made — and it now carries no version, so a
+ * caller lets any candidate freely supersede it under the general "null version cannot be ordered"
+ * rule rather than by naming the source.
  */
 const STAFF_AUTHORED_SOURCES: ReadonlySet<string> = new Set(["staff", "owner"]);
 
 /** Was this revision written by a PERSON here, rather than pulled from upstream or seeded? */
 export function isStaffAuthoredSource(source: string): boolean {
   return STAFF_AUTHORED_SOURCES.has(source);
-}
-
-/**
- * Is this current a SEED PLACEHOLDER — the version the catalog's migration stamped on a curated
- * server before any real document arrived? Such a current is freely superseded by any candidate: it
- * never requires an override and never causes an upstream version to be judged "behind", because
- * there is no real prior to move backward from. The accept guard and the upstream sweep both read
- * this to let a first real document land.
- */
-export function isSeedPlaceholder(source: string): boolean {
-  return source === "seed";
 }
 
 interface ParsedVersion {
@@ -189,9 +182,14 @@ function comparePrerelease(a: string[] | null, b: string[] | null): number {
 
 /**
  * Order two server versions: -1 / 0 / 1, or NULL when either is not a version this can read. The
- * null is load-bearing — every caller reads it as "cannot say", and cannot-say keeps ours.
+ * null is load-bearing — every caller reads it as "cannot say", and cannot-say keeps ours. A
+ * revision that names NO version (a null) is exactly such a "cannot say": there is nothing to
+ * order, so the answer is null.
  */
-export function compareServerVersion(a: string, b: string): number | null {
+export function compareServerVersion(a: string | null, b: string | null): number | null {
+  if (a === null || b === null) {
+    return null;
+  }
   const parsedA = parseVersion(a);
   const parsedB = parseVersion(b);
   if (parsedA === null || parsedB === null) {

--- a/web/app/lib/mcp/validate.server.ts
+++ b/web/app/lib/mcp/validate.server.ts
@@ -28,8 +28,11 @@ import {
  *
  * The shape rules mirror the official registry schema (2025-12-11): `name` is exactly one slash
  * between a reverse-DNS namespace and a server name (3–200 chars), `description` is 1–100
- * characters, `version` is required and names ONE version (never a range, never `latest`), and a
- * `packages[]` entry carries `registryType` + `identifier` + `transport` with STRUCTURED
+ * characters, and — when present — `version` names ONE version (never a range, never `latest`). A
+ * MISSING version is refused only when the caller asks for it (`requireVersion`): a document bound
+ * for the OFFICIAL registry must carry one, but an editorial or self-maintained server we author
+ * for OUR catalog may omit it, and we never invent one to fill the gap. A `packages[]` entry
+ * carries `registryType` + `identifier` + `transport` with STRUCTURED
  * argument/environment objects. `registryType` is OPEN-WORLD — npm, pypi, oci, nuget, mcpb and
  * whatever the registry adds next are all publishable here; whether a given machine can SET one
  * up is the client's question, answered when it renders, not this gate's. The refusal vectors
@@ -128,7 +131,9 @@ export interface McpPackage {
 export interface McpSummary {
   name: string;
   description: string;
-  version: string;
+  /** The server's own `version`, or NULL when the document names none — never a fabricated stand-in.
+   *  A surface renders the absence honestly (an "unversioned" label), never a made-up number. */
+  version: string | null;
   /**
    * The placed remote's address — NULL when the document offers only packages. A shared bundle
    * is allowed to be a thing every machine installs rather than a thing every machine dials, and
@@ -997,11 +1002,26 @@ function checkRemote(remote: Record<string, unknown>): RemoteCheck {
   return { ok: true, headers };
 }
 
+/** What a caller may relax about a document — nothing yet, save whether a version is mandatory. */
+export interface McpValidateOptions {
+  /**
+   * Refuse a document that names no `version`. TRUE (the default) is the strict, registry-grade
+   * gate every caller gets unless it says otherwise — a fail-closed default, so a forgotten option
+   * is the safe answer. A NON-registry door (a workspace's own server, a staff correction) passes
+   * FALSE: such a document may honestly carry no version, and we never fabricate one to pass here.
+   */
+  requireVersion?: boolean;
+}
+
 /**
  * Validate one server document. `raw` is the bytes as fetched or pasted — the scan reads THEM,
  * not a re-serialization, so nothing a caller strips can hide a credential from it.
  */
-export function validateServerJson(raw: Uint8Array | string): McpValidation {
+export function validateServerJson(
+  raw: Uint8Array | string,
+  options: McpValidateOptions = {},
+): McpValidation {
+  const requireVersion = options.requireVersion ?? true;
   let text: string;
   if (typeof raw === "string") {
     text = raw;
@@ -1081,21 +1101,36 @@ export function validateServerJson(raw: Uint8Array | string): McpValidation {
   ) {
     return refuse("MCP_INVALID", `description is required, 1–${DESCRIPTION_MAX} characters`);
   }
-  const version = parsed.version;
-  if (
-    typeof version !== "string" ||
-    version.length === 0 ||
-    codePointLength(version) > VERSION_MAX
+  // A version is OPTIONAL unless the caller demands one: a document destined for our own catalog
+  // (a workspace's server, a staff correction) may honestly carry none, and we never fabricate one
+  // to fill the gap. A registry-bound document still must — `requireVersion` says which this is.
+  const rawVersion = parsed.version;
+  let version: string | null = null;
+  if (rawVersion === undefined) {
+    // ABSENT means the KEY IS OMITTED — the honest shape of a version-less server. An explicit
+    // `null` is NOT absence: the field is present with a non-string value, which the registry
+    // schema forbids, so it falls through to the malformed refusal below rather than being read
+    // as "no version" (and stored/served as a literal `"version": null`).
+    if (requireVersion) {
+      return refuse("MCP_INVALID", "version is required");
+    }
+  } else if (
+    typeof rawVersion !== "string" ||
+    rawVersion.length === 0 ||
+    codePointLength(rawVersion) > VERSION_MAX
   ) {
-    return refuse("MCP_INVALID", "version is required");
-  }
-  // ONE version, the server's own: `latest` names whatever is served today and a range names a
-  // set, and neither is a thing a workspace can pin its members to.
-  if (version === RESERVED_VERSION || looksLikeVersionRange(version)) {
+    // A version that is PRESENT must be a real one — an empty string, a null, or any non-string is
+    // malformed whether or not one was required.
+    return refuse("MCP_INVALID", "version, when given, names one version");
+  } else if (rawVersion === RESERVED_VERSION || looksLikeVersionRange(rawVersion)) {
+    // ONE version, the server's own: `latest` names whatever is served today and a range names a
+    // set, and neither is a thing a workspace can pin its members to.
     return refuse(
       "MCP_INVALID",
-      `version names one version — ${version} names whichever one a machine resolves`,
+      `version names one version — ${rawVersion} names whichever one a machine resolves`,
     );
+  } else {
+    version = rawVersion;
   }
 
   const rawPackages = parsed.packages;
@@ -1189,7 +1224,10 @@ export interface McpCandidateFile {
  * answer to — a bundle whose behavior is one JSON document must not smuggle scripts or extra
  * payloads beside it.
  */
-export function validateCandidateFiles(files: McpCandidateFile[]): McpValidation {
+export function validateCandidateFiles(
+  files: McpCandidateFile[],
+  options: McpValidateOptions = {},
+): McpValidation {
   const server = files.find((f) => f.path === "server.json");
   if (server === undefined) {
     return refuse(
@@ -1229,7 +1267,7 @@ export function validateCandidateFiles(files: McpCandidateFile[]): McpValidation
       );
     }
   }
-  return validateServerJson(server.bytes);
+  return validateServerJson(server.bytes, options);
 }
 
 /**

--- a/web/app/routes/api.v1.mcp-servers.ts
+++ b/web/app/routes/api.v1.mcp-servers.ts
@@ -167,7 +167,12 @@ export async function action({ request, params }: ActionFunctionArgs): Promise<R
       "that is not a server.json — a server document is a JSON object",
     );
   }
-  const validated = validateServerJson(canonicalServerJson(unwrapped));
+  // A document read from the OFFICIAL registry (a `registry_name` was given) must carry a version —
+  // we ingest what upstream gives, and it mandates one, so a malformed registry response is refused
+  // rather than stored version-less. A document LINK is the author's own, and may honestly omit it.
+  const validated = validateServerJson(canonicalServerJson(unwrapped), {
+    requireVersion: typeof registryName === "string",
+  });
   if (!validated.ok) {
     return deniedCodeEnvelope("mcp", validated.code, validated.message);
   }

--- a/web/app/routes/mcp-new.tsx
+++ b/web/app/routes/mcp-new.tsx
@@ -18,6 +18,7 @@ import {
   connectableMcpServers,
   connectMcpServer,
   createPrivateMcpServer,
+  mcpRevisionFacts,
 } from "@/lib/db/queries.mcp-catalog.server";
 import {
   canonicalServerJson,
@@ -200,9 +201,25 @@ export async function action({ request, params }: ActionFunctionArgs) {
       );
     }
     const document = canonicalize(text);
-    const validated = validateServerJson(document);
+    // FIRST the document gate: it reads the raw bytes and answers MCP_INVALID for anything that is
+    // not a well-formed server.json (malformed JSON included — a paste is often that), so nothing
+    // below ever parses bytes the gate has not vouched for. A registry read must carry a version;
+    // a URL or a paste is the author's own and may omit it.
+    const validated = validateServerJson(document, {
+      requireVersion: source.kind === "registry",
+    });
     if (!validated.ok) {
       return refusal("preview", validated.message, validated.code);
+    }
+    // THEN the catalog's fact gate — the one `create` lands through — so the preview never offers an
+    // add that cannot land: a document declaring an official schema that itself requires a version,
+    // or a schema this build cannot read, is refused here in the same words the write would use.
+    // The bytes parsed cleanly above, so this parse cannot throw.
+    const landing = mcpRevisionFacts(JSON.parse(document) as Record<string, unknown>, {
+      requireVersion: source.kind === "registry",
+    });
+    if (landing.refusal !== null) {
+      return refusal("preview", landing.refusal.message, landing.refusal.code);
     }
     return data<PreviewData>({
       form: "preview",
@@ -256,7 +273,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
     // encoding, which normalizes line endings, so trusting the bytes back would make what is
     // stored depend on the browser rather than on the document.
     const document = canonicalize(posted);
-    const validated = validateServerJson(document);
+    // The custom arm writes this workspace's OWN server: a missing version is a truthful state, not
+    // a refusal, and the create write below stores it as such.
+    const validated = validateServerJson(document, { requireVersion: false });
     if (!validated.ok) {
       return refusal("create", validated.message, validated.code);
     }
@@ -848,7 +867,7 @@ export function PreviewCard({ preview }: { preview: PreviewData }) {
       <Card className="space-y-3 px-4 py-3">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span className="font-mono text-[13px] text-ink">{summary.name}</span>
-          <span className="text-faint text-xs">{summary.version}</span>
+          <span className="text-faint text-xs">{summary.version ?? "unversioned"}</span>
           {summary.transport !== null && <Chip tone="neutral">{summary.transport}</Chip>}
         </div>
         <p className="text-dim text-sm">{summary.description}</p>

--- a/web/app/routes/skill-current.tsx
+++ b/web/app/routes/skill-current.tsx
@@ -258,7 +258,9 @@ async function editServerIntent(
     notFound();
   }
   const posted = String(formData.get("document") ?? "");
-  const validated = validateServerJson(posted);
+  // Editing a workspace's own server: a document with no version is honest, so the edit accepts it
+  // and stores a null version rather than demanding a fabricated number.
+  const validated = validateServerJson(posted, { requireVersion: false });
   if (!validated.ok) {
     return data(
       { intent: "edit-mcp-server" as const, status: "error" as const, message: validated.message },

--- a/web/drizzle/0025_mcp-version-nullable.sql
+++ b/web/drizzle/0025_mcp-version-nullable.sql
@@ -1,0 +1,29 @@
+-- A SERVER WITH NO KNOWN VERSION CARRIES NONE — no fabricated number to fill a column.
+--
+-- The catalog was seeded from a curated list that held only a URL and a sign-in tier, never a
+-- version. The first seed stamped a placeholder `1.0.0` on every one so the column could be NOT
+-- NULL, which both broke semver precedence against a real-but-lower upstream version and published
+-- a fake version to the world through the feed. `upstream_version` becomes nullable, and the
+-- placeholder is undone: null column, no `version` in the stored document.
+
+ALTER TABLE "web"."mcp_server_revision" ALTER COLUMN "upstream_version" DROP NOT NULL;--> statement-breakpoint
+
+-- Undo the seed's fabricated version, in place and only where it was fabricated. The predicate is
+-- narrow on purpose: a row is a seed placeholder only when it came FROM the seed, its column reads
+-- the placeholder `1.0.0`, AND its document carries that same `1.0.0` — so a registry document is
+-- never touched (the fabrication only ever happened in the seed) and an owner's server a person
+-- deliberately versioned `1.0.0` is left exactly as they wrote it. Idempotent: once nulled, the
+-- `upstream_version = '1.0.0'` clause no longer matches, so a re-run is a no-op.
+--
+-- The seed documents also declared the official 2025-12-11 `$schema`, which REQUIRES a `version` —
+-- so a document that dropped its version while keeping that line would be schema-invalid, and the
+-- feed and delivery both serve the document verbatim. These are hand-authored editorial rows, not
+-- registry entries, so the honest shape is to make NO schema claim: the `$schema` line and the
+-- extracted `schema_version` column come off together with the version.
+UPDATE "web"."mcp_server_revision"
+SET "upstream_version" = NULL,
+    "schema_version" = NULL,
+    "document" = "document" - 'version' - '$schema'
+WHERE "source" = 'seed'
+  AND "upstream_version" = '1.0.0'
+  AND "document"->>'version' = '1.0.0';

--- a/web/drizzle/meta/0025_snapshot.json
+++ b/web/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,3873 @@
+{
+  "id": "3d53463d-27fb-4983-a030-6a1a86c4476b",
+  "prevId": "59f57eeb-f5b2-4162-8307-f6b1bac26b8c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "web.account": {
+      "name": "account",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.session": {
+      "name": "session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_idx": {
+          "name": "session_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.user": {
+      "name": "user",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_email_lowercase": {
+          "name": "user_email_lowercase",
+          "value": "\"web\".\"user\".\"email\" = lower(\"web\".\"user\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.verification": {
+      "name": "verification",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expires_idx": {
+          "name": "verification_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.approval": {
+      "name": "approval",
+      "schema": "web",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer": {
+          "name": "reviewer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_reviewer_idx": {
+          "name": "approval_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_proposal_id_proposal_id_fk": {
+          "name": "approval_proposal_id_proposal_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "proposal",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_reviewer_user_id_fk": {
+          "name": "approval_reviewer_user_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "reviewer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "approval_proposal_id_reviewer_pk": {
+          "name": "approval_proposal_id_reviewer_pk",
+          "columns": [
+            "proposal_id",
+            "reviewer"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.assignment": {
+      "name": "assignment",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self": {
+          "name": "self",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_person_bundle_once": {
+          "name": "assignment_person_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_bundle_once": {
+          "name": "assignment_everyone_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_person_channel_once": {
+          "name": "assignment_person_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_channel_once": {
+          "name": "assignment_everyone_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_ws_user_idx": {
+          "name": "assignment_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_bundle_idx": {
+          "name": "assignment_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_channel_idx": {
+          "name": "assignment_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_workspace_id_workspace_id_fk": {
+          "name": "assignment_workspace_id_workspace_id_fk",
+          "tableFrom": "assignment",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_seat_fk": {
+          "name": "assignment_seat_fk",
+          "tableFrom": "assignment",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_bundle_fk": {
+          "name": "assignment_bundle_fk",
+          "tableFrom": "assignment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_channel_fk": {
+          "name": "assignment_channel_fk",
+          "tableFrom": "assignment",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assignment_target_check": {
+          "name": "assignment_target_check",
+          "value": "(\"web\".\"assignment\".\"bundle_id\" is null) <> (\"web\".\"assignment\".\"channel_id\" is null)"
+        },
+        "assignment_self_check": {
+          "name": "assignment_self_check",
+          "value": "\"web\".\"assignment\".\"user_id\" is not null or not \"web\".\"assignment\".\"self\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.audit_event": {
+      "name": "audit_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "audit_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_session_id": {
+          "name": "actor_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display": {
+          "name": "actor_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_ws_time": {
+          "name": "audit_ws_time",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_user": {
+          "name": "audit_actor_user",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_session": {
+          "name": "audit_actor_session",
+          "columns": [
+            {
+              "expression": "actor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_session_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_invite_subject": {
+          "name": "audit_invite_subject",
+          "columns": [
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "kind = 'invitation_created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_event_actor_user_id_user_id_fk": {
+          "name": "audit_event_actor_user_id_user_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_event_actor_session_id_cli_session_id_fk": {
+          "name": "audit_event_actor_session_id_cli_session_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle": {
+      "name": "bundle",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "protection": {
+          "name": "protection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_name": {
+          "name": "base_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundle_workspace_id_workspace_id_fk": {
+          "name": "bundle_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_created_by_user_id_fk": {
+          "name": "bundle_created_by_user_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_workspace_id_name_unique": {
+          "name": "bundle_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "bundle_id_workspace_id_unique": {
+          "name": "bundle_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bundle_name_check": {
+          "name": "bundle_name_check",
+          "value": "\"web\".\"bundle\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"bundle\".\"name\") <= 200"
+        },
+        "bundle_kind_check": {
+          "name": "bundle_kind_check",
+          "value": "\"web\".\"bundle\".\"kind\" in ('skill', 'mcp')"
+        },
+        "bundle_status_check": {
+          "name": "bundle_status_check",
+          "value": "\"web\".\"bundle\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "bundle_protection_check": {
+          "name": "bundle_protection_check",
+          "value": "\"web\".\"bundle\".\"protection\" is null or \"web\".\"bundle\".\"protection\" in ('open', 'reviewed')"
+        },
+        "bundle_deleted_check": {
+          "name": "bundle_deleted_check",
+          "value": "(\"web\".\"bundle\".\"status\" = 'deleted') = (\"web\".\"bundle\".\"deleted_at\" is not null)"
+        },
+        "bundle_archived_check": {
+          "name": "bundle_archived_check",
+          "value": "\"web\".\"bundle\".\"status\" <> 'archived' or \"web\".\"bundle\".\"archived_at\" is not null"
+        },
+        "bundle_base_name_check": {
+          "name": "bundle_base_name_check",
+          "value": "\"web\".\"bundle\".\"base_name\" is null or \"web\".\"bundle\".\"status\" <> 'active'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.bundle_mcp": {
+      "name": "bundle_mcp",
+      "schema": "web",
+      "columns": {
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_revision_id": {
+          "name": "pinned_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_mcp_server_idx": {
+          "name": "bundle_mcp_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_mcp_server_id_mcp_server_id_fk": {
+          "name": "bundle_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "mcp_server",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_created_by_user_id_fk": {
+          "name": "bundle_mcp_created_by_user_id_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_bundle_fk": {
+          "name": "bundle_mcp_bundle_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_pinned_revision_fk": {
+          "name": "bundle_mcp_pinned_revision_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "mcp_server_revision",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "pinned_revision_id",
+            "server_id"
+          ],
+          "columnsTo": [
+            "id",
+            "server_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_mcp_workspace_server_unique": {
+          "name": "bundle_mcp_workspace_server_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_name_hint": {
+      "name": "bundle_name_hint",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renamed_by": {
+          "name": "renamed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_name_hint_bundle_idx": {
+          "name": "bundle_name_hint_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_name_hint_workspace_id_workspace_id_fk": {
+          "name": "bundle_name_hint_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_bundle_id_bundle_id_fk": {
+          "name": "bundle_name_hint_bundle_id_bundle_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_renamed_by_user_id_fk": {
+          "name": "bundle_name_hint_renamed_by_user_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "renamed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_name_hint_workspace_id_old_name_pk": {
+          "name": "bundle_name_hint_workspace_id_old_name_pk",
+          "columns": [
+            "workspace_id",
+            "old_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_upstream": {
+      "name": "bundle_upstream",
+      "schema": "web",
+      "columns": {
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_commit": {
+          "name": "last_seen_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bundle_upstream_ws_idx": {
+          "name": "bundle_upstream_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_upstream_bundle_fk": {
+          "name": "bundle_upstream_bundle_fk",
+          "tableFrom": "bundle_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bundle_upstream_repo_check": {
+          "name": "bundle_upstream_repo_check",
+          "value": "\"web\".\"bundle_upstream\".\"repo\" ~ '^[^/]+/[^/]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel": {
+      "name": "channel",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_one_default": {
+          "name": "channel_one_default",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_workspace_id_workspace_id_fk": {
+          "name": "channel_workspace_id_workspace_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_created_by_user_id_fk": {
+          "name": "channel_created_by_user_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "channel_workspace_id_name_unique": {
+          "name": "channel_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "channel_id_workspace_id_unique": {
+          "name": "channel_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "channel_mode_check": {
+          "name": "channel_mode_check",
+          "value": "\"web\".\"channel\".\"mode\" in ('open', 'curated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel_bundle": {
+      "name": "channel_bundle",
+      "schema": "web",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bundle_bundle_idx": {
+          "name": "channel_bundle_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bundle_added_by_user_id_fk": {
+          "name": "channel_bundle_added_by_user_id_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_channel_fk": {
+          "name": "channel_bundle_channel_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_bundle_fk": {
+          "name": "channel_bundle_bundle_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_bundle_channel_id_bundle_id_pk": {
+          "name": "channel_bundle_channel_id_bundle_id_pk",
+          "columns": [
+            "channel_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.cli_session": {
+      "name": "cli_session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_sha256": {
+          "name": "credential_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cli_session_workspace_idx": {
+          "name": "cli_session_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_session_user_idx": {
+          "name": "cli_session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_session_seat_fk": {
+          "name": "cli_session_seat_fk",
+          "tableFrom": "cli_session",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_session_credential_sha256_unique": {
+          "name": "cli_session_credential_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_session_status_check": {
+          "name": "cli_session_status_check",
+          "value": "\"web\".\"cli_session\".\"status\" in ('pending', 'active')"
+        },
+        "cli_session_credential_sha256_check": {
+          "name": "cli_session_credential_sha256_check",
+          "value": "octet_length(\"web\".\"cli_session\".\"credential_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.decline": {
+      "name": "decline",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "decline_ws_user_idx": {
+          "name": "decline_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decline_seat_fk": {
+          "name": "decline_seat_fk",
+          "tableFrom": "decline",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "decline_bundle_fk": {
+          "name": "decline_bundle_fk",
+          "tableFrom": "decline",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decline_user_id_bundle_id_unique": {
+          "name": "decline_user_id_bundle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.invitation": {
+      "name": "invitation",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_sha256": {
+          "name": "token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_bundle_id": {
+          "name": "hint_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_channel_id": {
+          "name": "hint_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_pending_once": {
+          "name": "invitation_pending_once",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_workspace_id_workspace_id_fk": {
+          "name": "invitation_workspace_id_workspace_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitation_accepted_by_user_id_fk": {
+          "name": "invitation_accepted_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_sha256_unique": {
+          "name": "invitation_token_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_email_check": {
+          "name": "invitation_email_check",
+          "value": "\"web\".\"invitation\".\"email\" = lower(\"web\".\"invitation\".\"email\")"
+        },
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"web\".\"invitation\".\"role\" in ('owner', 'reviewer', 'member')"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "\"web\".\"invitation\".\"status\" in ('pending', 'accepted', 'revoked', 'declined')"
+        },
+        "invitation_token_sha256_check": {
+          "name": "invitation_token_sha256_check",
+          "value": "\"web\".\"invitation\".\"token_sha256\" is null or octet_length(\"web\".\"invitation\".\"token_sha256\") = 32"
+        },
+        "invitation_hint_one_check": {
+          "name": "invitation_hint_one_check",
+          "value": "\"web\".\"invitation\".\"hint_bundle_id\" is null or \"web\".\"invitation\".\"hint_channel_id\" is null"
+        },
+        "invitation_accepted_check": {
+          "name": "invitation_accepted_check",
+          "value": "(\"web\".\"invitation\".\"status\" = 'accepted') = (\"web\".\"invitation\".\"accepted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.login_flow": {
+      "name": "login_flow",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_code_sha256": {
+          "name": "flow_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_name": {
+          "name": "requested_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preselect_workspace": {
+          "name": "preselect_workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_workspace_id": {
+          "name": "approved_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token_sha256": {
+          "name": "invite_token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "login_flow_live_code": {
+          "name": "login_flow_live_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "login_flow_expires_idx": {
+          "name": "login_flow_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "login_flow_approved_by_user_id_fk": {
+          "name": "login_flow_approved_by_user_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "login_flow_session_id_cli_session_id_fk": {
+          "name": "login_flow_session_id_cli_session_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "login_flow_flow_code_sha256_unique": {
+          "name": "login_flow_flow_code_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flow_code_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "login_flow_flow_code_sha256_check": {
+          "name": "login_flow_flow_code_sha256_check",
+          "value": "octet_length(\"web\".\"login_flow\".\"flow_code_sha256\") = 32"
+        },
+        "login_flow_invite_token_sha256_check": {
+          "name": "login_flow_invite_token_sha256_check",
+          "value": "\"web\".\"login_flow\".\"invite_token_sha256\" is null or octet_length(\"web\".\"login_flow\".\"invite_token_sha256\") = 32"
+        },
+        "login_flow_status_check": {
+          "name": "login_flow_status_check",
+          "value": "\"web\".\"login_flow\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "login_flow_binding_check": {
+          "name": "login_flow_binding_check",
+          "value": "\"web\".\"login_flow\".\"binding\" in ('device', 'loopback')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mail_event": {
+      "name": "mail_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_event_time_idx": {
+          "name": "mail_event_time_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mail_event_kind_check": {
+          "name": "mail_event_kind_check",
+          "value": "\"web\".\"mail_event\".\"kind\" in ('magic-link', 'invite', 'auth-verify', 'auth-reset')"
+        },
+        "mail_event_outcome_check": {
+          "name": "mail_event_outcome_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" in ('ok', 'failed')"
+        },
+        "mail_event_code_check": {
+          "name": "mail_event_code_check",
+          "value": "\"web\".\"mail_event\".\"code\" is null or \"web\".\"mail_event\".\"code\" in ('unconfigured', 'send_failed')"
+        },
+        "mail_event_code_on_failure_check": {
+          "name": "mail_event_code_on_failure_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" = 'failed' or \"web\".\"mail_event\".\"code\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_server": {
+      "name": "mcp_server",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registry_name": {
+          "name": "registry_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_note": {
+          "name": "auth_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_menu": {
+          "name": "scope_menu",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_server_global_registry_name": {
+          "name": "mcp_server_global_registry_name",
+          "columns": [
+            {
+              "expression": "registry_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "workspace_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_private_registry_name": {
+          "name": "mcp_server_private_registry_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registry_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "workspace_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_workspace_idx": {
+          "name": "mcp_server_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_workspace_id_workspace_id_fk": {
+          "name": "mcp_server_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_current_revision_fk": {
+          "name": "mcp_server_current_revision_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "mcp_server_revision",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "current_revision_id",
+            "id"
+          ],
+          "columnsTo": [
+            "id",
+            "server_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_server_auth_mode_check": {
+          "name": "mcp_server_auth_mode_check",
+          "value": "\"web\".\"mcp_server\".\"auth_mode\" is null or \"web\".\"mcp_server\".\"auth_mode\" in ('none', 'oauth', 'manual')"
+        },
+        "mcp_server_status_check": {
+          "name": "mcp_server_status_check",
+          "value": "\"web\".\"mcp_server\".\"status\" in ('candidate', 'active', 'delisted')"
+        },
+        "mcp_server_registry_name_check": {
+          "name": "mcp_server_registry_name_check",
+          "value": "\"web\".\"mcp_server\".\"registry_name\" is null or \"web\".\"mcp_server\".\"registry_name\" ~ '^[^/]+/[^/]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_server_revision": {
+      "name": "mcp_server_revision",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "upstream_version": {
+          "name": "upstream_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probe_outcome": {
+          "name": "probe_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probed_at": {
+          "name": "probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_versions": {
+          "name": "protocol_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification": {
+          "name": "verification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_server_revision_upstream_version": {
+          "name": "mcp_server_revision_upstream_version",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upstream_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'registry'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_revision_server_idx": {
+          "name": "mcp_server_revision_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_revision_server_id_mcp_server_id_fk": {
+          "name": "mcp_server_revision_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_server_revision",
+          "tableTo": "mcp_server",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_revision_seq_unique": {
+          "name": "mcp_server_revision_seq_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "server_id",
+            "seq"
+          ]
+        },
+        "mcp_server_revision_id_server_unique": {
+          "name": "mcp_server_revision_id_server_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mcp_server_revision_id_shape_check": {
+          "name": "mcp_server_revision_id_shape_check",
+          "value": "\"web\".\"mcp_server_revision\".\"id\" ~ '^mcpr_[0-9a-f]{32}$'"
+        },
+        "mcp_server_revision_status_check": {
+          "name": "mcp_server_revision_status_check",
+          "value": "\"web\".\"mcp_server_revision\".\"status\" in ('candidate', 'published', 'rejected', 'revoked', 'superseded')"
+        },
+        "mcp_server_revision_source_check": {
+          "name": "mcp_server_revision_source_check",
+          "value": "\"web\".\"mcp_server_revision\".\"source\" in ('registry', 'staff', 'owner', 'seed')"
+        },
+        "mcp_server_revision_seq_check": {
+          "name": "mcp_server_revision_seq_check",
+          "value": "\"web\".\"mcp_server_revision\".\"seq\" >= 1"
+        },
+        "mcp_server_revision_probe_outcome_check": {
+          "name": "mcp_server_revision_probe_outcome_check",
+          "value": "\"web\".\"mcp_server_revision\".\"probe_outcome\" is null or \"web\".\"mcp_server_revision\".\"probe_outcome\" in ('responding', 'sign_in_required', 'not_verifiable', 'not_responding')"
+        },
+        "mcp_server_revision_probed_check": {
+          "name": "mcp_server_revision_probed_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"probe_outcome\" is null) = (\"web\".\"mcp_server_revision\".\"probed_at\" is null)"
+        },
+        "mcp_server_revision_remote_check": {
+          "name": "mcp_server_revision_remote_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"url\" is null) = (\"web\".\"mcp_server_revision\".\"transport\" is null)"
+        },
+        "mcp_server_revision_url_check": {
+          "name": "mcp_server_revision_url_check",
+          "value": "\"web\".\"mcp_server_revision\".\"url\" is null or \"web\".\"mcp_server_revision\".\"url\" ~ '^https://'"
+        },
+        "mcp_server_revision_published_check": {
+          "name": "mcp_server_revision_published_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"status\" in ('published', 'revoked')) = (\"web\".\"mcp_server_revision\".\"published_at\" is not null)"
+        },
+        "mcp_server_revision_published_by_check": {
+          "name": "mcp_server_revision_published_by_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"published_at\" is null) = (\"web\".\"mcp_server_revision\".\"published_by\" is null)"
+        },
+        "mcp_server_revision_rejected_check": {
+          "name": "mcp_server_revision_rejected_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"status\" = 'rejected') = (\"web\".\"mcp_server_revision\".\"decided_at\" is not null)"
+        },
+        "mcp_server_revision_decided_by_check": {
+          "name": "mcp_server_revision_decided_by_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"decided_at\" is null) = (\"web\".\"mcp_server_revision\".\"decided_by\" is null)"
+        },
+        "mcp_server_revision_revoked_check": {
+          "name": "mcp_server_revision_revoked_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"status\" = 'revoked') = (\"web\".\"mcp_server_revision\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.notice": {
+      "name": "notice",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notice_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notice_inbox": {
+          "name": "notice_inbox",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "acked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notice_ws_idx": {
+          "name": "notice_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notice_user_id_user_id_fk": {
+          "name": "notice_user_id_user_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notice_workspace_id_workspace_id_fk": {
+          "name": "notice_workspace_id_workspace_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.op_receipt": {
+      "name": "op_receipt",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_id": {
+          "name": "op_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_sha256": {
+          "name": "request_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "op_receipt_retention_idx": {
+          "name": "op_receipt_retention_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "op_receipt_session_id_cli_session_id_fk": {
+          "name": "op_receipt_session_id_cli_session_id_fk",
+          "tableFrom": "op_receipt",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "op_receipt_workspace_id_session_id_op_id_pk": {
+          "name": "op_receipt_workspace_id_session_id_op_id_pk",
+          "columns": [
+            "workspace_id",
+            "session_id",
+            "op_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "op_receipt_request_sha256_check": {
+          "name": "op_receipt_request_sha256_check",
+          "value": "octet_length(\"web\".\"op_receipt\".\"request_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal": {
+      "name": "proposal",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_version_id": {
+          "name": "candidate_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason": {
+          "name": "resolved_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_open": {
+          "name": "proposal_open",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_one_open_per_candidate": {
+          "name": "proposal_one_open_per_candidate",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_proposed_by_user_id_fk": {
+          "name": "proposal_proposed_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_resolved_by_user_id_fk": {
+          "name": "proposal_resolved_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_bundle_fk": {
+          "name": "proposal_bundle_fk",
+          "tableFrom": "proposal",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_status_check": {
+          "name": "proposal_status_check",
+          "value": "\"web\".\"proposal\".\"status\" in ('open', 'approved', 'rejected', 'withdrawn')"
+        },
+        "proposal_resolved_check": {
+          "name": "proposal_resolved_check",
+          "value": "(\"web\".\"proposal\".\"status\" = 'open') = (\"web\".\"proposal\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal_comment": {
+      "name": "proposal_comment",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display": {
+          "name": "author_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_comment_thread_idx": {
+          "name": "proposal_comment_thread_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_comment_author_user_id_user_id_fk": {
+          "name": "proposal_comment_author_user_id_user_id_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_comment_bundle_fk": {
+          "name": "proposal_comment_bundle_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_comment_body_check": {
+          "name": "proposal_comment_body_check",
+          "value": "char_length(\"web\".\"proposal_comment\".\"body\") between 1 and 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.seat": {
+      "name": "seat",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seat_user_idx": {
+          "name": "seat_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seat_workspace_id_workspace_id_fk": {
+          "name": "seat_workspace_id_workspace_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_user_id_user_id_fk": {
+          "name": "seat_user_id_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_invited_by_user_id_fk": {
+          "name": "seat_invited_by_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "seat_workspace_id_user_id_pk": {
+          "name": "seat_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "seat_role_check": {
+          "name": "seat_role_check",
+          "value": "\"web\".\"seat\".\"role\" in ('owner', 'reviewer', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.session_bundle_state": {
+      "name": "session_bundle_state",
+      "schema": "web",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_version_id": {
+          "name": "applied_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_state": {
+          "name": "harness_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_bundle_state_bundle_idx": {
+          "name": "session_bundle_state_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_bundle_state_session_id_cli_session_id_fk": {
+          "name": "session_bundle_state_session_id_cli_session_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_bundle_state_bundle_id_bundle_id_fk": {
+          "name": "session_bundle_state_bundle_id_bundle_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_bundle_state_session_id_bundle_id_pk": {
+          "name": "session_bundle_state_session_id_bundle_id_pk",
+          "columns": [
+            "session_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.version_upstream": {
+      "name": "version_upstream",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "version_upstream_bundle_fk": {
+          "name": "version_upstream_bundle_fk",
+          "tableFrom": "version_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "version_upstream_bundle_id_version_id_pk": {
+          "name": "version_upstream_bundle_id_version_id_pk",
+          "columns": [
+            "bundle_id",
+            "version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.workspace": {
+      "name": "workspace",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_code_sha256": {
+          "name": "claim_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protection_default": {
+          "name": "protection_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "staleness_window_ms": {
+          "name": "staleness_window_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800000
+        },
+        "registration": {
+          "name": "registration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_only'"
+        },
+        "session_approval": {
+          "name": "session_approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "session_max_age_ms": {
+          "name": "session_max_age_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_name_unique": {
+          "name": "workspace_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_name_check": {
+          "name": "workspace_name_check",
+          "value": "\"web\".\"workspace\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"workspace\".\"name\") <= 100"
+        },
+        "workspace_claim_code_sha256_check": {
+          "name": "workspace_claim_code_sha256_check",
+          "value": "\"web\".\"workspace\".\"claim_code_sha256\" is null or octet_length(\"web\".\"workspace\".\"claim_code_sha256\") = 32"
+        },
+        "workspace_protection_default_check": {
+          "name": "workspace_protection_default_check",
+          "value": "\"web\".\"workspace\".\"protection_default\" in ('open', 'reviewed')"
+        },
+        "workspace_registration_check": {
+          "name": "workspace_registration_check",
+          "value": "\"web\".\"workspace\".\"registration\" in ('invite_only', 'open')"
+        },
+        "workspace_session_approval_check": {
+          "name": "workspace_session_approval_check",
+          "value": "\"web\".\"workspace\".\"session_approval\" in ('off', 'on')"
+        },
+        "workspace_session_max_age_check": {
+          "name": "workspace_session_max_age_check",
+          "value": "\"web\".\"workspace\".\"session_max_age_ms\" is null or \"web\".\"workspace\".\"session_max_age_ms\" > 0"
+        },
+        "workspace_claim_state_check": {
+          "name": "workspace_claim_state_check",
+          "value": "(\"web\".\"workspace\".\"claimed_at\" is null) <> (\"web\".\"workspace\".\"claim_code_sha256\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "web": "web"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1787200200000,
       "tag": "0024_mcp-revision-superseded",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1787200300000,
+      "tag": "0025_mcp-version-nullable",
+      "breakpoints": true
     }
   ]
 }

--- a/web/tests/e2e/mcp-new.spec.ts
+++ b/web/tests/e2e/mcp-new.spec.ts
@@ -218,6 +218,45 @@ test("write down a server the catalog does not carry, preview it, add it", async
   ).toContainText("mcp");
 });
 
+test("a version-less paste previews as unversioned, and never offers an add that cannot land", async ({
+  page,
+}) => {
+  const paste = async (doc: Record<string, unknown>) => {
+    await gotoSettled(page, "/mcp/new");
+    await page.getByText("A server that is not on this list", { exact: true }).click();
+    await page.getByLabel("Where it comes from").selectOption("paste");
+    await page.getByTestId("mcp-paste").fill(JSON.stringify(doc));
+    await page.getByRole("button", { name: "Preview" }).click();
+  };
+  const remotes = [{ type: "streamable-http", url: "https://vl.acme.example/mcp" }];
+
+  // A hand-written server that names no version and makes no schema claim previews honestly —
+  // "unversioned", never a fabricated number — and can be added.
+  await paste({ name: "io.github.acme/vl-open", description: "No version, no schema.", remotes });
+  await expect(page.getByTestId("mcp-preview")).toContainText("unversioned");
+  await expect(page.getByTestId("mcp-refusal")).toHaveCount(0);
+
+  // A document that omits the version but still declares an official schema that REQUIRES one is
+  // self-contradictory — the write would reject it, so the preview refuses up front rather than
+  // offering an add that cannot land.
+  await paste({
+    $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    name: "io.github.acme/vl-schema",
+    description: "No version, but a schema that needs one.",
+    remotes,
+  });
+  await expect(page.getByTestId("mcp-refusal")).toBeVisible();
+  await expect(page.getByTestId("mcp-preview")).toHaveCount(0);
+
+  // Malformed JSON is a refusal, not a crash: the gate answers before anything parses the bytes.
+  await gotoSettled(page, "/mcp/new");
+  await page.getByText("A server that is not on this list", { exact: true }).click();
+  await page.getByLabel("Where it comes from").selectOption("paste");
+  await page.getByTestId("mcp-paste").fill("{ not json");
+  await page.getByRole("button", { name: "Preview" }).click();
+  await expect(page.getByTestId("mcp-refusal")).toBeVisible();
+});
+
 /**
  * ADDING IS NOT SHARING. The destination field rests on no channel, so an untouched form leaves
  * the server in the workspace and nowhere else — the server's own page says "In no channel." and

--- a/web/tests/e2e/mcp-server.spec.ts
+++ b/web/tests/e2e/mcp-server.spec.ts
@@ -16,12 +16,18 @@ import { gotoSettled } from "./sign-in";
 const CATALOG = { serverId: "e2e_mcps_catalog", bundleId: "e2e_b_catalog", name: "e2e-catalog" };
 const PINNED = { serverId: "e2e_mcps_pinned", bundleId: "e2e_b_pinned", name: "e2e-pinned" };
 const OWN = { serverId: "e2e_mcps_own", bundleId: "e2e_b_own", name: "e2e-own" };
+const UNVERSIONED = {
+  serverId: "e2e_mcps_unversioned",
+  bundleId: "e2e_b_unversioned",
+  name: "e2e-unversioned",
+};
 
-function document(name: string, version: string, url: string): string {
+function document(name: string, version: string | null, url: string): string {
   return JSON.stringify({
     name,
     description: `Everything ${name} knows.`,
-    version,
+    // A version-less server names NO version key — never a fabricated number.
+    ...(version === null ? {} : { version }),
     remotes: [{ type: "streamable-http", url }],
   });
 }
@@ -44,7 +50,7 @@ async function seedRevision(
   serverId: string,
   id: string,
   seq: number,
-  version: string,
+  version: string | null,
   opts: { current?: boolean; status?: "published" | "revoked"; url?: string } = {},
 ): Promise<void> {
   const registryName = (
@@ -98,10 +104,10 @@ test.beforeAll(async () => {
   // counts — so the three fixtures are taken down (connections first: a catalog row a workspace
   // is connected to is deliberately not deletable out from under it) and seeded fresh.
   await adminQuery(`delete from web.bundle where id = any($1::text[])`, [
-    [CATALOG.bundleId, PINNED.bundleId, OWN.bundleId],
+    [CATALOG.bundleId, PINNED.bundleId, OWN.bundleId, UNVERSIONED.bundleId],
   ]);
   await adminQuery(`delete from web.mcp_server where id = any($1::text[])`, [
-    [CATALOG.serverId, PINNED.serverId, OWN.serverId],
+    [CATALOG.serverId, PINNED.serverId, OWN.serverId, UNVERSIONED.serverId],
   ]);
 
   // A catalog server on its current version, with a sign-in a person has to arrange.
@@ -132,6 +138,15 @@ test.beforeAll(async () => {
     url: "https://own.e2e.example/mcp",
   });
   await connect(OWN.bundleId, OWN.name, OWN.serverId);
+
+  // A server that names NO version — the honest shape of a self-maintained one. The page reads it
+  // without inventing a number: "the current version" with no digits, and an "unversioned" label.
+  await seedServer("e2e_mcps_unversioned", "io.github.e2e/unversioned", { authMode: "none" });
+  await seedRevision(UNVERSIONED.serverId, mcpRevisionId("e2e_unver_1"), 1, null, {
+    current: true,
+    url: "https://unversioned.e2e.example/mcp",
+  });
+  await connect(UNVERSIONED.bundleId, UNVERSIONED.name, UNVERSIONED.serverId);
 });
 
 test("says what the server is, what this workspace receives, and which versions exist", async ({
@@ -170,6 +185,20 @@ test("a pin is honored, and a withdrawn pin says so", async ({ page }) => {
   await gotoSettled(page, `/mcp/${PINNED.name}`);
   await expect(page.getByTestId("mcp-connection")).toContainText("Pinned to 1.0.0.");
   await expect(page.getByTestId("mcp-revoked")).toContainText("withdrawn after it was published");
+});
+
+test("a version-less server reads as unversioned, never as a fabricated number", async ({
+  page,
+}) => {
+  await gotoSettled(page, `/mcp/${UNVERSIONED.name}`);
+  // The connection line names the current version without a number, since there is none.
+  await expect(page.getByTestId("mcp-connection")).toContainText("Following the current version.");
+  // The history row wears the honest label rather than a made-up version like 1.0.0 or 0.0.0.
+  const revisions = page.getByTestId("mcp-revisions");
+  await expect(revisions).toContainText("unversioned");
+  await expect(revisions).toContainText("delivered here");
+  await expect(revisions).not.toContainText("1.0.0");
+  await expect(revisions).not.toContainText("0.0.0");
 });
 
 test("an owner's save of their own server is a NEW version, not a rewrite", async ({ page }) => {

--- a/web/tests/fixtures/mcp/vectors.json
+++ b/web/tests/fixtures/mcp/vectors.json
@@ -217,7 +217,7 @@
   {
     "file": "invalid/missing-version.json",
     "verdict": "MCP_INVALID",
-    "note": "version is required; without it there is nothing to compare a later publish against."
+    "note": "The default gate is registry-grade and requires a version; a non-registry door relaxes it (requireVersion:false), but the shared vectors pin the strict default."
   },
   {
     "file": "invalid/not-json.txt",

--- a/web/tests/unit/mcp-catalog-feed.test.ts
+++ b/web/tests/unit/mcp-catalog-feed.test.ts
@@ -27,6 +27,15 @@ function document(name: string, version: string): Record<string, unknown> {
   };
 }
 
+/** The honest shape of a server we never stamped a version on — no `version` key at all. */
+function versionlessDocument(name: string): Record<string, unknown> {
+  return {
+    name,
+    description: `Everything about ${name}.`,
+    remotes: [{ type: "streamable-http", url: "https://acme.example/mcp" }],
+  };
+}
+
 async function get(path: string): Promise<Response> {
   const { loader } = await import("@/routes/mcp-catalog-feed");
   try {
@@ -77,7 +86,15 @@ async function seedRevision(
              CASE WHEN $4 IN ('published', 'revoked') THEN now() END,
              CASE WHEN $4 IN ('published', 'revoked') THEN 'Staff' END,
              CASE WHEN $4 = 'revoked' THEN now() END)`,
-    [id, serverId, seq, status, String(doc.version), JSON.stringify(doc)],
+    [
+      id,
+      serverId,
+      seq,
+      status,
+      // A document that names no version stores a NULL column — never the string "undefined".
+      doc.version === undefined ? null : String(doc.version),
+      JSON.stringify(doc),
+    ],
   );
   if (opts.current === true) {
     await db.q(`UPDATE web.mcp_server SET current_revision_id = $2 WHERE id = $1`, [serverId, id]);
@@ -163,6 +180,20 @@ beforeAll(async () => {
     mcpRevisionId("self_2"),
     2,
     document("sh.topos/internal-notes", "1.0.0"),
+    { current: true },
+  );
+
+  // A VERSION-LESS self-maintained server: it names no version at all. The feed must serve it
+  // without inventing one — no `version` key on the document, `latest` resolving its single current.
+  await db.q(
+    `INSERT INTO web.mcp_server (id, workspace_id, registry_name, display_name, auth_mode, status)
+     VALUES ('mcps_f_unversioned', NULL, NULL, 'Unversioned', 'none', 'active')`,
+  );
+  await seedRevision(
+    "mcps_f_unversioned",
+    mcpRevisionId("unversioned_1"),
+    1,
+    versionlessDocument("sh.topos/unversioned"),
     { current: true },
   );
 }, 60000);
@@ -315,6 +346,48 @@ describe("a self-maintained server (no upstream name)", () => {
     expect(((await latest.json()) as { server: { version: string } }).server.version).toBe("1.0.0");
     const named = await get(`/mcp-catalog/v0.1/servers/${ENCODED}/versions/0.9.0`);
     expect(((await named.json()) as { server: { version: string } }).server.version).toBe("0.9.0");
+  });
+});
+
+describe("a version-less server (no version at all)", () => {
+  const ENCODED = encodeURIComponent("sh.topos/unversioned");
+
+  it("appears in the feed with no version key — never a fabricated number", async () => {
+    const res = await get("/mcp-catalog/v0.1/servers?limit=100");
+    const body = (await res.json()) as {
+      servers: { server: { name: string; version?: string } }[];
+    };
+    const self = body.servers.find((s) => s.server.name === "sh.topos/unversioned");
+    expect(self).toBeDefined();
+    // The document is served verbatim, and it never carried a version — so the wire carries none.
+    expect(self?.server.version).toBeUndefined();
+    expect(Object.hasOwn(self?.server ?? {}, "version")).toBe(false);
+  });
+
+  it("resolves /versions and /versions/latest to its one current document, no version invented", async () => {
+    const versions = await get(`/mcp-catalog/v0.1/servers/${ENCODED}/versions`);
+    expect(versions.status).toBe(200);
+    const list = (await versions.json()) as {
+      servers: {
+        server: { name: string; version?: string };
+        _meta: { "sh.topos/catalog": { isLatest: boolean } };
+      }[];
+    };
+    expect(list.servers).toHaveLength(1);
+    expect(list.servers[0]?.server.version).toBeUndefined();
+    expect(list.servers[0]?._meta["sh.topos/catalog"].isLatest).toBe(true);
+
+    const latest = await get(`/mcp-catalog/v0.1/servers/${ENCODED}/versions/latest`);
+    expect(latest.status).toBe(200);
+    const latestBody = (await latest.json()) as { server: { name: string; version?: string } };
+    expect(latestBody.server.name).toBe("sh.topos/unversioned");
+    expect(latestBody.server.version).toBeUndefined();
+  });
+
+  it("a numbered version selector matches nothing on a version-less server — the registry's 404", async () => {
+    const res = await get(`/mcp-catalog/v0.1/servers/${ENCODED}/versions/1.0.0`);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ title: "Not Found", status: 404 });
   });
 });
 

--- a/web/tests/unit/mcp-catalog.test.ts
+++ b/web/tests/unit/mcp-catalog.test.ts
@@ -55,6 +55,20 @@ function serverDocument(
   };
 }
 
+/** The same, but with NO `version` field — the honest shape of an editorial/self-maintained
+ *  server we never stamped a fake version on. */
+function versionlessDocument(
+  name: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    name,
+    description: "A server for the suite.",
+    remotes: [{ type: "streamable-http", url: "https://mcp.example.com/mcp" }],
+    ...extra,
+  };
+}
+
 /** A global catalog row with no revisions yet — the shape a sweep's pull-in leaves behind. */
 async function seedGlobalServer(
   id: string,
@@ -154,12 +168,17 @@ describe("the seeded catalog", () => {
     );
     const failures: string[] = [];
     for (const row of rows) {
-      const validated = validateCandidateFiles([
-        {
-          path: "server.json",
-          bytes: new TextEncoder().encode(canonicalServerJson(row.document)),
-        },
-      ]);
+      // The seed is editorial, not registry-sourced, so it is held to the same door those servers
+      // enter through — one that does NOT demand a version, because the curated list never had one.
+      const validated = validateCandidateFiles(
+        [
+          {
+            path: "server.json",
+            bytes: new TextEncoder().encode(canonicalServerJson(row.document)),
+          },
+        ],
+        { requireVersion: false },
+      );
       if (!validated.ok) {
         failures.push(`${row.registry_name}: ${validated.code} ${validated.message}`);
       } else if (validated.summary.name !== row.registry_name) {
@@ -167,6 +186,29 @@ describe("the seeded catalog", () => {
       }
     }
     expect(failures).toEqual([]);
+  });
+
+  it("stamps no fabricated version: every seeded revision is null, and its document names none", async () => {
+    // The migration undid the placeholder `1.0.0` — the honest end state is a null column and a
+    // document with no `version` key, never a made-up number to keep the column non-null. And the
+    // `$schema` that REQUIRED a version comes off with it (schema_version too), so the document is
+    // not left declaring a schema it now violates — a schema-aware client reading the feed accepts it.
+    const rows = await db.q<{
+      upstream_version: string | null;
+      schema_version: string | null;
+      has_version: boolean;
+      has_schema: boolean;
+    }>(
+      `SELECT r.upstream_version, r.schema_version,
+              (r.document ? 'version') AS has_version, (r.document ? '$schema') AS has_schema
+       FROM web.mcp_server s JOIN web.mcp_server_revision r ON r.id = s.current_revision_id
+       WHERE s.workspace_id IS NULL AND r.source = 'seed'`,
+    );
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => r.upstream_version === null)).toBe(true);
+    expect(rows.every((r) => r.has_version === false)).toBe(true);
+    expect(rows.every((r) => r.schema_version === null)).toBe(true);
+    expect(rows.every((r) => r.has_schema === false)).toBe(true);
   });
 
   it("carries the editorial half: a manual row says what the person has to do", async () => {
@@ -270,6 +312,57 @@ describe("a version is upstream's promise, and only upstream's", () => {
     expect(new Set(rows.map((r) => r.upstream_version))).toEqual(new Set(["4.0.0"]));
     // The pointer followed the edit: what the workspace receives is the newest save.
     expect(await currentRevisionOf(created.serverId)).toBe(edited.revisionId);
+  });
+});
+
+describe("a server with no version carries none — no fabricated number", () => {
+  it("an owner may write down a server whose document names no version, stored as NULL", async () => {
+    const { createPrivateMcpServer } = await catalog();
+    const owner = asOwner(wsId, "u_owner", "Owner");
+    const created = await createPrivateMcpServer(
+      owner,
+      { displayName: "Versionless", authMode: "none" },
+      versionlessDocument("com.example/versionless"),
+    );
+    expect(created.refusal, created.refusal?.message).toBeNull();
+    if (created.refusal !== null) {
+      return;
+    }
+    const rows = await db.q<{ upstream_version: string | null; has_version: boolean }>(
+      `SELECT upstream_version, (document ? 'version') AS has_version
+       FROM web.mcp_server_revision WHERE server_id = $1`,
+      [created.serverId],
+    );
+    // Null column, and the document never grew a version key on the way in.
+    expect(rows[0]?.upstream_version).toBeNull();
+    expect(rows[0]?.has_version).toBe(false);
+  });
+
+  it("a REGISTRY revision that names no version is still refused — upstream must carry one", async () => {
+    const serverId = await seedGlobalServer("mcps_reg_noversion", "com.example/reg-noversion");
+    const refused = await addRevision(serverId, {
+      document: versionlessDocument("com.example/reg-noversion"),
+      source: "registry",
+      publish: false,
+    });
+    expect(refused.refusal?.code).toBe("MCP_INVALID");
+    expect(refused.refusal?.message).toContain("version");
+  });
+
+  it("a version-less document that STILL declares an official schema is refused — that schema requires a version", async () => {
+    // The honest shape of a version-less server makes no schema claim. A document that omits the
+    // version but keeps a `$schema` that requires it is self-contradictory, and would be stored and
+    // served verbatim as schema-invalid — so even an owner's own write refuses it.
+    const { createPrivateMcpServer } = await catalog();
+    const owner = asOwner(wsId, "u_owner", "Owner");
+    const created = await createPrivateMcpServer(
+      owner,
+      { displayName: "Schema no version", authMode: "none" },
+      versionlessDocument("com.example/schema-no-version", {
+        $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      }),
+    );
+    expect(created.refusal?.code).toBe("MCP_INVALID");
   });
 });
 
@@ -564,16 +657,17 @@ describe("precedence guards the accept", () => {
     expect(await currentRevisionOf(serverId)).toBe(upstream.revisionId);
   });
 
-  it("lets any candidate freely supersede a SEED placeholder current — no override, even older", async () => {
+  it("lets any candidate freely supersede a version-less current — no override, even older", async () => {
     const serverId = await seedGlobalServer("mcps_prec_seed", "com.example/prec-seed");
-    // The current is a SEED placeholder — the version the migration stamped, not a decision.
+    // The current is a SEED placeholder — and a seed now carries NO version, which is precisely what
+    // makes it a starting point rather than a decision: there is nothing to move backward from.
     const seeded = await addRevision(serverId, {
-      document: serverDocument("com.example/prec-seed", "1.0.0"),
+      document: versionlessDocument("com.example/prec-seed"),
       source: "seed",
       publish: true,
     });
-    // Upstream's real version is OLDER by semver, yet it still moves the pointer: a seed is a
-    // placeholder to be replaced the moment a real document arrives, never a prior to move back from.
+    // Upstream's real version is OLDER by semver, yet it still moves the pointer: a version-less
+    // current is freely superseded the moment a real document arrives, never a prior to move back from.
     const upstream = await addRevision(serverId, {
       document: serverDocument("com.example/prec-seed", "0.0.1"),
       source: "registry",
@@ -593,6 +687,33 @@ describe("precedence guards the accept", () => {
       [upstream.revisionId],
     );
     expect(audit[0]?.details.overrode).toBeUndefined();
+  });
+
+  it("still protects a version-less current a PERSON authored — provenance outranks a null version", async () => {
+    const serverId = await seedGlobalServer("mcps_prec_staff_nv", "com.example/prec-staff-nv");
+    // A staff correction that names no version is STILL a decision someone made — the null-version
+    // "freely superseded" rule is for placeholders, not for a person's own hand-authored statement.
+    const authored = await addRevision(serverId, {
+      document: versionlessDocument("com.example/prec-staff-nv"),
+      source: "staff",
+      publish: true,
+    });
+    const upstream = await addRevision(serverId, {
+      document: serverDocument("com.example/prec-staff-nv", "2.0.0"),
+      source: "registry",
+      publish: false,
+    });
+    if (authored.refusal !== null || upstream.refusal !== null) {
+      throw new Error("the fixture revisions did not land");
+    }
+    const { acceptMcpRevision } = await catalog();
+    const refused = await acceptMcpRevision(staff, upstream.revisionId);
+    expect(refused.refusal?.code).toBe("MCP_PRECEDENCE_PROTECTED");
+    expect(await currentRevisionOf(serverId)).toBe(authored.revisionId);
+    // A deliberate override still moves it.
+    const overridden = await acceptMcpRevision(staff, upstream.revisionId, { override: true });
+    expect(overridden.refusal).toBeNull();
+    expect(await currentRevisionOf(serverId)).toBe(upstream.revisionId);
   });
 });
 

--- a/web/tests/unit/mcp-lane-add.test.ts
+++ b/web/tests/unit/mcp-lane-add.test.ts
@@ -246,6 +246,43 @@ describe("a server the catalog does NOT offer", () => {
   });
 });
 
+describe("a version is demanded of a registry read, but not of an author's own document", () => {
+  /** A document that names NO version — the honest shape of a self-authored server. */
+  function versionless(name: string): Record<string, unknown> {
+    return {
+      name,
+      description: "A server for the suite.",
+      remotes: [{ type: "streamable-http", url: "https://mcp.example.com/mcp" }],
+    };
+  }
+
+  it("a version-less response to a REGISTRY name is refused — upstream must carry a version", async () => {
+    upstream = { text: JSON.stringify(versionless("io.github.acme/reg-noversion")) };
+    const answer = await post("sn_owner", { registry_name: "io.github.acme/reg-noversion" });
+    expect(answer.body.ok).toBe(false);
+    expect(errorCodeOf(answer.body)).toBe("MCP_INVALID");
+    const rows = await db.q<{ n: string }>(
+      `SELECT COUNT(*) AS n FROM web.mcp_server WHERE registry_name = $1`,
+      ["io.github.acme/reg-noversion"],
+    );
+    expect(Number(rows[0]?.n)).toBe(0);
+  });
+
+  it("a version-less DOCUMENT LINK is the author's own server, stored with a null version", async () => {
+    upstream = { text: JSON.stringify(versionless("io.github.acme/link-noversion")) };
+    const answer = await post("sn_owner", { document_url: "https://acme.example/server.json" });
+    expect(answer.body.ok, JSON.stringify(answer.body)).toBe(true);
+    expect(dataOf(answer.body).created).toBe(true);
+    const rows = await db.q<{ upstream_version: string | null }>(
+      `SELECT r.upstream_version
+       FROM web.mcp_server s JOIN web.mcp_server_revision r ON r.id = s.current_revision_id
+       WHERE s.registry_name = $1`,
+      ["io.github.acme/link-noversion"],
+    );
+    expect(rows[0]?.upstream_version).toBeNull();
+  });
+});
+
 describe("the document gate rules, and its words are the ones the machine renders", () => {
   it("a document carrying a credential is refused with the gate's own code", async () => {
     upstream = {

--- a/web/tests/unit/mcp-precedence.test.ts
+++ b/web/tests/unit/mcp-precedence.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   compareServerVersion,
-  isSeedPlaceholder,
   isStaffAuthoredSource,
   isStrictlyNewer,
   type McpPrecedenceFacts,
@@ -13,7 +12,7 @@ import {
  * function of two revisions' facts and nothing else, and the `$schema` string is never one of them.
  */
 
-function facts(version: string, protocolVersions: unknown = null): McpPrecedenceFacts {
+function facts(version: string | null, protocolVersions: unknown = null): McpPrecedenceFacts {
   return { version, protocolVersions };
 }
 
@@ -39,6 +38,14 @@ describe("ordering server versions", () => {
   it("says it cannot order a version it does not read, rather than guessing", () => {
     expect(compareServerVersion("nightly", "1.0.0")).toBeNull();
     expect(compareServerVersion("1.0.0", "")).toBeNull();
+  });
+
+  it("cannot order a version that is ABSENT — a null is 'cannot say', never a zero", () => {
+    // A revision that names no version has nothing to compare, so neither side of a null orders —
+    // the accept guard reads this as "freely superseded", never as "1.0.0 beats null".
+    expect(compareServerVersion(null, "1.0.0")).toBeNull();
+    expect(compareServerVersion("1.0.0", null)).toBeNull();
+    expect(compareServerVersion(null, null)).toBeNull();
   });
 
   it("treats a malformed label as ambiguous, never as a clean release", () => {
@@ -89,6 +96,14 @@ describe("strictly newer", () => {
     expect(isStrictlyNewer(facts("rolling"), facts("1.0.0"))).toBe(false);
   });
 
+  it("cannot call a candidate strictly newer than a version-less current — that is the guard's job", () => {
+    // This pure comparison never says "newer" over a null on either side; a version-less CURRENT
+    // being freely superseded is a decision the accept guard makes on the null itself, not here.
+    expect(isStrictlyNewer(facts("2.0.0"), facts(null))).toBe(false);
+    expect(isStrictlyNewer(facts(null), facts("1.0.0"))).toBe(false);
+    expect(isStrictlyNewer(facts(null), facts(null))).toBe(false);
+  });
+
   it("a malformed candidate label never supersedes a real release", () => {
     expect(isStrictlyNewer(facts("2.0.0-"), facts("1.0.0"))).toBe(false);
     expect(isStrictlyNewer(facts("1.0.0-rc."), facts("1.0.0"))).toBe(false);
@@ -100,17 +115,9 @@ describe("which sources a person authored", () => {
     expect(isStaffAuthoredSource("staff")).toBe(true);
     expect(isStaffAuthoredSource("owner")).toBe(true);
     expect(isStaffAuthoredSource("registry")).toBe(false);
-    // A seed is a placeholder the migration stamped, not a decision a person made — so it does not
-    // stand between upstream and the pointer, and any candidate freely supersedes it.
+    // A seed is a starting point the catalog stood up, not a decision a person made — so it is not
+    // provenance-protected. It is instead freely superseded because it carries no version (the
+    // accept guard's general "null version" rule), never by naming the source.
     expect(isStaffAuthoredSource("seed")).toBe(false);
-  });
-});
-
-describe("which current is a seed placeholder", () => {
-  it("only a seed is one — a staff, owner or upstream current is a real prior", () => {
-    expect(isSeedPlaceholder("seed")).toBe(true);
-    expect(isSeedPlaceholder("staff")).toBe(false);
-    expect(isSeedPlaceholder("owner")).toBe(false);
-    expect(isSeedPlaceholder("registry")).toBe(false);
   });
 });

--- a/web/tests/unit/mcp-validate.test.ts
+++ b/web/tests/unit/mcp-validate.test.ts
@@ -227,6 +227,79 @@ describe("a real document on an older official schema", () => {
   });
 });
 
+/**
+ * A VERSION IS OPTIONAL UNLESS THE CALLER DEMANDS ONE. A document bound for the official registry
+ * must carry a version; one this install authors for its OWN catalog may honestly carry none, and
+ * the gate never fabricates a number to fill the gap.
+ */
+describe("a missing version is refused only when the caller requires one", () => {
+  const versionless = JSON.stringify({
+    name: "io.github.acme/versionless",
+    description: "A server that names no version.",
+    remotes: [{ type: STREAMABLE_HTTP, url: "https://versionless.acme.example/mcp" }],
+  });
+
+  it("refuses a missing version by default — the strict, registry-grade gate", () => {
+    const result = validateServerJson(versionless);
+    expect(result.ok === false && result.code).toBe("MCP_INVALID");
+    expect(result.ok === false && result.message).toContain("version");
+  });
+
+  it("still refuses a missing version when requireVersion is explicitly on", () => {
+    const result = validateServerJson(versionless, { requireVersion: true });
+    expect(result.ok === false && result.code).toBe("MCP_INVALID");
+  });
+
+  it("accepts a missing version when the caller relaxes it, and reports version as null", () => {
+    const result = validateServerJson(versionless, { requireVersion: false });
+    expect(result.ok, result.ok === false ? result.message : "").toBe(true);
+    expect(result.ok === true && result.summary.version).toBeNull();
+  });
+
+  it("an explicit `version: null` is malformed, not absent — a present field must be a string", () => {
+    // Absence is an OMITTED key; a present `null` is a non-string value the schema forbids, and
+    // storing it verbatim would serve `"version": null` to schema-aware clients. Refused even relaxed.
+    const explicitNull = JSON.stringify({
+      name: "io.github.acme/nulled",
+      description: "A version field present, but null.",
+      version: null,
+      remotes: [{ type: STREAMABLE_HTTP, url: "https://nulled.acme.example/mcp" }],
+    });
+    const result = validateServerJson(explicitNull, { requireVersion: false });
+    expect(result.ok === false && result.code).toBe("MCP_INVALID");
+  });
+
+  it("a version that IS present is still checked, relaxed or not — no range, no `latest`", () => {
+    const ranged = JSON.stringify({
+      name: "io.github.acme/ranged",
+      description: "A version that names a set.",
+      version: "^1.2.3",
+      remotes: [{ type: STREAMABLE_HTTP, url: "https://ranged.acme.example/mcp" }],
+    });
+    expect(validateServerJson(ranged, { requireVersion: false }).ok === false).toBe(true);
+    const latest = JSON.stringify({
+      name: "io.github.acme/latest",
+      description: "The moving pointer, not a version.",
+      version: "latest",
+      remotes: [{ type: STREAMABLE_HTTP, url: "https://latest.acme.example/mcp" }],
+    });
+    const result = validateServerJson(latest, { requireVersion: false });
+    expect(result.ok === false && result.code).toBe("MCP_INVALID");
+  });
+
+  it("the candidate gate carries the same relaxation through to its document", () => {
+    const relaxed = validateCandidateFiles(
+      [{ path: "server.json", bytes: Buffer.from(versionless, "utf8") }],
+      { requireVersion: false },
+    );
+    expect(relaxed.ok).toBe(true);
+    const strict = validateCandidateFiles([
+      { path: "server.json", bytes: Buffer.from(versionless, "utf8") },
+    ]);
+    expect(strict.ok === false && strict.code).toBe("MCP_INVALID");
+  });
+});
+
 describe("the exact-version grammars", () => {
   /**
    * Probe for probe, the SAME table the client's suite drives. A grammar that answered differently


### PR DESCRIPTION
The curated-catalog seed stamped a placeholder 1.0.0 on every curated server because the curated data had no versions. That fabricated number broke semver precedence against real-but-lower upstream versions and was published to the world through the feed.

- `mcp_server_revision.upstream_version` becomes nullable; null means no known version.
- The document validator stops requiring a version for our own editorial (non-registry) documents; registry-sourced documents still require one. No version is ever fabricated to pass the gate.
- The seed no longer stamps a version; a migration strips the fabricated 1.0.0 (and its now-invalid $schema) from existing seed rows, in place, seed-scoped and idempotent.
- Precedence treats a version-less current as freely superseded by rule, retiring the seed special-case; genuine downgrade protection between two real versions stays.
- Feed, the registry versions/latest endpoints, and the admin/workspace UI render a version-less server honestly ("unversioned" as a label only) — never an invented number.

Web-only feed/catalog change plus an additive CLI add-receipt tweak (no wire floor moved). Gates: bun run check, vitest 1168, cargo xtask ci, Playwright 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)