### PR TITLE
The master key can live in a key service instead of on the box

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -44,6 +44,9 @@ RUN bun install --frozen-lockfile --production
 COPY gateway/core ./core
 COPY gateway/service ./service
 COPY gateway/migrations ./migrations
+# The one-off master-key re-wrap, run against a stopped deployment's database:
+#   docker compose run --rm gateway bun scripts/rewrap-workspace-keys.ts --from file --dry-run
+COPY gateway/scripts ./scripts
 
 # Both listeners bind all interfaces INSIDE the container (the checkout defaults are loopback, for
 # a laptop); which of them the world can reach is the compose file's ruling, not this one.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -14,9 +14,13 @@ call. Revocation is a row change, effective next call.
   engine and whatever hosts it). The same engine runs in this container service and in an edge
   isolate.
 - `service/` — the container host: Postgres adapters (`store.ts`), envelope crypto
-  (`crypto.ts`), the SSRF-guarded fetch (`guarded-fetch.ts`), the OAuth authorize walk
-  (`oauth.ts`), the web→gateway internal lane (`internal.ts`), the public listener
-  (`server.ts`), boot migration (`migrate.ts`), entry point (`main.ts`).
+  (`crypto.ts`), the master key backends (`master-key.ts` picks one; `kms.ts` + `kms-gcp.ts` +
+  `kms-aws.ts` + `gcp-auth.ts` are the KMS clients), the master-key migration (`rewrap.ts`), the
+  SSRF-guarded fetch (`guarded-fetch.ts`), the OAuth authorize walk (`oauth.ts`), the
+  web→gateway internal lane (`internal.ts`), the public listener (`server.ts`), boot migration
+  (`migrate.ts`), entry point (`main.ts`).
+- `scripts/` — one-off operator tools run against a stopped deployment
+  (`rewrap-workspace-keys.ts`).
 - `migrations/` — the plain-SQL lineage for schema `gateway` (owned by role `topos_gateway`),
   applied at boot under an advisory lock, ledger `gateway.__migrations` (sha256-pinned; an
   applied file that changes on disk refuses to boot). Hand-rolled on purpose: the lineage is
@@ -43,9 +47,74 @@ call. Revocation is a row change, effective next call.
 Credentials split across two tables: `gateway.credential` (metadata — `topos_web` holds SELECT,
 so the web renders sign-in state with no lane call) and `gateway.credential_secret` (ciphertext —
 NO grant to web, ever; the grants suite proves the refusal). Envelope: AES-256-GCM via WebCrypto,
-a per-workspace data key wrapped by the master key (`GATEWAY_MASTER_KEY_FILE`, exactly 32 raw
-bytes, warn-on-loose-mode), and AAD binding every ciphertext to its (credential id, workspace id)
-so copied bytes decrypt nowhere else.
+a per-workspace data key wrapped by the master key, and AAD binding every ciphertext to its
+(credential id, workspace id) so copied bytes decrypt nowhere else.
+
+The leading byte of every envelope says which key opens it, and a backend refuses the other's
+bytes by name rather than failing to decrypt:
+
+| Byte | Meaning |
+|---|---|
+| `0x01` | AES-256-GCM under a key this process holds. Every credential ciphertext, always; and a data key wrapped by the `file` backend. |
+| `0x02` | A data key wrapped by an external KMS. Second byte is the provider (`0x01` gcp-kms, `0x02` aws-kms); the rest is that service's own ciphertext. |
+
+An unwrapped data key is cached in memory for 15 minutes, keyed by workspace **and** by the
+wrapped bytes it came from — so one KMS round trip serves a workspace's traffic instead of one per
+proxied call, and a row re-wrapped to another backend can never be served from a stale entry.
+Credential revocation is unaffected: it is a row delete, and the row is gone before any key is
+consulted.
+
+## Master key backends
+
+`GATEWAY_KEY_BACKEND` picks one. Missing configuration REFUSES TO BOOT — there is no fallback to a
+file key, ever. Whichever backend is configured, boot wraps and unwraps a probe value before the
+first listener binds, so a deployment that cannot open its own credentials fails in the deploy
+rather than on some agent's first tool call.
+
+- **`file`** (default, today's deployment) — 32 raw bytes at `GATEWAY_MASTER_KEY_FILE`, minted on
+  first boot by the image's entrypoint. Lose the volume and every stored sign-in becomes
+  unreadable; back it up with the database.
+- **`gcp-kms`** — wrap/unwrap are `cryptoKeys.encrypt`/`cryptoKeys.decrypt` calls to Cloud KMS
+  over its REST API with the workspace AAD in `additionalAuthenticatedData`. The master key never
+  enters this process. Credentials come from a mounted service-account JSON key
+  (`GOOGLE_APPLICATION_CREDENTIALS`, RFC 7523 JWT-bearer, scope
+  `https://www.googleapis.com/auth/cloudkms`) or, with none set, the instance metadata server.
+- **`aws-kms`** — the same shape over `Encrypt`/`Decrypt`, with the AAD as the `EncryptionContext`.
+  Static environment credentials only (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optionally
+  `AWS_SESSION_TOKEN`); the ECS/EKS container credential providers are not implemented and their
+  absence is a refusal, not an ambient guess.
+
+**Why plain `fetch` and not a vendor SDK.** Each provider is two calls against one host with a
+bearer or a signature. `@google-cloud/kms` brings gRPC and protobuf loading; `@aws-sdk/client-kms`
+brings a large dependency tree — into an image whose entire runtime dependency list is `pg` and
+`zod`, and into a service whose other transport is a hand-written SSRF-guarded fetch precisely so
+nothing dials on its own. Each client here is ~100 lines and every byte on the wire is visible in
+its file. The cost is the AWS request signature (SigV4, ~70 lines): worth it for one POST to one
+path with no query string, and pinned by the published test vectors.
+
+The KMS clients use the PLAIN fetch, not the guarded one: the guard exists to keep
+upstream-influenced addresses out of private ranges, and the metadata server is a link-local
+address it is built to refuse. These hosts are operator configuration, not upstream input.
+
+### What each backend does and does not protect against
+
+The file backend does NOT survive host compromise. Anyone who can read the volume — a container
+escape, a stolen backup of the volume, a root shell on the box — holds the master key, and with a
+copy of the database can decrypt every stored credential offline, forever, with no trace.
+
+A KMS keeps the master key out of this process and out of any backup: an attacker with the
+database and the disk holds only ciphertext, and unwrapping requires calls the key service
+authorizes, rate-limits, and logs. That is the real gain — key custody moves to a system with its
+own audit trail and its own revocation, and disabling the key ends all decryption everywhere.
+
+What a KMS does NOT protect against: an attacker who is executing code IN this process. The
+unwrapped data key transits this process's memory at call time and is cached there for up to 15
+minutes, and the credentials it opens are handed to the upstream on every proxied call — so a live
+compromise of the running container reads secrets as they flow, whichever backend is configured.
+Nor does it protect against a stolen service-account key file or a leaked instance credential:
+those are the authority to call unwrap, and anyone holding them plus the database is back to
+decrypting rows. A KMS narrows the window from "forever, offline, silently" to "while this
+credential is valid, online, and logged" — which is the point, and is not the same as immunity.
 
 ## Environment
 
@@ -57,8 +126,53 @@ so copied bytes decrypt nowhere else.
 | `GATEWAY_PUBLIC_URL` | the gateway's public base; the OAuth redirect_uri is `{here}/oauth/callback` |
 | `TOPOS_PUBLIC_URL` | the web app's origin — authorize-page links, callback return fence |
 | `GATEWAY_INTERNAL_TOKEN` | the lane's shared bearer; unset = lane unarmed (404) |
-| `GATEWAY_MASTER_KEY_FILE` | path to 32 raw bytes; any other size refuses boot |
+| `GATEWAY_KEY_BACKEND` | `file` (default) · `gcp-kms` · `aws-kms` |
+| `GATEWAY_MASTER_KEY_FILE` | path to 32 raw bytes; any other size refuses boot. Required for `file`; kept mounted alongside a KMS only while a re-wrap is pending |
+| `GATEWAY_KMS_KEY` | required by both KMS backends — the provider's full resource name: `projects/{p}/locations/{l}/keyRings/{r}/cryptoKeys/{k}` or `arn:aws:kms:{region}:{account}:key/{id}` (the AWS region is read out of the ARN) |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `gcp-kms`: path to a service-account JSON key. Unset ⇒ the instance metadata server |
+| `GATEWAY_GCP_ACCESS_TOKEN` | `gcp-kms`: a ready-made token for a hand smoke test. REFUSED in production — nothing renews it |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` | `aws-kms`: the credentials, the first two required |
 | `GATEWAY_ALLOW_PRIVATE_UPSTREAMS` | `1` lets upstreams resolve to private ranges (self-host) |
+
+## Moving the master key to a KMS
+
+Only `gateway.workspace_key` changes: the data keys themselves are untouched, so every stored
+credential ciphertext stays exactly as it is. The sweep is idempotent (a row the destination can
+already open is left alone), atomic per row (locked, converted, committed one at a time), and
+verified before every write (the new envelope is unwrapped again through the destination and
+compared before the UPDATE). A row neither backend can open is reported and left intact.
+
+1. Create the key, grant the gateway's identity encrypt/decrypt on it, and put the credential in
+   place (for GCP: the service-account key file on the volume).
+2. **Stop the gateway.** It speaks exactly one backend, so a converted row is unreadable to a
+   still-running old process — and a workspace signing in mid-run would mint a key under the old
+   backend after the sweep had passed it.
+3. Rehearse, with the NEW environment (`GATEWAY_KEY_BACKEND=gcp-kms`, `GATEWAY_KMS_KEY=…`,
+   `GOOGLE_APPLICATION_CREDENTIALS=…`) and the OLD `GATEWAY_MASTER_KEY_FILE` still mounted. The dry
+   run does every step for real — unwrap, re-wrap, read back — and rolls the write away:
+
+   ```sh
+   docker compose run --rm \
+     -e GATEWAY_KEY_BACKEND=gcp-kms \
+     -e GATEWAY_KMS_KEY=projects/…/cryptoKeys/… \
+     -e GOOGLE_APPLICATION_CREDENTIALS=/run/topos/gcp-kms.json \
+     gateway bun scripts/rewrap-workspace-keys.ts --from file --dry-run
+   ```
+
+4. Run it for real (same command without `--dry-run`). Exit code is 0 only when every row is
+   readable under the destination; re-running after any interruption converts exactly what is
+   left.
+5. Deploy the gateway with the new environment. Once it is serving, unmount the key file volume —
+   until it is gone the box still holds a master key, and boot says so in a warning.
+
+The bundled `docker-compose.yml` runs the `file` backend and passes no KMS variables: it is the
+self-host path, where a volume the operator already backs up is the right custody. A KMS
+deployment sets these on the container itself (an orchestrator's environment panel), which is why
+the one-off above passes them with `-e`.
+
+The same command moves back (`--from gcp-kms` with `GATEWAY_KEY_BACKEND=file`). Re-keying WITHIN
+one backend — a new key file, a rotated KMS key — is refused: nothing here can express which key
+is the old one.
 
 ## Upstream reach (SSRF posture)
 

--- a/gateway/docker-entrypoint.sh
+++ b/gateway/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # The gateway image's entrypoint: make sure a master key exists, then hand off to the service.
 #
+# ONLY for the `file` key backend (the default). Under GATEWAY_KEY_BACKEND=gcp-kms/aws-kms the
+# master key lives in the key service and minting a file here would leave a 32-byte decoy on the
+# volume that protects nothing. A file→KMS migration still needs the OLD key file, so it stays
+# mounted until the re-wrap has run — mounted, never minted.
+#
 # The master key wraps every workspace's data key, which in turn encrypts every stored upstream
 # credential — so the key file is not configuration, it is CUSTODY. It lives on a volume rather
 # than in the image or the environment, and it is minted HERE, on first boot, because a
@@ -13,14 +18,16 @@
 # lost). Back the volume up with the database.
 set -eu
 
-key="${GATEWAY_MASTER_KEY_FILE:?GATEWAY_MASTER_KEY_FILE must be set (the image defaults it)}"
+if [ "${GATEWAY_KEY_BACKEND:-file}" = "file" ]; then
+  key="${GATEWAY_MASTER_KEY_FILE:?GATEWAY_MASTER_KEY_FILE must be set (the image defaults it)}"
 
-if [ ! -e "$key" ]; then
-  mkdir -p "$(dirname "$key")"
-  # 0600 from birth: the umask covers the window between create and chmod.
-  (umask 077 && head -c 32 /dev/urandom >"$key")
-  chmod 600 "$key"
-  echo "gateway: minted a new master key at $key — back up this volume with the database, or every stored sign-in becomes unreadable" >&2
+  if [ ! -e "$key" ]; then
+    mkdir -p "$(dirname "$key")"
+    # 0600 from birth: the umask covers the window between create and chmod.
+    (umask 077 && head -c 32 /dev/urandom >"$key")
+    chmod 600 "$key"
+    echo "gateway: minted a new master key at $key — back up this volume with the database, or every stored sign-in becomes unreadable" >&2
+  fi
 fi
 
 exec "$@"

--- a/gateway/scripts/rewrap-workspace-keys.ts
+++ b/gateway/scripts/rewrap-workspace-keys.ts
@@ -1,0 +1,55 @@
+import pg from "pg";
+import { gatewayEnv } from "../service/env";
+import { stderrLogger } from "../service/log";
+import { createMasterKeyBackend, proveMasterKeyBackend } from "../service/master-key";
+import { planRewrap, rewrapWorkspaceKeys } from "../service/rewrap";
+
+/**
+ * Re-wrap every workspace data key from the OLD master key backend to the one this environment now
+ * configures. Run it as a one-off against the same environment the service runs with:
+ *
+ *   bun scripts/rewrap-workspace-keys.ts --from file --dry-run
+ *   bun scripts/rewrap-workspace-keys.ts --from file
+ *
+ * The DESTINATION is `GATEWAY_KEY_BACKEND` — the same variable the service reads. `--from` names
+ * the backend that wrote the rows today, and its configuration must still be present (the key file
+ * still mounted, for a file → KMS move).
+ *
+ * Both backends are PROVEN by a wrap/unwrap round trip before a single row is touched: a run that
+ * cannot reach the KMS stops before it has done anything.
+ *
+ * STOP THE GATEWAY FIRST. The service speaks exactly one backend, so a converted row is unreadable
+ * to a still-running old process — and a workspace signing in mid-run would mint a key under the
+ * old backend after the sweep had passed it. Convert with nothing serving, then deploy.
+ *
+ * Exit code is 0 only when every row is readable under the destination.
+ */
+
+const log = stderrLogger();
+const env = gatewayEnv();
+
+let plan;
+try {
+  plan = planRewrap(process.argv.slice(2), env.GATEWAY_KEY_BACKEND);
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(2);
+}
+
+const source = createMasterKeyBackend(env, log, { backend: plan.from });
+const destination = createMasterKeyBackend(env, log);
+await proveMasterKeyBackend(source, log);
+await proveMasterKeyBackend(destination, log);
+
+const pool = new pg.Pool({ connectionString: env.DATABASE_URL, max: 2 });
+try {
+  const summary = await rewrapWorkspaceKeys(pool, {
+    from: source,
+    to: destination,
+    dryRun: plan.dryRun,
+    log,
+  });
+  process.exitCode = summary.failed === 0 ? 0 : 1;
+} finally {
+  await pool.end();
+}

--- a/gateway/service/crypto.ts
+++ b/gateway/service/crypto.ts
@@ -4,20 +4,26 @@ import { randomBytes, timingSafeEqual as nodeTimingSafeEqual, createHash } from 
 /**
  * Envelope crypto for credential custody — AES-256-GCM throughout, via WebCrypto.
  *
- * Two layers: a per-workspace DATA KEY encrypts credential payloads; the MASTER KEY (increment 1
- * backend: a 32-byte file at GATEWAY_MASTER_KEY_FILE) wraps each data key. Every ciphertext's AAD
- * binds it to its row identity — a credential's to (credential id, workspace id), a wrapped key's
- * to its workspace id — so copying bytes between rows yields nothing but a decrypt failure.
+ * Two layers: a per-workspace DATA KEY encrypts credential payloads; a MASTER KEY BACKEND wraps
+ * each data key. Every ciphertext's AAD binds it to its row identity — a credential's to
+ * (credential id, workspace id), a wrapped key's to its workspace id — so copying bytes between
+ * rows yields nothing but a decrypt failure.
  *
- * The envelope byte layout is versioned for a later KMS backend:
- *   [0] format version (0x01) · [1..13] 96-bit IV · [13..] GCM ciphertext+tag.
+ * The leading byte of every envelope says which kind of key opens it:
+ *   0x01 — AES-256-GCM under a key THIS PROCESS HOLDS: [0] 0x01 · [1..13] 96-bit IV · [13..]
+ *          ciphertext+tag. Every credential ciphertext is this, always (the data key is local by
+ *          construction); a data key wrapped by `FileMasterKey` is this too.
+ *   0x02 — a data key wrapped by an EXTERNAL KMS (`service/kms.ts` owns that layout).
+ * A backend unwraps its own version and refuses the other by name, so a row's bytes — not the
+ * deployment's configuration — decide which key must open it.
  *
  * Nothing here logs, and nothing here holds plaintext longer than its caller does.
  */
 
-const FORMAT_VERSION = 0x01;
+/** AES-256-GCM under a key this process holds. Its meaning is frozen: rows in the field carry it. */
+export const LOCAL_FORMAT_VERSION = 0x01;
 const IV_BYTES = 12;
-const KEY_BYTES = 32;
+export const KEY_BYTES = 32;
 
 /** The decrypted payload one credential row protects. */
 export interface CredentialPayload {
@@ -77,11 +83,11 @@ async function seal(key: CryptoKey, plaintext: Buffer, aad: string): Promise<Buf
     key,
     new Uint8Array(plaintext),
   );
-  return Buffer.concat([Buffer.from([FORMAT_VERSION]), iv, Buffer.from(sealed)]);
+  return Buffer.concat([Buffer.from([LOCAL_FORMAT_VERSION]), iv, Buffer.from(sealed)]);
 }
 
 async function open(key: CryptoKey, envelope: Buffer, aad: string): Promise<Buffer> {
-  if (envelope.length < 1 + IV_BYTES || envelope[0] !== FORMAT_VERSION) {
+  if (envelope.length < 1 + IV_BYTES || envelope[0] !== LOCAL_FORMAT_VERSION) {
     throw new Error("unrecognized envelope format");
   }
   const iv = envelope.subarray(1, 1 + IV_BYTES);
@@ -99,28 +105,168 @@ function credentialAad(credentialId: string, workspaceId: string): string {
   return `topos:gateway:credential:${credentialId}:${workspaceId}`;
 }
 
-function workspaceKeyAad(workspaceId: string): string {
+/** The wrap's AAD. Exported because the re-wrap routine seals under the SAME binding. */
+export function workspaceKeyAad(workspaceId: string): string {
   return `topos:gateway:workspace-key:${workspaceId}`;
 }
 
-export class EnvelopeCrypto {
-  private masterKey: Promise<CryptoKey>;
+/**
+ * Where the master key lives. `wrapDataKey`/`unwrapDataKey` are the WHOLE contract: a backend may
+ * hold the key in this process (`FileMasterKey`) or never see it at all (`KmsMasterKey`, whose
+ * wrap and unwrap are RPCs), and nothing above this interface can tell which.
+ *
+ * `aad` binds a wrap to its row and MUST reach the underlying primitive as authenticated data —
+ * dropping it would let a wrapped key be moved between workspaces, which is the property the two
+ * layers exist for. Every backend stamps `formatVersion` as the envelope's first byte and refuses
+ * any other version by name; that refusal is what keeps a deployment from silently reading rows
+ * its configured key cannot actually open.
+ */
+export interface MasterKeyBackend {
+  /** The envelope version this backend produces AND the only one it will open. */
+  readonly formatVersion: number;
+  /** Log-safe identity for boot and the re-wrap ledger — never key material. */
+  readonly describe: string;
+  wrapDataKey(plaintextKey: Buffer, aad: string): Promise<Buffer>;
+  unwrapDataKey(envelope: Buffer, aad: string): Promise<Buffer>;
+}
+
+const VERSION_BLAME = new Map<number, string>([
+  [LOCAL_FORMAT_VERSION, "the file key backend"],
+  [0x02, "a KMS key backend"],
+]);
+
+/**
+ * Fail closed on a wrapped key this backend did not write. The version byte is the row's own
+ * statement of what wrote it, so the refusal names both sides: an operator who moved a deployment
+ * to a KMS without running the re-wrap gets told exactly that, not a decrypt failure.
+ */
+export function assertWrapVersion(envelope: Buffer, expected: number, backend: string): void {
+  const found = envelope[0];
+  if (found === expected) {
+    return;
+  }
+  const wrote =
+    found === undefined
+      ? "an empty value"
+      : (VERSION_BLAME.get(found) ?? `an unrecognized backend (0x${found.toString(16).padStart(2, "0")})`);
+  throw new Error(
+    `wrapped workspace key was written by ${wrote}; this gateway runs the ${backend} backend ` +
+      `(envelope format 0x${expected.toString(16).padStart(2, "0")})`,
+  );
+}
+
+/**
+ * The master key as 32 bytes in this process's memory — today's deployment, unchanged. The wrap
+ * is local AES-256-GCM, so a data key wrapped here is a plain 0x01 envelope and every wrapped key
+ * already in the field keeps opening.
+ */
+export class FileMasterKey implements MasterKeyBackend {
+  readonly formatVersion = LOCAL_FORMAT_VERSION;
+  readonly describe = "file";
+  private key: Promise<CryptoKey>;
 
   constructor(masterKeyBytes: Buffer) {
-    this.masterKey = importAesKey(masterKeyBytes);
+    this.key = importAesKey(masterKeyBytes);
   }
+
+  async wrapDataKey(plaintextKey: Buffer, aad: string): Promise<Buffer> {
+    return seal(await this.key, plaintextKey, aad);
+  }
+
+  async unwrapDataKey(envelope: Buffer, aad: string): Promise<Buffer> {
+    assertWrapVersion(envelope, this.formatVersion, this.describe);
+    return open(await this.key, envelope, aad);
+  }
+}
+
+/**
+ * How long an unwrapped data key stays usable in memory. Fifteen minutes is the trade: an unwrap
+ * is a network round trip under a KMS backend and EVERY proxied tool call needs one, so caching is
+ * what keeps the gateway's latency the upstream's rather than the key service's — while a window
+ * this short still bounds how long a workspace keeps working after its KMS key is disabled or its
+ * IAM binding is pulled. Nothing here is a substitute for revocation: revoking a CREDENTIAL is a
+ * row delete, which the store sees before any key is consulted.
+ */
+const DATA_KEY_TTL_MS = 15 * 60 * 1000;
+/** A ceiling on resident data keys — the busiest workspaces stay, the rest re-unwrap on demand. */
+const DATA_KEY_CACHE_MAX = 256;
+
+export class EnvelopeCrypto {
+  /**
+   * Unwrapped data keys, keyed by workspace AND by the wrapped bytes they came from. The digest in
+   * the key is what makes a re-wrapped row (a migration to another backend) impossible to serve
+   * from a stale entry: different bytes, different cache key, a real unwrap through whichever
+   * backend this process is configured with.
+   *
+   * The value is the in-flight PROMISE, so a burst of concurrent calls for one workspace makes one
+   * unwrap, not one per call. The CryptoKey it resolves to is non-extractable — the raw key bytes
+   * are dropped as soon as WebCrypto has imported them, and nothing can read them back out.
+   */
+  private dataKeys = new Map<string, { key: Promise<CryptoKey>; expiresAt: number }>();
+
+  constructor(
+    private masterKey: MasterKeyBackend,
+    private now: () => number = Date.now,
+  ) {}
 
   /** Mint a fresh workspace data key; returns it wrapped for storage. */
   async mintWrappedWorkspaceKey(workspaceId: string): Promise<Buffer> {
-    return seal(await this.masterKey, randomBytes(KEY_BYTES), workspaceKeyAad(workspaceId));
+    return this.masterKey.wrapDataKey(randomBytes(KEY_BYTES), workspaceKeyAad(workspaceId));
+  }
+
+  /** Drop every cached data key — the next call unwraps again. */
+  clearDataKeyCache(): void {
+    this.dataKeys.clear();
+  }
+
+  /**
+   * Can this backend actually open a wrap already sitting in the database? The boot proof answers
+   * "the configured key works", which is NOT the same question: a deployment switched to a KMS
+   * without running the re-wrap — or pointed at a different, perfectly valid key — passes that
+   * proof and then fails on every stored credential. This is what makes such a deployment refuse
+   * to serve instead of serving brokenly. Warms the cache for the workspaces it checks.
+   */
+  async canOpenWorkspaceKey(workspaceId: string, wrapped: Buffer): Promise<boolean> {
+    try {
+      await this.unwrapWorkspaceKey(workspaceId, wrapped);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async unwrapWorkspaceKey(workspaceId: string, wrapped: Buffer): Promise<CryptoKey> {
-    const raw = await open(await this.masterKey, wrapped, workspaceKeyAad(workspaceId));
-    if (raw.length !== KEY_BYTES) {
-      throw new Error("unwrapped workspace key has the wrong size");
+    const cacheKey = `${workspaceId}:${sha256Hex(wrapped)}`;
+    const standing = this.dataKeys.get(cacheKey);
+    if (standing !== undefined) {
+      if (this.now() < standing.expiresAt) {
+        // Re-insert to move this entry to the end: Map iterates in insertion order, so the
+        // eviction below drops the least recently USED rather than the oldest. The expiry is
+        // carried over unchanged — the TTL is absolute, so traffic cannot hold a key forever.
+        this.dataKeys.delete(cacheKey);
+        this.dataKeys.set(cacheKey, standing);
+        return standing.key;
+      }
+      this.dataKeys.delete(cacheKey);
     }
-    return importAesKey(raw);
+    const key = (async (): Promise<CryptoKey> => {
+      const raw = await this.masterKey.unwrapDataKey(wrapped, workspaceKeyAad(workspaceId));
+      if (raw.length !== KEY_BYTES) {
+        throw new Error("unwrapped workspace key has the wrong size");
+      }
+      return importAesKey(raw);
+    })();
+    // A failed unwrap must never be remembered — the next call has to ask the backend again.
+    key.catch(() => this.dataKeys.delete(cacheKey));
+    this.dataKeys.set(cacheKey, { key, expiresAt: this.now() + DATA_KEY_TTL_MS });
+    while (this.dataKeys.size > DATA_KEY_CACHE_MAX) {
+      const oldest = this.dataKeys.keys().next();
+      if (oldest.done === true) {
+        break;
+      }
+      this.dataKeys.delete(oldest.value);
+    }
+    return key;
   }
 
   async encryptCredential(

--- a/gateway/service/crypto.ts
+++ b/gateway/service/crypto.ts
@@ -219,22 +219,6 @@ export class EnvelopeCrypto {
     this.dataKeys.clear();
   }
 
-  /**
-   * Can this backend actually open a wrap already sitting in the database? The boot proof answers
-   * "the configured key works", which is NOT the same question: a deployment switched to a KMS
-   * without running the re-wrap — or pointed at a different, perfectly valid key — passes that
-   * proof and then fails on every stored credential. This is what makes such a deployment refuse
-   * to serve instead of serving brokenly. Warms the cache for the workspaces it checks.
-   */
-  async canOpenWorkspaceKey(workspaceId: string, wrapped: Buffer): Promise<boolean> {
-    try {
-      await this.unwrapWorkspaceKey(workspaceId, wrapped);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
   private async unwrapWorkspaceKey(workspaceId: string, wrapped: Buffer): Promise<CryptoKey> {
     const cacheKey = `${workspaceId}:${sha256Hex(wrapped)}`;
     const standing = this.dataKeys.get(cacheKey);
@@ -258,6 +242,14 @@ export class EnvelopeCrypto {
     })();
     // A failed unwrap must never be remembered — the next call has to ask the backend again.
     key.catch(() => this.dataKeys.delete(cacheKey));
+    // Sweep what has already expired. The TTL is checked on ACCESS, so without this an entry that
+    // is never asked for again sits in the map holding a live key long past its window — residency
+    // outliving usefulness, which is the opposite of what the TTL is for.
+    for (const [k, v] of this.dataKeys) {
+      if (this.now() >= v.expiresAt) {
+        this.dataKeys.delete(k);
+      }
+    }
     this.dataKeys.set(cacheKey, { key, expiresAt: this.now() + DATA_KEY_TTL_MS });
     while (this.dataKeys.size > DATA_KEY_CACHE_MAX) {
       const oldest = this.dataKeys.keys().next();

--- a/gateway/service/env.ts
+++ b/gateway/service/env.ts
@@ -27,8 +27,35 @@ const gatewaySchema = z.object({
    * only the sha256 is held past boot.
    */
   GATEWAY_INTERNAL_TOKEN: z.string().min(1).optional(),
-  /** Path to the 32-byte master key file (refused at boot if the size is anything else). */
-  GATEWAY_MASTER_KEY_FILE: z.string().min(1),
+  /**
+   * Where the master key lives. `file` is today's deployment and the default; the KMS spellings
+   * keep the key inside a key service and require that provider's configuration below — a missing
+   * piece REFUSES TO BOOT rather than falling back to a file key.
+   */
+  GATEWAY_KEY_BACKEND: z.enum(["file", "gcp-kms", "aws-kms"]).default("file"),
+  /**
+   * Path to the 32-byte master key file (refused at boot if the size is anything else). Required
+   * for the `file` backend; permitted alongside a KMS backend only because the re-wrap script
+   * needs the OLD key to read rows it is migrating.
+   */
+  GATEWAY_MASTER_KEY_FILE: z.string().min(1).optional(),
+  /**
+   * The KMS key, as the provider's own full resource name:
+   *   gcp-kms  projects/{p}/locations/{l}/keyRings/{r}/cryptoKeys/{k}
+   *   aws-kms  arn:aws:kms:{region}:{account}:key/{id}   (the region is read out of the ARN)
+   */
+  GATEWAY_KMS_KEY: z.string().min(1).optional(),
+  /** GCP: path to a service-account JSON key file — the container-on-a-box credential path. */
+  GOOGLE_APPLICATION_CREDENTIALS: z.string().min(1).optional(),
+  /**
+   * GCP: a ready-made OAuth access token (`gcloud auth print-access-token`) for smoke-testing a
+   * KMS key by hand. Refused in production — it expires in an hour and nothing here renews it.
+   */
+  GATEWAY_GCP_ACCESS_TOKEN: z.string().min(1).optional(),
+  /** AWS: static credentials. Instance/container credential providers are not implemented. */
+  AWS_ACCESS_KEY_ID: z.string().min(1).optional(),
+  AWS_SECRET_ACCESS_KEY: z.string().min(1).optional(),
+  AWS_SESSION_TOKEN: z.string().min(1).optional(),
   /** "1" lets upstream addresses resolve to private ranges (self-host with internal servers). */
   GATEWAY_ALLOW_PRIVATE_UPSTREAMS: z.enum(["0", "1"]).default("0"),
   APP_ENV: z.enum(["production", "development", "test"]).default("development"),
@@ -58,12 +85,88 @@ function assertNoShippedDefaults(env: GatewayEnv): void {
   }
 }
 
+/** GCP resource names are positional; a typo here is a 404 at first use, so shape-check it early. */
+const GCP_KEY_NAME =
+  /^projects\/[^/]+\/locations\/[^/]+\/keyRings\/[^/]+\/cryptoKeys\/[^/]+$/;
+/**
+ * A KEY arn (not an alias): the region sits in field 4 and the endpoint is derived from it.
+ *
+ * The COMMERCIAL partition only — `arn:aws:`. The client builds `kms.{region}.amazonaws.com`, and
+ * that host is wrong for every other partition (China is `.amazonaws.com.cn`, the isolated regions
+ * differ again), so accepting `arn:aws-cn:` here would send a boot call to a host that does not
+ * serve that key. Refusing an ARN we would dial wrongly is the honest answer; widening this means
+ * deriving the suffix from the partition in the client, not loosening the pattern here.
+ */
+const AWS_KEY_ARN = /^arn:aws:kms:([a-z0-9-]+):\d{12}:key\/[A-Za-z0-9-]+$/;
+
+/**
+ * The key backend's configuration is complete or the process does not start. A KMS backend that
+ * fell back to a file key on a missing variable would write rows the operator believes are
+ * KMS-held; a KMS backend that started without credentials would fail on the first credentialed
+ * request instead of at deploy. Both are refusals, here, with the variable named.
+ */
+function assertKeyBackendConfigured(env: GatewayEnv): void {
+  const missing = (variable: string): never => {
+    throw new Error(
+      `refusing to start: GATEWAY_KEY_BACKEND=${env.GATEWAY_KEY_BACKEND} requires ${variable}`,
+    );
+  };
+  if (env.GATEWAY_KEY_BACKEND === "file") {
+    if (env.GATEWAY_MASTER_KEY_FILE === undefined) {
+      missing("GATEWAY_MASTER_KEY_FILE");
+    }
+    return;
+  }
+  if (env.GATEWAY_KMS_KEY === undefined) {
+    missing("GATEWAY_KMS_KEY (the key's full resource name)");
+  }
+  if (env.GATEWAY_KEY_BACKEND === "gcp-kms") {
+    if (!GCP_KEY_NAME.test(env.GATEWAY_KMS_KEY ?? "")) {
+      throw new Error(
+        "refusing to start: GATEWAY_KMS_KEY must be a Cloud KMS crypto key resource name " +
+          "(projects/{p}/locations/{l}/keyRings/{r}/cryptoKeys/{k})",
+      );
+    }
+    if (env.APP_ENV === "production" && env.GATEWAY_GCP_ACCESS_TOKEN !== undefined) {
+      throw new Error(
+        "refusing to start: GATEWAY_GCP_ACCESS_TOKEN is a short-lived token for hand smoke tests. " +
+          "Production reads a service account from GOOGLE_APPLICATION_CREDENTIALS or the metadata server.",
+      );
+    }
+    return;
+  }
+  if (!AWS_KEY_ARN.test(env.GATEWAY_KMS_KEY ?? "")) {
+    throw new Error(
+      "refusing to start: GATEWAY_KMS_KEY must be a KMS key ARN " +
+        "(arn:aws:kms:{region}:{account}:key/{id}) — the region is read out of it",
+    );
+  }
+  // No instance/container credential provider here: an unset pair is a refusal, never an ambient
+  // guess at what role the host might be carrying.
+  if (env.AWS_ACCESS_KEY_ID === undefined) {
+    missing("AWS_ACCESS_KEY_ID");
+  }
+  if (env.AWS_SECRET_ACCESS_KEY === undefined) {
+    missing("AWS_SECRET_ACCESS_KEY");
+  }
+}
+
+/** The AWS region an ARN names — the endpoint host is built from it, never configured twice. */
+export function awsRegionFromKeyArn(arn: string): string {
+  const region = AWS_KEY_ARN.exec(arn)?.[1];
+  if (region === undefined) {
+    throw new Error("KMS key ARN carries no region");
+  }
+  return region;
+}
+
 let cached: GatewayEnv | undefined;
 
 export function gatewayEnv(source: NodeJS.ProcessEnv = process.env): GatewayEnv {
   if (cached === undefined) {
     const parsed = gatewaySchema.parse(source);
     assertNoShippedDefaults(parsed);
+    assertKeyBackendConfigured(parsed);
     cached = parsed;
   }
   return cached;
@@ -73,6 +176,7 @@ export function gatewayEnv(source: NodeJS.ProcessEnv = process.env): GatewayEnv 
 export function parseGatewayEnv(source: Record<string, string | undefined>): GatewayEnv {
   const parsed = gatewaySchema.parse(source);
   assertNoShippedDefaults(parsed);
+  assertKeyBackendConfigured(parsed);
   return parsed;
 }
 

--- a/gateway/service/env.ts
+++ b/gateway/service/env.ts
@@ -106,6 +106,17 @@ const AWS_KEY_ARN = /^arn:aws:kms:([a-z0-9-]+):\d{12}:key\/[A-Za-z0-9-]+$/;
  * request instead of at deploy. Both are refusals, here, with the variable named.
  */
 function assertKeyBackendConfigured(env: GatewayEnv): void {
+  // AWS is implemented but has never been exercised against a real endpoint, and its request
+  // signing is hand-written rather than a vendor SDK. That is acceptable for a self-hoster who
+  // chooses it deliberately; it is not something to run unproven where other people's credentials
+  // are at stake. A production deployment that wants AWS must first verify it and lift this.
+  if (env.APP_ENV === "production" && env.GATEWAY_KEY_BACKEND === "aws-kms") {
+    throw new Error(
+      "refusing to start: GATEWAY_KEY_BACKEND=aws-kms is not verified against a real AWS endpoint " +
+        "and is refused in production. Use gcp-kms, or verify the AWS path and lift this guard.",
+    );
+  }
+
   const missing = (variable: string): never => {
     throw new Error(
       `refusing to start: GATEWAY_KEY_BACKEND=${env.GATEWAY_KEY_BACKEND} requires ${variable}`,

--- a/gateway/service/gcp-auth.ts
+++ b/gateway/service/gcp-auth.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { createSign } from "node:crypto";
+import { KMS_CALL_TIMEOUT_MS } from "./kms";
 
 /**
  * Google access tokens for the KMS calls — the two credential paths a container actually has, and
@@ -90,7 +91,7 @@ async function postJson(
   init: RequestInit,
   where: string,
 ): Promise<unknown> {
-  const response = await fetchImpl(url, init);
+  const response = await fetchImpl(url, { ...init, signal: AbortSignal.timeout(KMS_CALL_TIMEOUT_MS) });
   const text = await response.text();
   if (!response.ok) {
     // The body of a token failure carries `error`/`error_description`, never a credential — but

--- a/gateway/service/gcp-auth.ts
+++ b/gateway/service/gcp-auth.ts
@@ -1,0 +1,224 @@
+import { readFileSync } from "node:fs";
+import { createSign } from "node:crypto";
+
+/**
+ * Google access tokens for the KMS calls — the two credential paths a container actually has, and
+ * nothing else. No ADC search, no gcloud, no vendor SDK: the token is either signed from a service
+ * account key file the operator mounted, or fetched from the instance metadata server.
+ *
+ * TRANSPORT NOTE: these requests do NOT ride the guarded fetch. The metadata server lives at a
+ * link-local address the SSRF guard exists to refuse, and both hosts here are configuration rather
+ * than anything an upstream document can influence — the guard's threat model does not apply.
+ *
+ * Tokens are cached until shortly before expiry and minted at most once at a time; a token is
+ * never logged, and neither is the assertion that bought it.
+ */
+
+/** Narrowest scope that permits encrypt/decrypt — `cloud-platform` would also open everything else. */
+const KMS_SCOPE = "https://www.googleapis.com/auth/cloudkms";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+const METADATA_TOKEN_URL =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+/** Assertions are minted per token, so a short life costs nothing and bounds a leaked one. */
+const ASSERTION_TTL_SECONDS = 3600;
+const REFRESH_EARLY_MS = 5 * 60 * 1000;
+
+export interface AccessTokenSource {
+  /** Log-safe: which credential path, and whose identity — never the token. */
+  readonly describe: string;
+  token(): Promise<string>;
+}
+
+interface Minted {
+  accessToken: string;
+  expiresInSeconds: number;
+}
+
+function base64url(input: Buffer | string): string {
+  return (typeof input === "string" ? Buffer.from(input, "utf8") : input)
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+/** One mint at a time, reused until expiry — a burst of proxied calls must not mint a burst. */
+function cache(
+  mint: () => Promise<Minted>,
+  now: () => number,
+): () => Promise<string> {
+  let token: string | undefined;
+  let expiresAt = 0;
+  let inFlight: Promise<string> | undefined;
+  return async () => {
+    if (token !== undefined && now() < expiresAt) {
+      return token;
+    }
+    if (inFlight === undefined) {
+      inFlight = (async () => {
+        try {
+          const minted = await mint();
+          const lifetimeMs = minted.expiresInSeconds * 1000;
+          // A token shorter than the refresh margin still gets used, for half its life.
+          const early = Math.min(REFRESH_EARLY_MS, Math.floor(lifetimeMs / 2));
+          token = minted.accessToken;
+          expiresAt = now() + lifetimeMs - early;
+          return minted.accessToken;
+        } finally {
+          inFlight = undefined;
+        }
+      })();
+    }
+    return inFlight;
+  };
+}
+
+function readMinted(body: unknown, where: string): Minted {
+  const record = body as { access_token?: unknown; expires_in?: unknown };
+  if (typeof record.access_token !== "string" || record.access_token === "") {
+    throw new Error(`${where} returned no access_token`);
+  }
+  // A missing expires_in is treated as the shortest plausible life rather than as forever.
+  const expiresIn = typeof record.expires_in === "number" ? record.expires_in : 60;
+  return { accessToken: record.access_token, expiresInSeconds: expiresIn };
+}
+
+async function postJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit,
+  where: string,
+): Promise<unknown> {
+  const response = await fetchImpl(url, init);
+  const text = await response.text();
+  if (!response.ok) {
+    // The body of a token failure carries `error`/`error_description`, never a credential — but
+    // it is upstream text, so it is truncated rather than trusted to be small.
+    throw new Error(`${where} refused (${response.status}): ${text.slice(0, 300)}`);
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error(`${where} returned a body that is not JSON`);
+  }
+}
+
+export interface ServiceAccountKey {
+  clientEmail: string;
+  privateKeyPem: string;
+  tokenUri: string;
+  projectId: string | null;
+}
+
+/**
+ * Parse a service-account JSON key. Every field the JWT flow needs is checked HERE, at boot, so a
+ * truncated or wrong-type key file refuses to start instead of failing at the first credential.
+ */
+export function parseServiceAccountKey(json: string, path: string): ServiceAccountKey {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json) as unknown;
+  } catch {
+    throw new Error(`${path} is not valid JSON`);
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`${path} is not a service account key file`);
+  }
+  const record = parsed as Record<string, unknown>;
+  if (record.type !== "service_account") {
+    throw new Error(
+      `${path} has type "${String(record.type)}" — the gateway needs a service_account key file`,
+    );
+  }
+  const clientEmail = record.client_email;
+  const privateKey = record.private_key;
+  if (typeof clientEmail !== "string" || clientEmail === "") {
+    throw new Error(`${path} has no client_email`);
+  }
+  if (typeof privateKey !== "string" || !privateKey.includes("PRIVATE KEY")) {
+    throw new Error(`${path} has no PEM private_key`);
+  }
+  return {
+    clientEmail,
+    privateKeyPem: privateKey,
+    tokenUri: typeof record.token_uri === "string" ? record.token_uri : DEFAULT_TOKEN_URI,
+    projectId: typeof record.project_id === "string" ? record.project_id : null,
+  };
+}
+
+export function loadServiceAccountKey(path: string): ServiceAccountKey {
+  return parseServiceAccountKey(readFileSync(path, "utf8"), path);
+}
+
+/**
+ * RFC 7523 self-signed JWT bearer: sign an assertion with the account's own key, trade it at
+ * Google's token endpoint for an access token. This is the path a container with a mounted key
+ * file takes — the one the box will run.
+ */
+export function serviceAccountTokens(
+  key: ServiceAccountKey,
+  deps: { fetch?: typeof fetch; now?: () => number } = {},
+): AccessTokenSource {
+  const fetchImpl = deps.fetch ?? fetch;
+  const now = deps.now ?? Date.now;
+  const mint = async (): Promise<Minted> => {
+    const issuedAt = Math.floor(now() / 1000);
+    const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+    const claims = base64url(
+      JSON.stringify({
+        iss: key.clientEmail,
+        scope: KMS_SCOPE,
+        aud: key.tokenUri,
+        iat: issuedAt,
+        exp: issuedAt + ASSERTION_TTL_SECONDS,
+      }),
+    );
+    const signingInput = `${header}.${claims}`;
+    const signature = base64url(
+      createSign("RSA-SHA256").update(signingInput).sign(key.privateKeyPem),
+    );
+    const body = new URLSearchParams({
+      grant_type: JWT_BEARER_GRANT,
+      assertion: `${signingInput}.${signature}`,
+    });
+    const parsed = await postJson(
+      fetchImpl,
+      key.tokenUri,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      },
+      "the Google token endpoint",
+    );
+    return readMinted(parsed, "the Google token endpoint");
+  };
+  return { describe: `service account ${key.clientEmail}`, token: cache(mint, now) };
+}
+
+/** The instance metadata server — GCE, GKE, Cloud Run. Plain http and the header are both required. */
+export function metadataTokens(
+  deps: { fetch?: typeof fetch; now?: () => number } = {},
+): AccessTokenSource {
+  const fetchImpl = deps.fetch ?? fetch;
+  const now = deps.now ?? Date.now;
+  const mint = async (): Promise<Minted> => {
+    const parsed = await postJson(
+      fetchImpl,
+      METADATA_TOKEN_URL,
+      { method: "GET", headers: { "metadata-flavor": "Google" } },
+      "the GCE metadata server",
+    );
+    return readMinted(parsed, "the GCE metadata server");
+  };
+  return { describe: "instance metadata server", token: cache(mint, now) };
+}
+
+/**
+ * A token handed in whole (`gcloud auth print-access-token`) — a hand smoke test against a real
+ * key, refused in production by the env check because nothing renews it.
+ */
+export function staticToken(token: string): AccessTokenSource {
+  return { describe: "a supplied access token", token: async () => token };
+}

--- a/gateway/service/kms-aws.ts
+++ b/gateway/service/kms-aws.ts
@@ -5,6 +5,7 @@ import {
   RetryableKmsError,
   withKmsRetry,
   type KmsProvider,
+  KMS_CALL_TIMEOUT_MS,
 } from "./kms";
 
 /**
@@ -260,6 +261,7 @@ export class AwsKms implements KmsProvider {
     let response: Response;
     try {
       response = await this.fetchImpl(`https://${host}/`, {
+        signal: AbortSignal.timeout(KMS_CALL_TIMEOUT_MS),
         method: "POST",
         headers: signed.headers,
         body,

--- a/gateway/service/kms-aws.ts
+++ b/gateway/service/kms-aws.ts
@@ -1,0 +1,285 @@
+import { createHash, createHmac } from "node:crypto";
+import {
+  assertAad,
+  PROVIDER_TAG,
+  RetryableKmsError,
+  withKmsRetry,
+  type KmsProvider,
+} from "./kms";
+
+/**
+ * AWS KMS over its JSON API with plain `fetch` and hand-written SigV4 — the sibling of
+ * `kms-gcp.ts`, reaching the same `KmsProvider` contract so nothing above either file knows which
+ * cloud holds the master key.
+ *
+ * WHY SIGV4 BY HAND: this signs ONE shape of request — POST to `/` on one host, no query string,
+ * a JSON body always present, a fixed header set. That erases the parts of SigV4 that are actually
+ * hard (path/query canonicalization, unsigned and chunked payloads, presigned URLs), leaving the
+ * HMAC chain below. `@aws-sdk/client-kms` would be the largest dependency in an image that
+ * otherwise carries two.
+ *
+ * CREDENTIALS: the static environment triple only. The ECS/EKS container credential providers are
+ * deliberately NOT implemented — a half-built provider chain that guesses at an ambient role is
+ * worse than a refusal at boot, and the env check refuses instead.
+ *
+ * AAD: `EncryptionContext` is AWS's authenticated-data analogue and decrypt must present the same
+ * map, so the row binding survives the move. It is NOT secret — CloudTrail logs it in the clear —
+ * which is fine: the AAD here is a workspace id, already in every log line.
+ */
+
+const SERVICE = "kms";
+const ALGORITHM = "AWS4-HMAC-SHA256";
+const CONTENT_TYPE = "application/x-amz-json-1.1";
+/** The AAD travels as one entry; the key names the property, the value is the AAD string itself. */
+const CONTEXT_KEY = "topos_aad";
+/** Symmetric `Plaintext` caps at 4096 bytes decoded — a data key is 32. */
+const MAX_PLAINTEXT_BYTES = 4096;
+
+export interface AwsCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+export interface AwsKmsOptions {
+  /** `arn:aws:kms:{region}:{account}:key/{id}` — the region below is read out of it. */
+  keyArn: string;
+  region: string;
+  credentials: AwsCredentials;
+  fetch?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+function sha256Hex(input: string | Buffer): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hmac(key: Buffer | string, data: string): Buffer {
+  return createHmac("sha256", key).update(data, "utf8").digest();
+}
+
+/** `20260821T203825Z` and its `20260821` scope date — the two must agree or the signature fails. */
+export function amzDate(nowMs: number): { stamp: string; date: string } {
+  const stamp = new Date(nowMs).toISOString().replaceAll("-", "").replaceAll(":", "").replace(/\.\d+/, "");
+  return { stamp, date: stamp.slice(0, 8) };
+}
+
+/** The four-step derivation, verbatim from the signing spec. */
+export function deriveSigningKey(
+  secretAccessKey: string,
+  date: string,
+  region: string,
+  service: string,
+): Buffer {
+  const kDate = hmac(`AWS4${secretAccessKey}`, date);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  return hmac(kService, "aws4_request");
+}
+
+export interface SignInput {
+  host: string;
+  target: string;
+  body: string;
+  region: string;
+  credentials: AwsCredentials;
+  nowMs: number;
+}
+
+export interface SignedRequest {
+  /**
+   * The headers to SEND — `host` is signed but not among them: it is a forbidden header name for
+   * fetch, and the runtime sets it from the URL to exactly the value signed here.
+   */
+  headers: Record<string, string>;
+  /** Exposed for the tests that pin the wire format — the signature is a hash of exactly this. */
+  canonicalRequest: string;
+  stringToSign: string;
+}
+
+/**
+ * Sign one POST-to-`/` request. The body string passed here MUST be the same string handed to
+ * fetch: the signature covers its bytes, and a second `JSON.stringify` that orders keys
+ * differently would produce a valid-looking request that AWS rejects as unsigned.
+ */
+export function signKmsRequest(input: SignInput): SignedRequest {
+  const { stamp, date } = amzDate(input.nowMs);
+  const headers: Record<string, string> = {
+    "content-type": CONTENT_TYPE,
+    host: input.host,
+    "x-amz-date": stamp,
+    "x-amz-target": input.target,
+  };
+  if (input.credentials.sessionToken !== undefined) {
+    // A session token must be BOTH sent and signed; signing it is what binds the temporary
+    // credential to this request.
+    headers["x-amz-security-token"] = input.credentials.sessionToken;
+  }
+  const names = Object.keys(headers).sort();
+  const canonicalHeaders = names.map((name) => `${name}:${headers[name] ?? ""}\n`).join("");
+  const signedHeaders = names.join(";");
+  const canonicalRequest = [
+    "POST",
+    "/",
+    "",
+    canonicalHeaders,
+    signedHeaders,
+    sha256Hex(input.body),
+  ].join("\n");
+  const scope = `${date}/${input.region}/${SERVICE}/aws4_request`;
+  const stringToSign = [ALGORITHM, stamp, scope, sha256Hex(canonicalRequest)].join("\n");
+  const signature = hmac(
+    deriveSigningKey(input.credentials.secretAccessKey, date, input.region, SERVICE),
+    stringToSign,
+  ).toString("hex");
+  const { host: _signedHost, ...sendable } = headers;
+  return {
+    headers: {
+      ...sendable,
+      authorization:
+        `${ALGORITHM} Credential=${input.credentials.accessKeyId}/${scope}, ` +
+        `SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    },
+    canonicalRequest,
+    stringToSign,
+  };
+}
+
+/** The shape name out of `__type`, which arrives fully qualified: `com.amazonaws.kms#Name`. */
+function errorCode(text: string): { code: string; message: string } {
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    const raw = typeof parsed.__type === "string" ? parsed.__type : "";
+    const code = raw.split("#").pop()?.split(":")[0] ?? "";
+    const message = parsed.message ?? parsed.Message;
+    return { code, message: typeof message === "string" ? message : text.slice(0, 300) };
+  } catch {
+    return { code: "", message: text.slice(0, 300) };
+  }
+}
+
+/**
+ * Classify on the CODE first, the status second: KMS answers a throttle with HTTP 400, so a
+ * status-only reading would treat back-pressure as a permanent refusal and drop the request.
+ */
+const RETRYABLE_CODES = new Set([
+  "ThrottlingException",
+  "Throttling",
+  "TooManyRequestsException",
+  "RequestLimitExceeded",
+  "RequestTimeout",
+  "RequestTimeoutException",
+  "KMSInternalException",
+  "DependencyTimeoutException",
+  "KeyUnavailableException",
+  "InternalFailure",
+  "InternalError",
+  "ServiceUnavailable",
+]);
+
+function classify(status: number, text: string): Error {
+  const { code, message } = errorCode(text);
+  const label = code === "" ? `HTTP ${status}` : code;
+  if (RETRYABLE_CODES.has(code) || (code === "" && status >= 500) || status >= 500) {
+    return new RetryableKmsError(`AWS KMS is unavailable (${label}): ${message}`);
+  }
+  return new Error(`AWS KMS refused the request (${label}): ${message}`);
+}
+
+export class AwsKms implements KmsProvider {
+  readonly name = "aws-kms";
+  readonly tag = PROVIDER_TAG.aws;
+  private fetchImpl: typeof fetch;
+  private sleep: (ms: number) => Promise<void>;
+  private now: () => number;
+
+  constructor(private options: AwsKmsOptions) {
+    this.fetchImpl = options.fetch ?? fetch;
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.now = options.now ?? Date.now;
+  }
+
+  get describe(): string {
+    return this.options.keyArn;
+  }
+
+  async encrypt(plaintext: Buffer, aad: string): Promise<Buffer> {
+    if (plaintext.length > MAX_PLAINTEXT_BYTES) {
+      throw new Error("payload is too large for a single AWS KMS call");
+    }
+    return withKmsRetry(async () => {
+      const body = await this.call("TrentService.Encrypt", {
+        KeyId: this.options.keyArn,
+        Plaintext: plaintext.toString("base64"),
+        EncryptionContext: { [CONTEXT_KEY]: assertAad(aad) },
+      });
+      if (typeof body.CiphertextBlob !== "string") {
+        throw new Error("AWS KMS returned no CiphertextBlob");
+      }
+      // The key that answered must be the key configured — an alias resolving elsewhere would
+      // otherwise write rows this deployment cannot open.
+      if (typeof body.KeyId === "string" && body.KeyId !== this.options.keyArn) {
+        throw new Error(`AWS KMS answered for key ${body.KeyId}, not ${this.options.keyArn}`);
+      }
+      return Buffer.from(body.CiphertextBlob, "base64");
+    }, this.sleep);
+  }
+
+  async decrypt(ciphertext: Buffer, aad: string): Promise<Buffer> {
+    return withKmsRetry(async () => {
+      const body = await this.call("TrentService.Decrypt", {
+        // Naming the key is optional for symmetric ciphertext and load-bearing anyway: without it
+        // KMS would decrypt under whatever key the blob names.
+        KeyId: this.options.keyArn,
+        CiphertextBlob: ciphertext.toString("base64"),
+        EncryptionContext: { [CONTEXT_KEY]: assertAad(aad) },
+      });
+      if (typeof body.Plaintext !== "string") {
+        throw new Error("AWS KMS returned no Plaintext");
+      }
+      return Buffer.from(body.Plaintext, "base64");
+    }, this.sleep);
+  }
+
+  private async call(
+    target: string,
+    request: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const host = `kms.${this.options.region}.amazonaws.com`;
+    // ONE serialization, signed and sent — see signKmsRequest.
+    const body = JSON.stringify(request);
+    const signed = signKmsRequest({
+      host,
+      target,
+      body,
+      region: this.options.region,
+      credentials: this.options.credentials,
+      nowMs: this.now(),
+    });
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`https://${host}/`, {
+        method: "POST",
+        headers: signed.headers,
+        body,
+      });
+    } catch (error) {
+      throw new RetryableKmsError(`AWS KMS is unreachable: ${String(error)}`);
+    }
+    const text = await response.text();
+    if (!response.ok) {
+      throw classify(response.status, text);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch {
+      throw new RetryableKmsError("AWS KMS returned a body that is not JSON");
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new RetryableKmsError("AWS KMS returned a body that is not an object");
+    }
+    return parsed as Record<string, unknown>;
+  }
+}

--- a/gateway/service/kms-gcp.ts
+++ b/gateway/service/kms-gcp.ts
@@ -5,6 +5,7 @@ import {
   RetryableKmsError,
   withKmsRetry,
   type KmsProvider,
+  KMS_CALL_TIMEOUT_MS,
 } from "./kms";
 
 /**
@@ -186,6 +187,7 @@ export class GcpKms implements KmsProvider {
     let response: Response;
     try {
       response = await this.fetchImpl(url, {
+        signal: AbortSignal.timeout(KMS_CALL_TIMEOUT_MS),
         method: "POST",
         headers: {
           authorization: `Bearer ${token}`,

--- a/gateway/service/kms-gcp.ts
+++ b/gateway/service/kms-gcp.ts
@@ -1,0 +1,215 @@
+import type { AccessTokenSource } from "./gcp-auth";
+import {
+  assertAad,
+  PROVIDER_TAG,
+  RetryableKmsError,
+  withKmsRetry,
+  type KmsProvider,
+} from "./kms";
+
+/**
+ * Google Cloud KMS over its REST API with plain `fetch` — no vendor SDK.
+ *
+ * WHY NO SDK: two calls (`cryptoKeys.encrypt`, `cryptoKeys.decrypt`) against one host, with a
+ * bearer token this service already knows how to mint. `@google-cloud/kms` brings gRPC, protobuf
+ * loading, and a dependency tree measured in hundreds of packages into an image whose entire
+ * runtime dependency list is `pg` and `zod` — and into a service whose OTHER transport is a
+ * hand-written SSRF-guarded fetch precisely so nothing dials on its own. The REST surface here is
+ * ~100 lines and every byte on the wire is visible in this file.
+ *
+ * INTEGRITY: Cloud KMS accepts a CRC32C of each field and reports whether it verified it. Both are
+ * sent and both are checked, and the ciphertext's own checksum is recomputed on the way back — a
+ * corrupted request that the service did not verify is retried, never accepted. The response's
+ * `name` is compared to the configured key, so a misrouted answer is refused rather than stored.
+ *
+ * AAD: `additionalAuthenticatedData` is the row binding. Cloud KMS authenticates it exactly as the
+ * local AES-GCM layer does, which is why moving to this backend loses no property.
+ *
+ * Both calls name the CRYPTO KEY, never a version: encrypt uses the key's primary version, decrypt
+ * reads the version out of the ciphertext — which is what lets a rotated key still open old rows.
+ */
+
+/**
+ * The global endpoint serves keys in every location — a key's own region is part of its resource
+ * name, not of the host. (Regional endpoints exist for data-residency rules; adding one would be a
+ * second variable, and nothing here needs it yet.)
+ */
+const ENDPOINT = "https://cloudkms.googleapis.com/v1";
+/**
+ * The HSM protection level caps plaintext+AAD at 8 KiB (software keys allow 64 KiB). A data key
+ * plus its AAD is under a hundred bytes, so hold everything to the smaller ceiling rather than
+ * discover the difference from a production 400.
+ */
+const MAX_PAYLOAD_BYTES = 8 * 1024;
+
+export interface GcpKmsOptions {
+  /** `projects/{p}/locations/{l}/keyRings/{r}/cryptoKeys/{k}` — shape-checked at env parse. */
+  keyName: string;
+  tokens: AccessTokenSource;
+  fetch?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * CRC32C (Castagnoli, reflected polynomial 0x82F63B78) — the checksum Cloud KMS speaks. Computed
+ * a bit at a time with no lookup table: the payloads here are a 32-byte key and a short AAD, so
+ * the table would cost more to build than the loop costs to run.
+ */
+export function crc32c(bytes: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (crc ^ byte) >>> 0;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = ((crc & 1) !== 0 ? (crc >>> 1) ^ 0x82f63b78 : crc >>> 1) >>> 0;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** Cloud KMS carries checksums as int64, which ProtoJSON spells as a decimal STRING. */
+function checksum(bytes: Buffer): string {
+  return crc32c(bytes).toString();
+}
+
+function checksumMatches(bytes: Buffer, reported: unknown): boolean {
+  if (typeof reported !== "string" && typeof reported !== "number") {
+    // A response with no checksum at all is not proof of corruption; the field is optional.
+    return true;
+  }
+  return String(reported) === checksum(bytes);
+}
+
+/** 429 and 5xx are the transport having a bad minute; 4xx is an answer. */
+function classify(status: number, detail: string): Error {
+  if (status === 429 || status >= 500) {
+    return new RetryableKmsError(`Cloud KMS is unavailable (${status}): ${detail}`);
+  }
+  return new Error(`Cloud KMS refused the request (${status}): ${detail}`);
+}
+
+function errorDetail(text: string): string {
+  try {
+    const parsed = JSON.parse(text) as { error?: { message?: unknown; status?: unknown } };
+    const message = parsed.error?.message;
+    const status = parsed.error?.status;
+    if (typeof message === "string") {
+      return typeof status === "string" ? `${status}: ${message}` : message;
+    }
+  } catch {
+    // Not the documented envelope — fall through to the raw text.
+  }
+  return text.slice(0, 300);
+}
+
+export class GcpKms implements KmsProvider {
+  readonly name = "gcp-kms";
+  readonly tag = PROVIDER_TAG.gcp;
+  private fetchImpl: typeof fetch;
+  private sleep: (ms: number) => Promise<void>;
+
+  constructor(private options: GcpKmsOptions) {
+    this.fetchImpl = options.fetch ?? fetch;
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  get describe(): string {
+    return `${this.options.keyName} (${this.options.tokens.describe})`;
+  }
+
+  async encrypt(plaintext: Buffer, aad: string): Promise<Buffer> {
+    const aadBytes = Buffer.from(assertAad(aad), "utf8");
+    this.assertSize(plaintext, aadBytes);
+    return withKmsRetry(async () => {
+      const body = await this.call("encrypt", {
+        plaintext: plaintext.toString("base64"),
+        plaintextCrc32c: checksum(plaintext),
+        additionalAuthenticatedData: aadBytes.toString("base64"),
+        additionalAuthenticatedDataCrc32c: checksum(aadBytes),
+      });
+      // A false flag means the checksum never reached the service, so the request went
+      // unverified — the documented answer is to discard the response and try again.
+      if (body.verifiedPlaintextCrc32c !== true) {
+        throw new RetryableKmsError("Cloud KMS did not verify the plaintext checksum");
+      }
+      if (body.verifiedAdditionalAuthenticatedDataCrc32c !== true) {
+        throw new RetryableKmsError("Cloud KMS did not verify the AAD checksum");
+      }
+      const version = body.name;
+      if (typeof version !== "string" || !version.startsWith(`${this.options.keyName}/`)) {
+        throw new Error(
+          `Cloud KMS answered for key ${String(version)}, not the configured ${this.options.keyName}`,
+        );
+      }
+      if (typeof body.ciphertext !== "string") {
+        throw new Error("Cloud KMS returned no ciphertext");
+      }
+      const ciphertext = Buffer.from(body.ciphertext, "base64");
+      if (!checksumMatches(ciphertext, body.ciphertextCrc32c)) {
+        throw new RetryableKmsError("Cloud KMS ciphertext failed its checksum in transit");
+      }
+      return ciphertext;
+    }, this.sleep);
+  }
+
+  async decrypt(ciphertext: Buffer, aad: string): Promise<Buffer> {
+    const aadBytes = Buffer.from(assertAad(aad), "utf8");
+    return withKmsRetry(async () => {
+      const body = await this.call("decrypt", {
+        ciphertext: ciphertext.toString("base64"),
+        ciphertextCrc32c: checksum(ciphertext),
+        additionalAuthenticatedData: aadBytes.toString("base64"),
+        additionalAuthenticatedDataCrc32c: checksum(aadBytes),
+      });
+      if (typeof body.plaintext !== "string") {
+        throw new Error("Cloud KMS returned no plaintext");
+      }
+      const plaintext = Buffer.from(body.plaintext, "base64");
+      if (!checksumMatches(plaintext, body.plaintextCrc32c)) {
+        throw new RetryableKmsError("Cloud KMS plaintext failed its checksum in transit");
+      }
+      return plaintext;
+    }, this.sleep);
+  }
+
+  private assertSize(plaintext: Buffer, aad: Buffer): void {
+    if (plaintext.length + aad.length > MAX_PAYLOAD_BYTES) {
+      throw new Error("payload is too large for a single Cloud KMS call");
+    }
+  }
+
+  private async call(
+    method: "encrypt" | "decrypt",
+    request: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    const token = await this.options.tokens.token();
+    const url = `${ENDPOINT}/${this.options.keyName}:${method}`;
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify(request),
+      });
+    } catch (error) {
+      // A connection that never completed says nothing about whether the key works.
+      throw new RetryableKmsError(`Cloud KMS is unreachable: ${String(error)}`);
+    }
+    const text = await response.text();
+    if (!response.ok) {
+      throw classify(response.status, errorDetail(text));
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch {
+      throw new RetryableKmsError("Cloud KMS returned a body that is not JSON");
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new RetryableKmsError("Cloud KMS returned a body that is not an object");
+    }
+    return parsed as Record<string, unknown>;
+  }
+}

--- a/gateway/service/kms.ts
+++ b/gateway/service/kms.ts
@@ -1,0 +1,128 @@
+import { assertWrapVersion, type MasterKeyBackend } from "./crypto";
+
+/**
+ * The KMS-wrapped data key — format 0x02. The master key never enters this process: `wrapDataKey`
+ * and `unwrapDataKey` are RPCs to a key service that holds it, and what lands in
+ * `gateway.workspace_key` is the service's opaque ciphertext under a two-byte header.
+ *
+ *   [0] 0x02 — a KMS wrote this
+ *   [1] provider tag — 0x01 gcp-kms, 0x02 aws-kms
+ *   [2..] the provider's own ciphertext, byte-for-byte
+ *
+ * The provider tag is not redundant with the deployment's configuration: it is what makes an
+ * AWS-configured gateway REFUSE a GCP-wrapped row here, with a sentence, instead of shipping the
+ * bytes to a cloud that will reject them with a generic error. Tags are permanent — a row written
+ * today must still name its provider years from now.
+ *
+ * AAD IS LOAD-BEARING and every provider must carry it into the call as authenticated data (GCP:
+ * `additionalAuthenticatedData`; AWS: `EncryptionContext`). It binds a wrapped key to its
+ * workspace, which is what makes a row copied between workspaces fail rather than open.
+ */
+
+export const KMS_FORMAT_VERSION = 0x02;
+
+export const PROVIDER_TAG = {
+  gcp: 0x01,
+  aws: 0x02,
+} as const;
+
+const TAG_NAMES = new Map<number, string>([
+  [PROVIDER_TAG.gcp, "gcp-kms"],
+  [PROVIDER_TAG.aws, "aws-kms"],
+]);
+
+/**
+ * One key service's symmetric encrypt/decrypt. Deliberately smaller than any vendor SDK surface:
+ * a provider owns its wire format, its auth, and nothing else — no key creation, no rotation, no
+ * listing. Adding a sibling provider touches this file's tag table and nothing above it.
+ */
+export interface KmsProvider {
+  /** The `GATEWAY_KEY_BACKEND` spelling — used in refusals an operator has to act on. */
+  readonly name: string;
+  /** The permanent byte that marks this provider's rows. */
+  readonly tag: number;
+  /** Log-safe identity: the key resource name, which is configuration, not a secret. */
+  readonly describe: string;
+  encrypt(plaintext: Buffer, aad: string): Promise<Buffer>;
+  decrypt(ciphertext: Buffer, aad: string): Promise<Buffer>;
+}
+
+/**
+ * An empty AAD would be a wrap with no row binding — accepted by both clouds, and silently
+ * unbound. Every provider passes its input through here before the call.
+ */
+export function assertAad(aad: string): string {
+  if (aad === "") {
+    throw new Error("refusing a KMS wrap with an empty AAD");
+  }
+  return aad;
+}
+
+/** Bounded, jittered retry for the transport-level failures a key service is allowed to have. */
+export class RetryableKmsError extends Error {}
+
+export const KMS_ATTEMPTS = 3;
+
+export async function withKmsRetry<T>(
+  attempt: () => Promise<T>,
+  sleep: (ms: number) => Promise<void>,
+): Promise<T> {
+  let last: unknown;
+  for (let tries = 0; tries < KMS_ATTEMPTS; tries += 1) {
+    try {
+      return await attempt();
+    } catch (error) {
+      // Only the marked failures repeat. A refusal (bad key, denied permission, wrong AAD) is an
+      // answer, and answering it three times just delays the log line an operator needs.
+      if (!(error instanceof RetryableKmsError)) {
+        throw error;
+      }
+      last = error;
+      if (tries + 1 < KMS_ATTEMPTS) {
+        // Full jitter over an exponential window — encrypt and decrypt are both safe to repeat.
+        await sleep(Math.floor(Math.random() * Math.min(2000, 100 * 2 ** tries)));
+      }
+    }
+  }
+  throw last;
+}
+
+export class KmsMasterKey implements MasterKeyBackend {
+  readonly formatVersion = KMS_FORMAT_VERSION;
+
+  constructor(private provider: KmsProvider) {}
+
+  get describe(): string {
+    return `${this.provider.name} ${this.provider.describe}`;
+  }
+
+  async wrapDataKey(plaintextKey: Buffer, aad: string): Promise<Buffer> {
+    const ciphertext = await this.provider.encrypt(plaintextKey, aad);
+    if (ciphertext.length === 0) {
+      // A KMS that answered 200 with nothing would otherwise write a header-only row that reads
+      // back as an empty key. Refuse at the write, where the caller can still recover.
+      throw new Error(`${this.provider.name} returned an empty ciphertext`);
+    }
+    return Buffer.concat([Buffer.from([KMS_FORMAT_VERSION, this.provider.tag]), ciphertext]);
+  }
+
+  async unwrapDataKey(envelope: Buffer, aad: string): Promise<Buffer> {
+    assertWrapVersion(envelope, KMS_FORMAT_VERSION, this.provider.name);
+    const tag = envelope[1];
+    if (tag !== this.provider.tag) {
+      const wrote =
+        tag === undefined
+          ? "a truncated envelope"
+          : (TAG_NAMES.get(tag) ?? `provider tag 0x${tag.toString(16).padStart(2, "0")}`);
+      throw new Error(
+        `wrapped workspace key was written by ${wrote}; this gateway runs ${this.provider.name}`,
+      );
+    }
+    const ciphertext = envelope.subarray(2);
+    if (ciphertext.length === 0) {
+      // A header with no body is a corrupted row, not something to ask a cloud about.
+      throw new Error("wrapped workspace key carries no ciphertext");
+    }
+    return this.provider.decrypt(ciphertext, aad);
+  }
+}

--- a/gateway/service/kms.ts
+++ b/gateway/service/kms.ts
@@ -61,6 +61,14 @@ export function assertAad(aad: string): string {
 /** Bounded, jittered retry for the transport-level failures a key service is allowed to have. */
 export class RetryableKmsError extends Error {}
 
+/**
+ * Every call to a key service is bounded. Without this a socket that never settles hangs the boot
+ * proof with no listener bound and no error line, hangs any proxied call that needs an unwrap, and
+ * — worst — parks an open transaction and a row lock through the whole re-wrap. A hang is treated
+ * as RETRYABLE: "no answer yet" is the one failure that genuinely might succeed on a second ask.
+ */
+export const KMS_CALL_TIMEOUT_MS = 10_000;
+
 export const KMS_ATTEMPTS = 3;
 
 export async function withKmsRetry<T>(

--- a/gateway/service/main.ts
+++ b/gateway/service/main.ts
@@ -1,13 +1,19 @@
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import pg from "pg";
 import { handleGatewayRequest } from "../core/engine";
 import type { GatewayContext } from "../core/ports";
-import { EnvelopeCrypto, loadMasterKey } from "./crypto";
+import { EnvelopeCrypto } from "./crypto";
 import { gatewayEnv, parseBind } from "./env";
 import { createGuardedFetch } from "./guarded-fetch";
 import { createInternalHandler } from "./internal";
 import { stderrLogger } from "./log";
+import {
+  assertStoredWrapsOpen,
+  createMasterKeyBackend,
+  proveMasterKeyBackend,
+} from "./master-key";
 import { runMigrations } from "./migrate";
 import type { OauthConfig } from "./oauth";
 import { createPublicHandler, type EngineHandler } from "./server";
@@ -15,18 +21,30 @@ import { PgStore } from "./store";
 import { BufferedUsageSink } from "./usage";
 
 /**
- * The container entry point. Boot order mirrors the plane's: logs armed → env parsed → master
- * key read once → migrations under the advisory lock → adapters wired → BOTH listeners bound
- * (public MCP + the never-published internal lane) → signal-driven shutdown that drains the
- * usage buffer before the pool closes.
+ * The container entry point. Boot order mirrors the plane's: logs armed → env parsed → the master
+ * key backend built and PROVEN by a wrap/unwrap round trip → migrations under the advisory lock →
+ * adapters wired → BOTH listeners bound (public MCP + the never-published internal lane) →
+ * signal-driven shutdown that drains the usage buffer before the pool closes.
  */
 
 const log = stderrLogger();
 const env = gatewayEnv();
 
-const masterKey = loadMasterKey(env.GATEWAY_MASTER_KEY_FILE, (message, fields) =>
-  log("warn", message, fields),
-);
+// Before the database, before the listeners: a deployment that cannot open its own credentials
+// must fail in the deploy, not on some agent's first tool call.
+const masterKey = createMasterKeyBackend(env, log);
+if (
+  env.GATEWAY_KEY_BACKEND !== "file" &&
+  env.GATEWAY_MASTER_KEY_FILE !== undefined &&
+  existsSync(env.GATEWAY_MASTER_KEY_FILE)
+) {
+  // A real key file still on disk under a KMS backend is the middle of a migration — or its
+  // forgotten leftover. Either way the host is still holding a master key that opens nothing.
+  log("warn", "a master key file is still present but this key backend does not use it", {
+    backend: env.GATEWAY_KEY_BACKEND,
+  });
+}
+await proveMasterKeyBackend(masterKey, log);
 
 const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "..", "migrations");
 await runMigrations(env.DATABASE_URL, migrationsDir, log);
@@ -34,6 +52,14 @@ await runMigrations(env.DATABASE_URL, migrationsDir, log);
 const pool = new pg.Pool({ connectionString: env.DATABASE_URL, max: 10 });
 const crypto = new EnvelopeCrypto(masterKey);
 const store = new PgStore(pool, crypto, env.TOPOS_PUBLIC_URL, log);
+// The key works (proved above) — but is it the key that wrapped what is already stored? A
+// deployment moved to a KMS without its re-wrap, or pointed at a different valid key, would
+// otherwise bind and then fail every credential. Nothing stored yet passes trivially.
+const storedWraps = await pool.query<{ workspace_id: string; wrapped_key: Buffer }>(
+  "SELECT workspace_id, wrapped_key FROM gateway.workspace_key",
+);
+await assertStoredWrapsOpen(storedWraps.rows, crypto, log);
+
 const usage = new BufferedUsageSink(pool, log);
 const guardedFetch = createGuardedFetch(
   { allowPrivate: env.GATEWAY_ALLOW_PRIVATE_UPSTREAMS === "1" },

--- a/gateway/service/main.ts
+++ b/gateway/service/main.ts
@@ -58,7 +58,7 @@ const store = new PgStore(pool, crypto, env.TOPOS_PUBLIC_URL, log);
 const storedWraps = await pool.query<{ workspace_id: string; wrapped_key: Buffer }>(
   "SELECT workspace_id, wrapped_key FROM gateway.workspace_key",
 );
-await assertStoredWrapsOpen(storedWraps.rows, crypto, log);
+await assertStoredWrapsOpen(storedWraps.rows, masterKey, log);
 
 const usage = new BufferedUsageSink(pool, log);
 const guardedFetch = createGuardedFetch(

--- a/gateway/service/master-key.ts
+++ b/gateway/service/master-key.ts
@@ -5,6 +5,7 @@ import {
   KEY_BYTES,
   loadMasterKey,
   type MasterKeyBackend,
+  workspaceKeyAad,
 } from "./crypto";
 import { awsRegionFromKeyArn, type GatewayEnv } from "./env";
 import {
@@ -14,7 +15,7 @@ import {
   staticToken,
   type AccessTokenSource,
 } from "./gcp-auth";
-import { KmsMasterKey } from "./kms";
+import { KmsMasterKey, RetryableKmsError } from "./kms";
 import { AwsKms } from "./kms-aws";
 import { GcpKms } from "./kms-gcp";
 import type { Logger } from "./log";
@@ -93,6 +94,10 @@ export function createMasterKeyBackend(
 /** Never a workspace's AAD: a probe wrap must not be mistakable for a row's. */
 const PROBE_AAD = "topos:gateway:master-key-probe";
 
+/** How many stored wraps the boot check opens. A wrong key fails every row, so a handful settles
+ *  it; checking the whole table would be one KMS round trip per workspace on every restart. */
+const STORED_WRAP_SAMPLE = 5;
+
 /**
  * Prove the configured backend can wrap AND unwrap before the process serves anything. For a file
  * key that is nearly free; for a KMS it is the round trip that turns "the operator typed a key
@@ -126,26 +131,54 @@ export async function proveMasterKeyBackend(
  */
 export async function assertStoredWrapsOpen(
   rows: readonly { workspace_id: string; wrapped_key: Buffer }[],
-  crypto: { canOpenWorkspaceKey(workspaceId: string, wrapped: Buffer): Promise<boolean> },
+  backend: MasterKeyBackend,
   log: Logger,
 ): Promise<void> {
   if (rows.length === 0) {
     log("info", "no stored workspace keys to verify");
     return;
   }
-  const unreadable: string[] = [];
-  for (const row of rows) {
-    if (!(await crypto.canOpenWorkspaceKey(row.workspace_id, row.wrapped_key))) {
-      unreadable.push(row.workspace_id);
+  // A SAMPLE, not the whole table. The question is "is this the key that wrapped what is stored",
+  // and a wrong key fails EVERY row — so a handful answers it. Checking all of them would make
+  // boot O(workspaces) sequential KMS round trips on every restart, and would turn one deliberately
+  // unreadable row (the re-wrap leaves those as evidence) into a deployment that cannot start.
+  const sample = rows.slice(0, STORED_WRAP_SAMPLE);
+  let refused = 0;
+  for (const row of sample) {
+    try {
+      // Straight to the backend, NOT through the cache: this needs an answer, not a usable key,
+      // and routing it through EnvelopeCrypto would leave every sampled workspace's plaintext data
+      // key resident in memory from boot — widening exactly the in-process exposure a key service
+      // cannot cover.
+      await backend.unwrapDataKey(row.wrapped_key, workspaceKeyAad(row.workspace_id));
+    } catch (error) {
+      if (error instanceof RetryableKmsError) {
+        // "I could not ASK" is not "the key is wrong". A KMS blip must not produce a refusal whose
+        // remedy text tells the operator to run a migration.
+        log("warn", "could not verify a stored workspace key (the key service did not answer)", {
+          error: (error as Error).name,
+        });
+        return;
+      }
+      refused += 1;
     }
   }
-  if (unreadable.length > 0) {
+  if (refused === sample.length) {
     throw new Error(
-      `refusing to serve: ${unreadable.length} of ${rows.length} stored workspace keys cannot be ` +
-        "opened by the configured key backend. This deployment would authenticate and then fail " +
-        "every credential. Run the re-wrap (bun scripts/rewrap-workspace-keys.ts --from <backend>) " +
-        "or point GATEWAY_KMS_KEY back at the key that wrapped them.",
+      `refusing to serve: none of the ${sample.length} stored workspace keys sampled can be opened ` +
+        "by the configured key backend, so this deployment would authenticate and then fail every " +
+        "credential. Run the re-wrap (bun scripts/rewrap-workspace-keys.ts --from <backend>) or " +
+        "point the key configuration back at the key that wrapped them.",
     );
   }
-  log("info", "stored workspace keys verified", { count: rows.length });
+  if (refused > 0) {
+    // A minority that will not open is a real problem for those workspaces and not a reason to
+    // refuse everyone else — the re-wrap deliberately leaves such rows intact as evidence.
+    log("warn", "some stored workspace keys cannot be opened by the configured backend", {
+      refused,
+      sampled: sample.length,
+    });
+    return;
+  }
+  log("info", "stored workspace keys verified", { sampled: sample.length, stored: rows.length });
 }

--- a/gateway/service/master-key.ts
+++ b/gateway/service/master-key.ts
@@ -1,0 +1,151 @@
+import { randomBytes } from "node:crypto";
+import {
+  digestsEqual,
+  FileMasterKey,
+  KEY_BYTES,
+  loadMasterKey,
+  type MasterKeyBackend,
+} from "./crypto";
+import { awsRegionFromKeyArn, type GatewayEnv } from "./env";
+import {
+  loadServiceAccountKey,
+  metadataTokens,
+  serviceAccountTokens,
+  staticToken,
+  type AccessTokenSource,
+} from "./gcp-auth";
+import { KmsMasterKey } from "./kms";
+import { AwsKms } from "./kms-aws";
+import { GcpKms } from "./kms-gcp";
+import type { Logger } from "./log";
+
+/**
+ * Which master key backend a deployment runs, built from its environment — the one place that
+ * reads `GATEWAY_KEY_BACKEND`, so a new provider lands here and nowhere else.
+ *
+ * The KMS clients are handed the PLAIN fetch, not the guarded one: the guard exists to keep
+ * upstream-influenced addresses out of private ranges, and one of the credential paths (the
+ * instance metadata server) is a link-local address the guard is built to refuse. These hosts are
+ * operator configuration — the guard's threat model does not reach them.
+ */
+
+export type KeyBackendName = GatewayEnv["GATEWAY_KEY_BACKEND"];
+
+/** Every backend a deployment may name — the env enum and the re-wrap's `--from` share this list. */
+export const KEY_BACKENDS: readonly KeyBackendName[] = ["file", "gcp-kms", "aws-kms"];
+
+/** The env check already refuses a missing variable; this is the same refusal, one layer in. */
+function required(value: string | undefined, variable: string, backend: string): string {
+  if (value === undefined) {
+    throw new Error(`the ${backend} key backend requires ${variable}`);
+  }
+  return value;
+}
+
+/**
+ * Where Google credentials come from, in order: a mounted service-account key file, then a
+ * supplied token (hand smoke tests, refused in production), then the instance metadata server.
+ * Whichever answers, boot proves it works before a listener binds — see `proveMasterKeyBackend`.
+ */
+function gcpTokens(env: GatewayEnv, fetchImpl: typeof fetch): AccessTokenSource {
+  if (env.GOOGLE_APPLICATION_CREDENTIALS !== undefined) {
+    return serviceAccountTokens(loadServiceAccountKey(env.GOOGLE_APPLICATION_CREDENTIALS), {
+      fetch: fetchImpl,
+    });
+  }
+  if (env.GATEWAY_GCP_ACCESS_TOKEN !== undefined) {
+    return staticToken(env.GATEWAY_GCP_ACCESS_TOKEN);
+  }
+  return metadataTokens({ fetch: fetchImpl });
+}
+
+export function createMasterKeyBackend(
+  env: GatewayEnv,
+  log: Logger,
+  overrides: { backend?: KeyBackendName; fetch?: typeof fetch } = {},
+): MasterKeyBackend {
+  const backend = overrides.backend ?? env.GATEWAY_KEY_BACKEND;
+  const fetchImpl = overrides.fetch ?? fetch;
+  if (backend === "file") {
+    const path = required(env.GATEWAY_MASTER_KEY_FILE, "GATEWAY_MASTER_KEY_FILE", backend);
+    return new FileMasterKey(loadMasterKey(path, (message, fields) => log("warn", message, fields)));
+  }
+  const keyName = required(env.GATEWAY_KMS_KEY, "GATEWAY_KMS_KEY", backend);
+  if (backend === "gcp-kms") {
+    return new KmsMasterKey(
+      new GcpKms({ keyName, tokens: gcpTokens(env, fetchImpl), fetch: fetchImpl }),
+    );
+  }
+  return new KmsMasterKey(
+    new AwsKms({
+      keyArn: keyName,
+      region: awsRegionFromKeyArn(keyName),
+      credentials: {
+        accessKeyId: required(env.AWS_ACCESS_KEY_ID, "AWS_ACCESS_KEY_ID", backend),
+        secretAccessKey: required(env.AWS_SECRET_ACCESS_KEY, "AWS_SECRET_ACCESS_KEY", backend),
+        ...(env.AWS_SESSION_TOKEN === undefined ? {} : { sessionToken: env.AWS_SESSION_TOKEN }),
+      },
+      fetch: fetchImpl,
+    }),
+  );
+}
+
+/** Never a workspace's AAD: a probe wrap must not be mistakable for a row's. */
+const PROBE_AAD = "topos:gateway:master-key-probe";
+
+/**
+ * Prove the configured backend can wrap AND unwrap before the process serves anything. For a file
+ * key that is nearly free; for a KMS it is the round trip that turns "the operator typed a key
+ * name and a credential path" into "this deployment can actually read its credentials" — at boot,
+ * in the deploy's logs, rather than on the first agent's first tool call.
+ */
+export async function proveMasterKeyBackend(
+  backend: MasterKeyBackend,
+  log: Logger,
+): Promise<void> {
+  const probe = randomBytes(KEY_BYTES);
+  const wrapped = await backend.wrapDataKey(probe, PROBE_AAD);
+  const opened = await backend.unwrapDataKey(wrapped, PROBE_AAD);
+  if (!digestsEqual(probe, opened)) {
+    throw new Error("the master key backend did not return what it wrapped");
+  }
+  log("info", "master key backend ready", {
+    backend: backend.describe,
+    envelope: `0x${backend.formatVersion.toString(16).padStart(2, "0")}`,
+  });
+}
+
+
+/**
+ * Every wrap already in the database must open under the CONFIGURED backend, checked before a
+ * listener binds. `proveMasterKeyBackend` asks whether the key works; this asks whether it is the
+ * RIGHT key for what is stored — the question a half-finished migration, or a correct-but-different
+ * key, would otherwise answer at an agent's first tool call instead of at deploy time.
+ *
+ * A deployment with nothing stored yet passes trivially, which is the ordinary first boot.
+ */
+export async function assertStoredWrapsOpen(
+  rows: readonly { workspace_id: string; wrapped_key: Buffer }[],
+  crypto: { canOpenWorkspaceKey(workspaceId: string, wrapped: Buffer): Promise<boolean> },
+  log: Logger,
+): Promise<void> {
+  if (rows.length === 0) {
+    log("info", "no stored workspace keys to verify");
+    return;
+  }
+  const unreadable: string[] = [];
+  for (const row of rows) {
+    if (!(await crypto.canOpenWorkspaceKey(row.workspace_id, row.wrapped_key))) {
+      unreadable.push(row.workspace_id);
+    }
+  }
+  if (unreadable.length > 0) {
+    throw new Error(
+      `refusing to serve: ${unreadable.length} of ${rows.length} stored workspace keys cannot be ` +
+        "opened by the configured key backend. This deployment would authenticate and then fail " +
+        "every credential. Run the re-wrap (bun scripts/rewrap-workspace-keys.ts --from <backend>) " +
+        "or point GATEWAY_KMS_KEY back at the key that wrapped them.",
+    );
+  }
+  log("info", "stored workspace keys verified", { count: rows.length });
+}

--- a/gateway/service/rewrap.ts
+++ b/gateway/service/rewrap.ts
@@ -1,0 +1,190 @@
+import type { Pool } from "pg";
+import { digestsEqual, KEY_BYTES, workspaceKeyAad, type MasterKeyBackend } from "./crypto";
+import type { Logger } from "./log";
+import { KEY_BACKENDS, type KeyBackendName } from "./master-key";
+
+/**
+ * Moving a deployment's wrapped data keys from one master key backend to another — file → KMS
+ * being the case this exists for.
+ *
+ * Only `gateway.workspace_key` changes. The data keys themselves are untouched, so every
+ * `credential_secret` ciphertext stays exactly as it was: this rewrites the WRAP, never the
+ * credential.
+ *
+ * The three properties that make it safe to run against a production database:
+ *
+ *  · IDEMPOTENT — a row the destination can already open is left alone. That test is a real
+ *    unwrap, not a version-byte guess, so re-running after any interruption converts exactly the
+ *    rows that still need it.
+ *  · ATOMIC PER ROW — each row is locked, converted, and committed on its own. An interrupted run
+ *    leaves every row either fully old or fully new; there is no half-written wrap.
+ *  · VERIFIED BEFORE WRITE — the new envelope is unwrapped again through the destination and
+ *    compared to the plaintext before the UPDATE. A backend that cannot read back what it just
+ *    wrote fails the row instead of storing bytes nobody can open.
+ *
+ * A row that neither backend can open is reported and SKIPPED, never overwritten — that row is
+ * evidence, and the operator needs it intact.
+ *
+ * NOTHING NEEDS ITS DATA-KEY CACHE CLEARED. This sweep runs as a one-off process that holds no
+ * cache, against a stopped gateway; and even a running one could not serve a converted row from a
+ * stale entry, because `EnvelopeCrypto` keys its cache by the WRAPPED BYTES as well as the
+ * workspace — the row's new bytes are a new cache key.
+ *
+ * The run never logs key material: workspace ids and counts only.
+ */
+
+export interface RewrapPlan {
+  /** The backend that wrote the rows today. */
+  from: KeyBackendName;
+  dryRun: boolean;
+}
+
+export const REWRAP_USAGE = `usage: bun scripts/rewrap-workspace-keys.ts --from <${KEY_BACKENDS.join(
+  "|",
+)}> [--dry-run]`;
+
+/**
+ * What a re-wrap run was asked to do, or a refusal that says why. The destination is never an
+ * argument: it is `GATEWAY_KEY_BACKEND`, so a run can only move rows toward the backend the
+ * deployment is about to boot with.
+ */
+export function planRewrap(argv: readonly string[], destination: KeyBackendName): RewrapPlan {
+  const dryRun = argv.includes("--dry-run");
+  const at = argv.indexOf("--from");
+  const from = at === -1 ? undefined : argv[at + 1];
+  for (const [index, arg] of argv.entries()) {
+    if (arg !== "--dry-run" && arg !== "--from" && index !== at + 1) {
+      throw new Error(`unrecognized argument: ${arg}\n\n${REWRAP_USAGE}`);
+    }
+  }
+  if (from === undefined) {
+    throw new Error(`--from is required: name the backend that wrote the rows today\n\n${REWRAP_USAGE}`);
+  }
+  if (!KEY_BACKENDS.includes(from as KeyBackendName)) {
+    throw new Error(`--from must be one of ${KEY_BACKENDS.join(", ")}\n\n${REWRAP_USAGE}`);
+  }
+  if (from === destination) {
+    // Re-keying WITHIN one backend (a new key file, a rotated KMS key) would need a second set of
+    // variables to say which key is the old one. Nothing here can express that, so refuse rather
+    // than convert every row to itself and report success.
+    throw new Error(
+      `--from ${from} matches GATEWAY_KEY_BACKEND; there is nothing to move ` +
+        "(re-keying within one backend is not supported here)",
+    );
+  }
+  return { from: from as KeyBackendName, dryRun };
+}
+
+export interface RewrapOptions {
+  /** The backend that wrote the rows today. */
+  from: MasterKeyBackend;
+  /** The backend the deployment is moving to. */
+  to: MasterKeyBackend;
+  /** Do every step including the read-back verification, then roll back instead of committing. */
+  dryRun: boolean;
+  log: Logger;
+}
+
+export interface RewrapSummary {
+  scanned: number;
+  converted: number;
+  alreadyThere: number;
+  failed: number;
+}
+
+async function openWith(
+  backend: MasterKeyBackend,
+  wrapped: Buffer,
+  workspaceId: string,
+): Promise<Buffer | null> {
+  try {
+    const key = await backend.unwrapDataKey(wrapped, workspaceKeyAad(workspaceId));
+    return key.length === KEY_BYTES ? key : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function rewrapWorkspaceKeys(
+  pool: Pool,
+  options: RewrapOptions,
+): Promise<RewrapSummary> {
+  const { from, to, dryRun, log } = options;
+  const summary: RewrapSummary = { scanned: 0, converted: 0, alreadyThere: 0, failed: 0 };
+  const listed = await pool.query<{ workspace_id: string }>(
+    "SELECT workspace_id FROM gateway.workspace_key ORDER BY workspace_id",
+  );
+  log("info", "re-wrap starting", {
+    rows: listed.rows.length,
+    from: from.describe,
+    to: to.describe,
+    mode: dryRun ? "dry-run" : "write",
+  });
+
+  for (const { workspace_id: workspaceId } of listed.rows) {
+    summary.scanned += 1;
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      // Re-read under the row lock: a parallel run (or a second replica) may already have
+      // converted this row since the listing above.
+      const locked = await client.query<{ wrapped_key: Buffer }>(
+        "SELECT wrapped_key FROM gateway.workspace_key WHERE workspace_id = $1 FOR UPDATE",
+        [workspaceId],
+      );
+      const standing = locked.rows[0]?.wrapped_key;
+      if (standing === undefined) {
+        // Deleted between the listing and the lock — nothing to convert, nothing wrong.
+        await client.query("ROLLBACK");
+        summary.scanned -= 1;
+        continue;
+      }
+      if ((await openWith(to, standing, workspaceId)) !== null) {
+        await client.query("ROLLBACK");
+        summary.alreadyThere += 1;
+        continue;
+      }
+      const plaintext = await openWith(from, standing, workspaceId);
+      if (plaintext === null) {
+        await client.query("ROLLBACK");
+        summary.failed += 1;
+        log("error", "workspace key opens under neither backend; left untouched", { workspaceId });
+        continue;
+      }
+      const rewrapped = await to.wrapDataKey(plaintext, workspaceKeyAad(workspaceId));
+      const readBack = await openWith(to, rewrapped, workspaceId);
+      if (readBack === null || !digestsEqual(plaintext, readBack)) {
+        await client.query("ROLLBACK");
+        summary.failed += 1;
+        log("error", "re-wrapped key failed its read-back; row left untouched", { workspaceId });
+        continue;
+      }
+      await client.query(
+        "UPDATE gateway.workspace_key SET wrapped_key = $2 WHERE workspace_id = $1",
+        [workspaceId, rewrapped],
+      );
+      // The dry run has now proven the whole path — unwrap, re-wrap, read back — and throws the
+      // write away. It is the honest rehearsal: everything a real run does except the commit.
+      await client.query(dryRun ? "ROLLBACK" : "COMMIT");
+      summary.converted += 1;
+      log("info", dryRun ? "workspace key would be re-wrapped" : "workspace key re-wrapped", {
+        workspaceId,
+      });
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      summary.failed += 1;
+      log("error", "re-wrap failed for a workspace; row left untouched", {
+        workspaceId,
+        detail: String(error).slice(0, 200),
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  log(summary.failed === 0 ? "info" : "error", "re-wrap finished", {
+    ...summary,
+    mode: dryRun ? "dry-run" : "write",
+  });
+  return summary;
+}

--- a/gateway/service/store.ts
+++ b/gateway/service/store.ts
@@ -411,7 +411,11 @@ export class PgStore implements GatewayStore {
     }
   }
 
-  /** True when a row was deleted (the secret cascades with it). */
+  /**
+   * True when a row was deleted (the secret cascades with it). Revocation is unaffected by the
+   * data-key cache: `credentialFor` finds no row and answers null before any key is consulted, so
+   * a cached workspace key cannot keep a revoked credential alive for a moment.
+   */
   async deleteCredential(credentialId: string): Promise<boolean> {
     const result = await this.pool.query("DELETE FROM gateway.credential WHERE id = $1", [
       credentialId,

--- a/gateway/tests/helpers/fake-kms.ts
+++ b/gateway/tests/helpers/fake-kms.ts
@@ -1,0 +1,188 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { crc32c } from "../../service/kms-gcp";
+
+/**
+ * Fake key services — in-process stand-ins for Cloud KMS and AWS KMS that speak the real wire
+ * shapes over an injected `fetch`. NOTHING in the suite reaches a cloud.
+ *
+ * They are not mocks that echo canned bytes: each holds a local AES-256-GCM key and performs a
+ * real authenticated encryption with the AAD the request carried, so an AAD that does not match
+ * on the way back fails the way the real service fails. That is what makes the row-binding tests
+ * meaningful rather than decorative.
+ *
+ * Each returns its `fetch` plus a `calls` log and a `fail` hook, so a suite can make the service
+ * misbehave (a 503, an unverified checksum) and watch the provider's answer.
+ */
+
+export interface FakeFailure {
+  status: number;
+  body: unknown;
+}
+
+export interface FakeKms {
+  fetch: typeof fetch;
+  /** One entry per HTTP call the provider made, in order — the request body included. */
+  calls: { url: string; target: string; headers: Record<string, string>; body: string }[];
+  /** Queued responses — each call shifts one; empty means behave normally. */
+  failures: (FakeFailure | "unverified-plaintext-crc" | "corrupt-ciphertext-crc" | null)[];
+}
+
+function localSeal(key: Buffer, plaintext: Buffer, aad: Buffer): Buffer {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(aad);
+  const body = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), body]);
+}
+
+function localOpen(key: Buffer, blob: Buffer, aad: Buffer): Buffer {
+  const decipher = createDecipheriv("aes-256-gcm", key, blob.subarray(0, 12));
+  decipher.setAAD(aad);
+  decipher.setAuthTag(blob.subarray(12, 28));
+  return Buffer.concat([decipher.update(blob.subarray(28)), decipher.final()]);
+}
+
+function headerMap(init: RequestInit | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  const headers = init?.headers;
+  if (headers !== undefined && !Array.isArray(headers) && !(headers instanceof Headers)) {
+    for (const [name, value] of Object.entries(headers)) {
+      out[name.toLowerCase()] = String(value);
+    }
+  }
+  return out;
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function googleError(status: number, message: string, code: string): Response {
+  return json(status, { error: { code: status, message, status: code } });
+}
+
+/** Cloud KMS: `{name}:encrypt` / `{name}:decrypt`, base64 fields, int64-as-string checksums. */
+export function fakeGcpKms(options: {
+  keyName: string;
+  key?: Buffer;
+  /** Answer for a different key than the one asked for. */
+  answerAsKeyName?: string;
+}): FakeKms {
+  const key = options.key ?? randomBytes(32);
+  const state: FakeKms = {
+    calls: [],
+    failures: [],
+    fetch: null as unknown as typeof fetch,
+  };
+  state.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const target = url.endsWith(":encrypt") ? "encrypt" : url.endsWith(":decrypt") ? "decrypt" : "";
+    const headers = headerMap(init);
+    state.calls.push({ url, target, headers, body: String(init?.body ?? "") });
+    const failure = state.failures.shift() ?? null;
+    if (failure !== null && typeof failure === "object") {
+      return json(failure.status, failure.body);
+    }
+    if (!(headers.authorization ?? "").startsWith("Bearer ")) {
+      return googleError(401, "missing bearer", "UNAUTHENTICATED");
+    }
+    if (!url.startsWith(`https://cloudkms.googleapis.com/v1/${options.keyName}:`)) {
+      return googleError(404, "no such key", "NOT_FOUND");
+    }
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, string>;
+    const aad = Buffer.from(body.additionalAuthenticatedData ?? "", "base64");
+    const answeringKey = options.answerAsKeyName ?? options.keyName;
+    if (target === "encrypt") {
+      const plaintext = Buffer.from(body.plaintext ?? "", "base64");
+      const ciphertext = localSeal(key, plaintext, aad);
+      return json(200, {
+        name: `${answeringKey}/cryptoKeyVersions/1`,
+        ciphertext: ciphertext.toString("base64"),
+        ciphertextCrc32c:
+          failure === "corrupt-ciphertext-crc" ? "1" : crc32c(ciphertext).toString(),
+        verifiedPlaintextCrc32c: failure !== "unverified-plaintext-crc",
+        verifiedAdditionalAuthenticatedDataCrc32c: true,
+        protectionLevel: "SOFTWARE",
+      });
+    }
+    if (target === "decrypt") {
+      let plaintext: Buffer;
+      try {
+        plaintext = localOpen(key, Buffer.from(body.ciphertext ?? "", "base64"), aad);
+      } catch {
+        // What a wrong AAD (or a foreign ciphertext) really looks like from Cloud KMS.
+        return googleError(400, "Decryption failed", "INVALID_ARGUMENT");
+      }
+      return json(200, {
+        plaintext: plaintext.toString("base64"),
+        plaintextCrc32c: crc32c(plaintext).toString(),
+        usedPrimary: true,
+        protectionLevel: "SOFTWARE",
+      });
+    }
+    return googleError(400, "unknown method", "INVALID_ARGUMENT");
+  }) as typeof fetch;
+  return state;
+}
+
+/** AWS KMS: one POST to `/`, the operation in `X-Amz-Target`, EncryptionContext as the AAD. */
+export function fakeAwsKms(options: { keyArn: string; region: string; key?: Buffer }): FakeKms {
+  const key = options.key ?? randomBytes(32);
+  const state: FakeKms = {
+    calls: [],
+    failures: [],
+    fetch: null as unknown as typeof fetch,
+  };
+  state.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = headerMap(init);
+    const target = headers["x-amz-target"] ?? "";
+    state.calls.push({ url, target, headers, body: String(init?.body ?? "") });
+    const failure = state.failures.shift() ?? null;
+    if (failure !== null && typeof failure === "object") {
+      return json(failure.status, failure.body);
+    }
+    if (!(headers.authorization ?? "").startsWith("AWS4-HMAC-SHA256 ")) {
+      return json(403, { __type: "IncompleteSignature", message: "unsigned" });
+    }
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    // The context is a map; its ORDER is not part of the match, its pairs are.
+    const context = Buffer.from(
+      JSON.stringify(
+        Object.entries((body.EncryptionContext ?? {}) as Record<string, string>).sort(),
+      ),
+      "utf8",
+    );
+    if (body.KeyId !== options.keyArn) {
+      return json(400, { __type: "NotFoundException", message: "key not found" });
+    }
+    if (target === "TrentService.Encrypt") {
+      const blob = localSeal(key, Buffer.from(String(body.Plaintext), "base64"), context);
+      return json(200, {
+        CiphertextBlob: blob.toString("base64"),
+        KeyId: options.keyArn,
+        EncryptionAlgorithm: "SYMMETRIC_DEFAULT",
+      });
+    }
+    if (target === "TrentService.Decrypt") {
+      try {
+        const plaintext = localOpen(
+          key,
+          Buffer.from(String(body.CiphertextBlob), "base64"),
+          context,
+        );
+        return json(200, { Plaintext: plaintext.toString("base64"), KeyId: options.keyArn });
+      } catch {
+        return json(400, {
+          __type: "com.amazonaws.kms#InvalidCiphertextException",
+          message: "bad ciphertext or context",
+        });
+      }
+    }
+    return json(400, { __type: "UnknownOperationException", message: target });
+  }) as typeof fetch;
+  return state;
+}

--- a/gateway/tests/service-crypto.test.ts
+++ b/gateway/tests/service-crypto.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
-import { EnvelopeCrypto, loadMasterKey } from "../service/crypto";
+import {
+  EnvelopeCrypto,
+  FileMasterKey,
+  loadMasterKey,
+  type MasterKeyBackend,
+} from "../service/crypto";
 
 const dir = mkdtempSync(join(tmpdir(), "gw-crypto-"));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
@@ -39,7 +44,7 @@ describe("master key file", () => {
 });
 
 describe("credential envelope", () => {
-  const crypto = new EnvelopeCrypto(randomBytes(32));
+  const crypto = new EnvelopeCrypto(new FileMasterKey(randomBytes(32)));
 
   it("round-trips a payload under its own identity", async () => {
     const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
@@ -65,7 +70,7 @@ describe("credential envelope", () => {
 
   it("a wrapped key does not unwrap under a different master key", async () => {
     const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
-    const other = new EnvelopeCrypto(randomBytes(32));
+    const other = new EnvelopeCrypto(new FileMasterKey(randomBytes(32)));
     await expect(
       other.decryptCredential(
         await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped),
@@ -81,5 +86,168 @@ describe("credential envelope", () => {
     await expect(
       crypto.decryptCredential(Buffer.from([0x02, 1, 2, 3]), "cred_a", "ws1", wrapped),
     ).rejects.toThrow(/format/);
+  });
+});
+
+/**
+ * The 0x01 envelope is FROZEN. These bytes were produced by the file-backed envelope as it stood
+ * before the key-backend seam existed — a real witness, generated from that revision of
+ * `service/crypto.ts`, not re-derived from the code under test. Every deployment in the field
+ * holds rows exactly like them, so a change that stops opening these has broken custody.
+ */
+describe("the 0x01 envelope stays byte-compatible", () => {
+  const FROZEN = {
+    master: "4f8b2c1d9e3a7f6058b4c2d1e0f9a8b7c6d5e4f3021a3b4c5d6e7f8091a2b3c4",
+    wrapped:
+      "01f8319267a7ed4e2fd899a882eff46f5a9650e7854905a718a07b3bb4786710b1c479a5b7add1bf8ba9025ed6ce2749c90de108def1879d865138cf62",
+    sealed:
+      "0123a50f10d05b819e50e40410ea954093aad95ea98ba44021af5ac099586bc031791a87040fb33ebc2de0f075a06f2c8c9c518c5e5f7a99bd32fb201821c2b5f5a50e35d39b049fe810ac32548a94ef",
+    workspaceId: "ws_frozen",
+    credentialId: "cred_frozen",
+  };
+  const frozen = new EnvelopeCrypto(new FileMasterKey(Buffer.from(FROZEN.master, "hex")));
+
+  it("opens a wrapped key and credential written before the seam existed", async () => {
+    const opened = await frozen.decryptCredential(
+      Buffer.from(FROZEN.sealed, "hex"),
+      FROZEN.credentialId,
+      FROZEN.workspaceId,
+      Buffer.from(FROZEN.wrapped, "hex"),
+    );
+    expect(opened).toEqual({ secret: "tok-frozen", refreshToken: "ref-frozen" });
+  });
+
+  it("still writes that same shape: 0x01, a 12-byte IV, a 32-byte key and its tag", async () => {
+    const wrapped = await frozen.mintWrappedWorkspaceKey("ws_frozen");
+    expect(wrapped[0]).toBe(0x01);
+    expect(wrapped.length).toBe(Buffer.from(FROZEN.wrapped, "hex").length);
+    // Freshly written bytes and the frozen ones open under the same key, for the same workspace.
+    const sealed = await frozen.encryptCredential({ secret: "s" }, "cred_frozen", "ws_frozen", wrapped);
+    expect((await frozen.decryptCredential(sealed, "cred_frozen", "ws_frozen", wrapped)).secret).toBe("s");
+  });
+});
+
+describe("a backend refuses another backend's wrapped key", () => {
+  it("names the KMS backend when a 0x02 row meets a file key", async () => {
+    const file = new EnvelopeCrypto(new FileMasterKey(randomBytes(32)));
+    const kmsShaped = Buffer.concat([Buffer.from([0x02, 0x01]), randomBytes(48)]);
+    await expect(
+      file.encryptCredential({ secret: "s" }, "cred_a", "ws1", kmsShaped),
+    ).rejects.toThrow(/KMS key backend.*file backend/s);
+  });
+});
+
+/**
+ * The data-key cache. Under a KMS backend an unwrap is a network round trip and every proxied tool
+ * call needs one, so these are the properties that keep that from being one RPC per request —
+ * without letting a key outlive its window or a migrated row be served from a stale entry.
+ */
+describe("the data-key cache", () => {
+  function counting(inner: MasterKeyBackend): MasterKeyBackend & { unwraps: number } {
+    const spy = {
+      formatVersion: inner.formatVersion,
+      describe: inner.describe,
+      unwraps: 0,
+      wrapDataKey: (key: Buffer, aad: string) => inner.wrapDataKey(key, aad),
+      unwrapDataKey: (envelope: Buffer, aad: string) => {
+        spy.unwraps += 1;
+        return inner.unwrapDataKey(envelope, aad);
+      },
+    };
+    return spy;
+  }
+
+  it("unwraps once for a burst on one workspace, and once more per workspace", async () => {
+    const backend = counting(new FileMasterKey(randomBytes(32)));
+    const crypto = new EnvelopeCrypto(backend);
+    const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
+    const other = await crypto.mintWrappedWorkspaceKey("ws2");
+    await Promise.all(
+      Array.from({ length: 8 }, async () =>
+        crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped),
+      ),
+    );
+    expect(backend.unwraps).toBe(1);
+    await crypto.encryptCredential({ secret: "s" }, "cred_b", "ws2", other);
+    expect(backend.unwraps).toBe(2);
+  });
+
+  it("re-unwraps once the entry has aged out", async () => {
+    const backend = counting(new FileMasterKey(randomBytes(32)));
+    let clock = 1_000_000;
+    const crypto = new EnvelopeCrypto(backend, () => clock);
+    const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    clock += 14 * 60 * 1000;
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    expect(backend.unwraps).toBe(1);
+    clock += 2 * 60 * 1000;
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    expect(backend.unwraps).toBe(2);
+  });
+
+  it("never serves a re-wrapped row from the key cached for the old bytes", async () => {
+    const backend = counting(new FileMasterKey(randomBytes(32)));
+    const crypto = new EnvelopeCrypto(backend);
+    const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    expect(backend.unwraps).toBe(1);
+    // The same workspace, a wrap this backend cannot open — a row migrated to another backend.
+    const migrated = Buffer.concat([Buffer.from([0x02, 0x01]), randomBytes(48)]);
+    await expect(
+      crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", migrated),
+    ).rejects.toThrow(/KMS key backend/);
+    expect(backend.unwraps).toBe(2);
+  });
+
+  it("does not remember a failed unwrap", async () => {
+    const inner = new FileMasterKey(randomBytes(32));
+    let failNext = true;
+    const backend: MasterKeyBackend & { unwraps: number } = {
+      formatVersion: inner.formatVersion,
+      describe: inner.describe,
+      unwraps: 0,
+      wrapDataKey: (key: Buffer, aad: string) => inner.wrapDataKey(key, aad),
+      unwrapDataKey: async (envelope: Buffer, aad: string) => {
+        backend.unwraps += 1;
+        if (failNext) {
+          failNext = false;
+          throw new Error("the key service is unreachable");
+        }
+        return inner.unwrapDataKey(envelope, aad);
+      },
+    };
+    const crypto = new EnvelopeCrypto(backend);
+    const wrapped = await inner.wrapDataKey(randomBytes(32), "topos:gateway:workspace-key:ws1");
+    await expect(
+      crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped),
+    ).rejects.toThrow(/unreachable/);
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    expect(backend.unwraps).toBe(2);
+  });
+
+  it("keeps the cache bounded, evicting the least recently used", async () => {
+    const backend = counting(new FileMasterKey(randomBytes(32)));
+    const crypto = new EnvelopeCrypto(backend);
+    const first = await crypto.mintWrappedWorkspaceKey("ws-first");
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws-first", first);
+    const before = backend.unwraps;
+    for (let i = 0; i < 300; i += 1) {
+      const wrapped = await crypto.mintWrappedWorkspaceKey(`ws-${i}`);
+      await crypto.encryptCredential({ secret: "s" }, "cred_a", `ws-${i}`, wrapped);
+    }
+    // The first workspace fell out of a bounded cache and has to be unwrapped again.
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws-first", first);
+    expect(backend.unwraps).toBe(before + 301);
+  });
+
+  it("clears on demand", async () => {
+    const backend = counting(new FileMasterKey(randomBytes(32)));
+    const crypto = new EnvelopeCrypto(backend);
+    const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    crypto.clearDataKeyCache();
+    await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    expect(backend.unwraps).toBe(2);
   });
 });

--- a/gateway/tests/service-grants.test.ts
+++ b/gateway/tests/service-grants.test.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import pg from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { EnvelopeCrypto } from "../service/crypto";
+import { EnvelopeCrypto, FileMasterKey } from "../service/crypto";
 import { PgStore } from "../service/store";
 import {
   createServiceDb,
@@ -29,7 +29,7 @@ beforeAll(async () => {
   gatewayPool = new pg.Pool({ connectionString: db.gatewayUrl, max: 2 });
   const store = new PgStore(
     gatewayPool,
-    new EnvelopeCrypto(randomBytes(32)),
+    new EnvelopeCrypto(new FileMasterKey(randomBytes(32))),
     "https://team.example.com",
     () => {},
   );

--- a/gateway/tests/service-kms.test.ts
+++ b/gateway/tests/service-kms.test.ts
@@ -4,9 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import { EnvelopeCrypto, FileMasterKey, workspaceKeyAad } from "../service/crypto";
+import type { MasterKeyBackend } from "../service/crypto";
 import { awsRegionFromKeyArn, parseGatewayEnv } from "../service/env";
 import { metadataTokens, parseServiceAccountKey, serviceAccountTokens } from "../service/gcp-auth";
-import { KmsMasterKey } from "../service/kms";
+import { KmsMasterKey, RetryableKmsError } from "../service/kms";
 import { AwsKms, deriveSigningKey, signKmsRequest } from "../service/kms-aws";
 import { crc32c, GcpKms } from "../service/kms-gcp";
 import {
@@ -613,35 +614,87 @@ describe("the boot proof", () => {
 });
 
 describe("the boot check against what is already stored", () => {
+  // A backend that opens exactly the wraps it is told to, and fails the rest the way a real one
+  // does — a definite refusal, not a transport error.
+  const backendThatOpens = (openable: (ws: string) => boolean): MasterKeyBackend => ({
+    describe: "fake",
+    formatVersion: 0x01,
+    wrapDataKey: async (key: Buffer) => key,
+    unwrapDataKey: async (envelope: Buffer, aad: string) => {
+      if (!openable(aad)) {
+        throw new Error("refused");
+      }
+      return envelope;
+    },
+  });
+
   it("passes trivially when nothing is stored yet", async () => {
     const seen: string[] = [];
-    await assertStoredWrapsOpen([], { canOpenWorkspaceKey: async () => true }, (_l, m) => {
+    await assertStoredWrapsOpen([], backendThatOpens(() => true), (_l, m) => {
       seen.push(m);
     });
     expect(seen).toContain("no stored workspace keys to verify");
   });
 
-  it("refuses to serve when a stored wrap cannot be opened by the configured backend", async () => {
-    // The half-finished migration: the key works (the boot proof passed) but it is not the key
-    // that wrapped these rows, so every credential would fail at an agent's first tool call.
+  it("refuses to serve when NONE of the sampled wraps open — the wrong-key deployment", async () => {
     const rows = [
-      { workspace_id: "ws_ok", wrapped_key: Buffer.from([1]) },
-      { workspace_id: "ws_stale", wrapped_key: Buffer.from([2]) },
+      { workspace_id: "ws_a", wrapped_key: Buffer.from([1]) },
+      { workspace_id: "ws_b", wrapped_key: Buffer.from([2]) },
     ];
     await expect(
-      assertStoredWrapsOpen(
-        rows,
-        { canOpenWorkspaceKey: async (ws) => ws === "ws_ok" },
-        () => {},
-      ),
-    ).rejects.toThrow(/1 of 2 stored workspace keys cannot be opened/);
+      assertStoredWrapsOpen(rows, backendThatOpens(() => false), () => {}),
+    ).rejects.toThrow(/none of the 2 stored workspace keys sampled can be opened/);
   });
 
-  it("passes when every stored wrap opens", async () => {
+  it("warns rather than refuses when only SOME will not open", async () => {
+    // The re-wrap deliberately leaves a row it could not convert, as evidence. That must not stop
+    // every other workspace from being served.
+    const rows = [
+      { workspace_id: "ws_ok", wrapped_key: Buffer.from([1]) },
+      { workspace_id: "ws_evidence", wrapped_key: Buffer.from([2]) },
+    ];
+    const warned: string[] = [];
+    await assertStoredWrapsOpen(
+      rows,
+      backendThatOpens((aad) => aad.endsWith("ws_ok")),
+      (level, m) => {
+        if (level === "warn") warned.push(m);
+      },
+    );
+    expect(warned.join()).toMatch(/some stored workspace keys cannot be opened/);
+  });
+
+  it("does not refuse when the key service could not be ASKED", async () => {
+    // A KMS blip must never produce a refusal telling the operator to run a migration.
     const rows = [{ workspace_id: "ws_a", wrapped_key: Buffer.from([1]) }];
-    await expect(
-      assertStoredWrapsOpen(rows, { canOpenWorkspaceKey: async () => true }, () => {}),
-    ).resolves.toBeUndefined();
+    const backend: MasterKeyBackend = {
+      describe: "fake",
+      formatVersion: 0x02,
+      wrapDataKey: async (k: Buffer) => k,
+      unwrapDataKey: async () => {
+        throw new RetryableKmsError("Cloud KMS is unavailable (503)");
+      },
+    };
+    await expect(assertStoredWrapsOpen(rows, backend, () => {})).resolves.toBeUndefined();
+  });
+
+  it("samples rather than opening every row — boot stays O(1) in workspaces", async () => {
+    const rows = Array.from({ length: 400 }, (_, i) => ({
+      workspace_id: `ws_${i}`,
+      wrapped_key: Buffer.from([1]),
+    }));
+    let calls = 0;
+    const backend: MasterKeyBackend = {
+      describe: "fake",
+      formatVersion: 0x02,
+      wrapDataKey: async (k: Buffer) => k,
+      unwrapDataKey: async (e: Buffer) => {
+        calls += 1;
+        return e;
+      },
+    };
+    await assertStoredWrapsOpen(rows, backend, () => {});
+    expect(calls).toBeLessThanOrEqual(5);
   });
 });
 
@@ -656,5 +709,37 @@ describe("the AWS key ARN's partition", () => {
 
   it("accepts a commercial ARN and names its region", () => {
     expect(awsRegionFromKeyArn("arn:aws:kms:us-west-2:123456789012:key/abc-def")).toBe("us-west-2");
+  });
+});
+
+describe("the guards the security review asked for", () => {
+  it("refuses aws-kms in production — hand-rolled signing, never verified against AWS", () => {
+    expect(() =>
+      parseGatewayEnv({
+        DATABASE_URL: "postgres://x",
+        GATEWAY_PUBLIC_URL: "https://gw.example.com",
+        TOPOS_PUBLIC_URL: "https://topos.example.com",
+        APP_ENV: "production",
+        GATEWAY_KEY_BACKEND: "aws-kms",
+        GATEWAY_KMS_KEY: "arn:aws:kms:us-west-2:123456789012:key/abc-def",
+        AWS_ACCESS_KEY_ID: "AKIA",
+        AWS_SECRET_ACCESS_KEY: "secret",
+      }),
+    ).toThrow(/aws-kms is not verified against a real AWS endpoint/);
+  });
+
+  it("still allows aws-kms outside production, where an operator chose it deliberately", () => {
+    expect(() =>
+      parseGatewayEnv({
+        DATABASE_URL: "postgres://x",
+        GATEWAY_PUBLIC_URL: "https://gw.example.com",
+        TOPOS_PUBLIC_URL: "https://topos.example.com",
+        APP_ENV: "development",
+        GATEWAY_KEY_BACKEND: "aws-kms",
+        GATEWAY_KMS_KEY: "arn:aws:kms:us-west-2:123456789012:key/abc-def",
+        AWS_ACCESS_KEY_ID: "AKIA",
+        AWS_SECRET_ACCESS_KEY: "secret",
+      }),
+    ).not.toThrow();
   });
 });

--- a/gateway/tests/service-kms.test.ts
+++ b/gateway/tests/service-kms.test.ts
@@ -1,0 +1,660 @@
+import { createHash, createHmac, createVerify, generateKeyPairSync, randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { EnvelopeCrypto, FileMasterKey, workspaceKeyAad } from "../service/crypto";
+import { awsRegionFromKeyArn, parseGatewayEnv } from "../service/env";
+import { metadataTokens, parseServiceAccountKey, serviceAccountTokens } from "../service/gcp-auth";
+import { KmsMasterKey } from "../service/kms";
+import { AwsKms, deriveSigningKey, signKmsRequest } from "../service/kms-aws";
+import { crc32c, GcpKms } from "../service/kms-gcp";
+import {
+  assertStoredWrapsOpen,
+  createMasterKeyBackend,
+  proveMasterKeyBackend,
+} from "../service/master-key";
+import { fakeAwsKms, fakeGcpKms } from "./helpers/fake-kms";
+
+/**
+ * The KMS key backend, end to end against FAKE key services (`tests/helpers/fake-kms.ts`). No
+ * test here reaches a cloud: what is proven is the envelope, the dispatch, the wire shapes, the
+ * integrity checks, the retry classification, and the refusals — everything except whether a real
+ * Google or AWS endpoint accepts these bytes, which only a credentialed deployment can answer.
+ */
+
+const KEY_NAME = "projects/topos-test/locations/us-east1/keyRings/gateway/cryptoKeys/master";
+const KEY_ARN = "arn:aws:kms:us-east-1:123456789012:key/2f4b1c3d-1111-2222-3333-444455556666";
+const quiet = () => {};
+const nosleep = async (): Promise<void> => {};
+
+const dir = mkdtempSync(join(tmpdir(), "gw-kms-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+function gcpBackend(fake = fakeGcpKms({ keyName: KEY_NAME })): {
+  backend: KmsMasterKey;
+  fake: ReturnType<typeof fakeGcpKms>;
+} {
+  const backend = new KmsMasterKey(
+    new GcpKms({
+      keyName: KEY_NAME,
+      tokens: { describe: "a test token", token: async () => "test-token" },
+      fetch: fake.fetch,
+      sleep: nosleep,
+    }),
+  );
+  return { backend, fake };
+}
+
+function awsBackend(fake = fakeAwsKms({ keyArn: KEY_ARN, region: "us-east-1" })): {
+  backend: KmsMasterKey;
+  fake: ReturnType<typeof fakeAwsKms>;
+} {
+  const backend = new KmsMasterKey(
+    new AwsKms({
+      keyArn: KEY_ARN,
+      region: "us-east-1",
+      credentials: { accessKeyId: "AKIDEXAMPLE", secretAccessKey: "secret" },
+      fetch: fake.fetch,
+      sleep: nosleep,
+    }),
+  );
+  return { backend, fake };
+}
+
+describe("crc32c", () => {
+  it("matches the published check values", () => {
+    // The standard CRC-32/ISCSI check value for "123456789", and the empty-input identity.
+    expect(crc32c(Buffer.from("123456789", "utf8"))).toBe(0xe3069283);
+    expect(crc32c(Buffer.alloc(0))).toBe(0);
+    expect(crc32c(Buffer.from([0x00]))).toBe(0x527d5351);
+  });
+});
+
+describe("the KMS backend round-trips", () => {
+  it("wraps and unwraps a data key without the master key entering the process", async () => {
+    const { backend, fake } = gcpBackend();
+    const key = randomBytes(32);
+    const wrapped = await backend.wrapDataKey(key, workspaceKeyAad("ws1"));
+    expect(wrapped[0]).toBe(0x02);
+    expect(wrapped[1]).toBe(0x01);
+    // Nothing in the stored envelope is the data key itself.
+    expect(wrapped.subarray(2).includes(key)).toBe(false);
+    expect(await backend.unwrapDataKey(wrapped, workspaceKeyAad("ws1"))).toEqual(key);
+    expect(fake.calls.map((call) => call.target)).toEqual(["encrypt", "decrypt"]);
+  });
+
+  it("carries a whole credential through the same two layers", async () => {
+    const { backend } = gcpBackend();
+    const crypto = new EnvelopeCrypto(backend);
+    const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
+    const payload = { secret: "tok-abc", refreshToken: "ref-xyz" };
+    const sealed = await crypto.encryptCredential(payload, "cred_a", "ws1", wrapped);
+    expect(await crypto.decryptCredential(sealed, "cred_a", "ws1", wrapped)).toEqual(payload);
+  });
+
+  it("costs one KMS round trip per workspace, not one per proxied call", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    const { backend } = gcpBackend(fake);
+    const crypto = new EnvelopeCrypto(backend);
+    const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
+    for (let call = 0; call < 20; call += 1) {
+      const sealed = await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+      await crypto.decryptCredential(sealed, "cred_a", "ws1", wrapped);
+    }
+    // One encrypt to mint the data key, one decrypt to unwrap it. Forty credential operations
+    // added nothing: this is what keeps a KMS backend off the per-request path.
+    expect(fake.calls.map((call) => call.target)).toEqual(["encrypt", "decrypt"]);
+  });
+
+  it("does the same through AWS", async () => {
+    const { backend } = awsBackend();
+    const crypto = new EnvelopeCrypto(backend);
+    const wrapped = await crypto.mintWrappedWorkspaceKey("ws1");
+    expect(wrapped[0]).toBe(0x02);
+    expect(wrapped[1]).toBe(0x02);
+    const sealed = await crypto.encryptCredential({ secret: "s" }, "cred_a", "ws1", wrapped);
+    expect((await crypto.decryptCredential(sealed, "cred_a", "ws1", wrapped)).secret).toBe("s");
+  });
+});
+
+describe("AAD binds a wrapped key to its workspace on both clouds", () => {
+  it("a GCP-wrapped key does not unwrap under another workspace", async () => {
+    const { backend } = gcpBackend();
+    const wrapped = await backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"));
+    await expect(backend.unwrapDataKey(wrapped, workspaceKeyAad("ws2"))).rejects.toThrow(
+      /refused the request/,
+    );
+  });
+
+  it("an AWS-wrapped key does not unwrap under another workspace", async () => {
+    const { backend } = awsBackend();
+    const wrapped = await backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"));
+    await expect(backend.unwrapDataKey(wrapped, workspaceKeyAad("ws2"))).rejects.toThrow(
+      /InvalidCiphertextException/,
+    );
+  });
+
+  it("refuses to wrap with no AAD at all", async () => {
+    const { backend } = gcpBackend();
+    await expect(backend.wrapDataKey(randomBytes(32), "")).rejects.toThrow(/empty AAD/);
+  });
+});
+
+describe("the version byte decides which key opens a row", () => {
+  it("a 0x01 row refuses to open under a KMS backend", async () => {
+    const fileWrapped = await new FileMasterKey(randomBytes(32)).wrapDataKey(
+      randomBytes(32),
+      workspaceKeyAad("ws1"),
+    );
+    const { backend, fake } = gcpBackend();
+    await expect(backend.unwrapDataKey(fileWrapped, workspaceKeyAad("ws1"))).rejects.toThrow(
+      /written by the file key backend; this gateway runs the gcp-kms backend/,
+    );
+    // Refused locally: the bytes never left the process.
+    expect(fake.calls).toEqual([]);
+  });
+
+  it("a 0x02 row refuses to open under the file backend", async () => {
+    const { backend } = gcpBackend();
+    const kmsWrapped = await backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"));
+    await expect(
+      new FileMasterKey(randomBytes(32)).unwrapDataKey(kmsWrapped, workspaceKeyAad("ws1")),
+    ).rejects.toThrow(/written by a KMS key backend; this gateway runs the file backend/);
+  });
+
+  it("a GCP row refuses to open under an AWS-configured gateway", async () => {
+    const { backend: gcp } = gcpBackend();
+    const { backend: aws, fake } = awsBackend();
+    const wrapped = await gcp.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"));
+    await expect(aws.unwrapDataKey(wrapped, workspaceKeyAad("ws1"))).rejects.toThrow(
+      /written by gcp-kms; this gateway runs aws-kms/,
+    );
+    expect(fake.calls).toEqual([]);
+  });
+
+  it("refuses a truncated envelope rather than guessing", async () => {
+    const { backend } = gcpBackend();
+    await expect(backend.unwrapDataKey(Buffer.alloc(0), workspaceKeyAad("ws1"))).rejects.toThrow(
+      /empty value/,
+    );
+    await expect(
+      backend.unwrapDataKey(Buffer.from([0x02]), workspaceKeyAad("ws1")),
+    ).rejects.toThrow(/truncated envelope/);
+  });
+});
+
+describe("Cloud KMS integrity checks", () => {
+  it("retries a response the service did not checksum-verify, then accepts the good one", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    fake.failures.push("unverified-plaintext-crc");
+    const { backend } = gcpBackend(fake);
+    const key = randomBytes(32);
+    const wrapped = await backend.wrapDataKey(key, workspaceKeyAad("ws1"));
+    expect(fake.calls.length).toBe(2);
+    expect(await backend.unwrapDataKey(wrapped, workspaceKeyAad("ws1"))).toEqual(key);
+  });
+
+  it("retries a ciphertext whose checksum does not match what arrived", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    fake.failures.push("corrupt-ciphertext-crc");
+    const { backend } = gcpBackend(fake);
+    await backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"));
+    expect(fake.calls.length).toBe(2);
+  });
+
+  it("puts the plaintext, the AAD and both checksums on the wire", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    const { backend } = gcpBackend(fake);
+    const key = randomBytes(32);
+    await backend.wrapDataKey(key, workspaceKeyAad("ws1"));
+    const sent = JSON.parse(fake.calls[0]?.body ?? "{}") as Record<string, string>;
+    expect(fake.calls[0]?.url).toBe(`https://cloudkms.googleapis.com/v1/${KEY_NAME}:encrypt`);
+    expect(Buffer.from(sent.plaintext ?? "", "base64")).toEqual(key);
+    expect(Buffer.from(sent.additionalAuthenticatedData ?? "", "base64").toString("utf8")).toBe(
+      "topos:gateway:workspace-key:ws1",
+    );
+    // int64 on the wire is a decimal STRING, and it is the checksum of the RAW bytes.
+    expect(sent.plaintextCrc32c).toBe(crc32c(key).toString());
+    expect(sent.additionalAuthenticatedDataCrc32c).toBe(
+      crc32c(Buffer.from("topos:gateway:workspace-key:ws1", "utf8")).toString(),
+    );
+  });
+
+  it("refuses an answer that names a different key", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME, answerAsKeyName: `${KEY_NAME}-other` });
+    const { backend } = gcpBackend(fake);
+    await expect(backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"))).rejects.toThrow(
+      /answered for key .*-other/,
+    );
+  });
+});
+
+describe("retry classification", () => {
+  it("retries a 503 and then succeeds", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    fake.failures.push({ status: 503, body: { error: { message: "backend down", status: "UNAVAILABLE" } } });
+    const { backend } = gcpBackend(fake);
+    await backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"));
+    expect(fake.calls.length).toBe(2);
+  });
+
+  it("does not retry a permission refusal", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    for (let i = 0; i < 3; i += 1) {
+      fake.failures.push({
+        status: 403,
+        body: { error: { message: "caller lacks cloudkms.cryptoKeyVersions.useToEncrypt", status: "PERMISSION_DENIED" } },
+      });
+    }
+    const { backend } = gcpBackend(fake);
+    await expect(backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"))).rejects.toThrow(
+      /PERMISSION_DENIED/,
+    );
+    expect(fake.calls.length).toBe(1);
+  });
+
+  it("gives up after a bounded number of tries", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    for (let i = 0; i < 5; i += 1) {
+      fake.failures.push({ status: 500, body: { error: { message: "internal", status: "INTERNAL" } } });
+    }
+    const { backend } = gcpBackend(fake);
+    await expect(backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"))).rejects.toThrow(
+      /unavailable/,
+    );
+    expect(fake.calls.length).toBe(3);
+  });
+
+  it("retries an AWS throttle even though it arrives as HTTP 400", async () => {
+    const fake = fakeAwsKms({ keyArn: KEY_ARN, region: "us-east-1" });
+    fake.failures.push({ status: 400, body: { __type: "ThrottlingException", message: "slow down" } });
+    const { backend } = awsBackend(fake);
+    await backend.wrapDataKey(randomBytes(32), workspaceKeyAad("ws1"));
+    expect(fake.calls.length).toBe(2);
+  });
+
+  it("does not retry an AWS ciphertext refusal", async () => {
+    const fake = fakeAwsKms({ keyArn: KEY_ARN, region: "us-east-1" });
+    const { backend } = awsBackend(fake);
+    await expect(
+      backend.unwrapDataKey(
+        Buffer.concat([Buffer.from([0x02, 0x02]), randomBytes(64)]),
+        workspaceKeyAad("ws1"),
+      ),
+    ).rejects.toThrow(/InvalidCiphertextException/);
+    expect(fake.calls.length).toBe(1);
+  });
+});
+
+describe("SigV4", () => {
+  it("derives the signing key of the published example", () => {
+    // AWS's own worked example — the value below was also re-derived independently with openssl.
+    expect(
+      deriveSigningKey(
+        "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        "20150830",
+        "us-east-1",
+        "iam",
+      ).toString("hex"),
+    ).toBe("c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9");
+  });
+
+  it("builds the canonical request and signature the spec describes", () => {
+    const body = '{"KeyId":"k"}';
+    const signed = signKmsRequest({
+      host: "kms.us-east-1.amazonaws.com",
+      target: "TrentService.Encrypt",
+      body,
+      region: "us-east-1",
+      credentials: { accessKeyId: "AKIDEXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY" },
+      nowMs: Date.UTC(2015, 7, 30, 12, 36, 0),
+    });
+    // Written out by hand — headers lowercased and sorted, a blank line after them, the body's
+    // hash last, no trailing newline. The same construction reproduces AWS's published
+    // `get-vanilla` signature when computed with an independent tool.
+    const expectedCanonical = [
+      "POST",
+      "/",
+      "",
+      "content-type:application/x-amz-json-1.1",
+      "host:kms.us-east-1.amazonaws.com",
+      "x-amz-date:20150830T123600Z",
+      "x-amz-target:TrentService.Encrypt",
+      "",
+      "content-type;host;x-amz-date;x-amz-target",
+      createHash("sha256").update(body).digest("hex"),
+    ].join("\n");
+    expect(signed.canonicalRequest).toBe(expectedCanonical);
+    expect(signed.stringToSign).toBe(
+      [
+        "AWS4-HMAC-SHA256",
+        "20150830T123600Z",
+        "20150830/us-east-1/kms/aws4_request",
+        createHash("sha256").update(expectedCanonical).digest("hex"),
+      ].join("\n"),
+    );
+    const expectedSignature = createHmac(
+      "sha256",
+      deriveSigningKey("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20150830", "us-east-1", "kms"),
+    )
+      .update(signed.stringToSign)
+      .digest("hex");
+    expect(signed.headers.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/kms/aws4_request, " +
+        "SignedHeaders=content-type;host;x-amz-date;x-amz-target, " +
+        `Signature=${expectedSignature}`,
+    );
+    // `host` is signed but never sent: fetch forbids the header and sets it from the URL.
+    expect(signed.headers.host).toBeUndefined();
+    expect(signed.headers["x-amz-date"]).toBe("20150830T123600Z");
+  });
+
+  it("signs and sends a session token when one is configured", () => {
+    const signed = signKmsRequest({
+      host: "kms.eu-west-1.amazonaws.com",
+      target: "TrentService.Decrypt",
+      body: "{}",
+      region: "eu-west-1",
+      credentials: { accessKeyId: "A", secretAccessKey: "S", sessionToken: "SESSION" },
+      nowMs: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    expect(signed.canonicalRequest).toContain("x-amz-security-token:SESSION");
+    expect(signed.headers.authorization).toContain(
+      "SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target",
+    );
+    expect(signed.headers["x-amz-security-token"]).toBe("SESSION");
+  });
+});
+
+describe("Google credentials", () => {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  const keyJson = JSON.stringify({
+    type: "service_account",
+    project_id: "topos-test",
+    private_key_id: "kid1",
+    private_key: privateKey,
+    client_email: "gateway@topos-test.iam.gserviceaccount.com",
+    token_uri: "https://oauth2.googleapis.com/token",
+  });
+
+  function tokenEndpoint(): { fetch: typeof fetch; assertions: string[]; minted: number } {
+    const state = { assertions: [] as string[], minted: 0, fetch: null as unknown as typeof fetch };
+    state.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const body = new URLSearchParams(String(init?.body ?? ""));
+      state.assertions.push(body.get("assertion") ?? "");
+      state.minted += 1;
+      expect(body.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:jwt-bearer");
+      return new Response(JSON.stringify({ access_token: `tok-${state.minted}`, expires_in: 3600 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    return state;
+  }
+
+  it("refuses a key file that is not a service account", () => {
+    expect(() => parseServiceAccountKey('{"type":"authorized_user"}', "/k.json")).toThrow(
+      /service_account/,
+    );
+    expect(() => parseServiceAccountKey("not json", "/k.json")).toThrow(/valid JSON/);
+    expect(() => parseServiceAccountKey('{"type":"service_account"}', "/k.json")).toThrow(
+      /client_email/,
+    );
+  });
+
+  it("signs an RFC 7523 assertion the account's own key verifies", async () => {
+    const endpoint = tokenEndpoint();
+    const source = serviceAccountTokens(parseServiceAccountKey(keyJson, "/k.json"), {
+      fetch: endpoint.fetch,
+      now: () => Date.UTC(2026, 5, 1),
+    });
+    expect(await source.token()).toBe("tok-1");
+    const assertion = endpoint.assertions[0] ?? "";
+    const [header, claims, signature] = assertion.split(".");
+    expect(JSON.parse(Buffer.from(header ?? "", "base64url").toString("utf8"))).toEqual({
+      alg: "RS256",
+      typ: "JWT",
+    });
+    const parsedClaims = JSON.parse(Buffer.from(claims ?? "", "base64url").toString("utf8")) as Record<string, unknown>;
+    expect(parsedClaims.iss).toBe("gateway@topos-test.iam.gserviceaccount.com");
+    expect(parsedClaims.aud).toBe("https://oauth2.googleapis.com/token");
+    expect(parsedClaims.scope).toBe("https://www.googleapis.com/auth/cloudkms");
+    expect(Number(parsedClaims.exp) - Number(parsedClaims.iat)).toBe(3600);
+    expect(
+      createVerify("RSA-SHA256")
+        .update(`${header}.${claims}`)
+        .verify(publicKey, Buffer.from(signature ?? "", "base64url")),
+    ).toBe(true);
+  });
+
+  it("mints one token for a burst and re-mints only after expiry", async () => {
+    const endpoint = tokenEndpoint();
+    let now = Date.UTC(2026, 5, 1);
+    const source = serviceAccountTokens(parseServiceAccountKey(keyJson, "/k.json"), {
+      fetch: endpoint.fetch,
+      now: () => now,
+    });
+    const burst = await Promise.all([source.token(), source.token(), source.token()]);
+    expect(burst).toEqual(["tok-1", "tok-1", "tok-1"]);
+    expect(endpoint.minted).toBe(1);
+    // Still inside the token's life minus the refresh margin.
+    now += 3000 * 1000;
+    expect(await source.token()).toBe("tok-1");
+    now += 600 * 1000;
+    expect(await source.token()).toBe("tok-2");
+    expect(endpoint.minted).toBe(2);
+  });
+
+  it("reads the metadata server with the header it requires", async () => {
+    const seen: Record<string, string>[] = [];
+    const source = metadataTokens({
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        expect(String(input)).toBe(
+          "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+        );
+        seen.push((init?.headers ?? {}) as Record<string, string>);
+        return new Response(JSON.stringify({ access_token: "metadata-tok", expires_in: 3599 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch,
+    });
+    expect(await source.token()).toBe("metadata-tok");
+    expect(seen[0]?.["metadata-flavor"]).toBe("Google");
+  });
+
+  it("surfaces a token endpoint refusal instead of a decrypt failure later", async () => {
+    const source = serviceAccountTokens(parseServiceAccountKey(keyJson, "/k.json"), {
+      fetch: (async (): Promise<Response> =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 })) as typeof fetch,
+    });
+    await expect(source.token()).rejects.toThrow(/token endpoint refused \(400\)/);
+  });
+});
+
+describe("the env refuses to boot on an incomplete key backend", () => {
+  const base = {
+    DATABASE_URL: "postgres://topos_gateway@localhost/topos",
+    GATEWAY_PUBLIC_URL: "https://gateway.example.com",
+    TOPOS_PUBLIC_URL: "https://topos.example.com",
+  };
+
+  it("defaults to the file backend and still requires the key file", () => {
+    expect(parseGatewayEnv({ ...base, GATEWAY_MASTER_KEY_FILE: "/k" }).GATEWAY_KEY_BACKEND).toBe(
+      "file",
+    );
+    expect(() => parseGatewayEnv({ ...base })).toThrow(/requires GATEWAY_MASTER_KEY_FILE/);
+  });
+
+  it("refuses a KMS backend with no key named — it never falls back to a file key", () => {
+    expect(() =>
+      parseGatewayEnv({ ...base, GATEWAY_KEY_BACKEND: "gcp-kms", GATEWAY_MASTER_KEY_FILE: "/k" }),
+    ).toThrow(/requires GATEWAY_KMS_KEY/);
+    expect(() =>
+      parseGatewayEnv({ ...base, GATEWAY_KEY_BACKEND: "aws-kms", GATEWAY_MASTER_KEY_FILE: "/k" }),
+    ).toThrow(/requires GATEWAY_KMS_KEY/);
+  });
+
+  it("refuses a key name that is not the provider's resource shape", () => {
+    expect(() =>
+      parseGatewayEnv({ ...base, GATEWAY_KEY_BACKEND: "gcp-kms", GATEWAY_KMS_KEY: "master" }),
+    ).toThrow(/crypto key resource name/);
+    expect(() =>
+      parseGatewayEnv({ ...base, GATEWAY_KEY_BACKEND: "gcp-kms", GATEWAY_KMS_KEY: KEY_ARN }),
+    ).toThrow(/crypto key resource name/);
+    expect(() =>
+      parseGatewayEnv({
+        ...base,
+        GATEWAY_KEY_BACKEND: "aws-kms",
+        GATEWAY_KMS_KEY: "alias/gateway",
+        AWS_ACCESS_KEY_ID: "A",
+        AWS_SECRET_ACCESS_KEY: "S",
+      }),
+    ).toThrow(/key ARN/);
+  });
+
+  it("refuses AWS with no credentials in the environment", () => {
+    expect(() =>
+      parseGatewayEnv({ ...base, GATEWAY_KEY_BACKEND: "aws-kms", GATEWAY_KMS_KEY: KEY_ARN }),
+    ).toThrow(/requires AWS_ACCESS_KEY_ID/);
+    expect(() =>
+      parseGatewayEnv({
+        ...base,
+        GATEWAY_KEY_BACKEND: "aws-kms",
+        GATEWAY_KMS_KEY: KEY_ARN,
+        AWS_ACCESS_KEY_ID: "A",
+      }),
+    ).toThrow(/requires AWS_SECRET_ACCESS_KEY/);
+  });
+
+  it("refuses a hand-pasted access token in production", () => {
+    const env = {
+      ...base,
+      GATEWAY_KEY_BACKEND: "gcp-kms",
+      GATEWAY_KMS_KEY: KEY_NAME,
+      GATEWAY_GCP_ACCESS_TOKEN: "ya29.short-lived",
+    };
+    expect(parseGatewayEnv({ ...env, APP_ENV: "development" }).GATEWAY_GCP_ACCESS_TOKEN).toBe(
+      "ya29.short-lived",
+    );
+    expect(() => parseGatewayEnv({ ...env, APP_ENV: "production" })).toThrow(
+      /GATEWAY_GCP_ACCESS_TOKEN is a short-lived token/,
+    );
+  });
+
+  it("accepts a complete KMS configuration and keeps the file path for the re-wrap", () => {
+    const env = parseGatewayEnv({
+      ...base,
+      GATEWAY_KEY_BACKEND: "gcp-kms",
+      GATEWAY_KMS_KEY: KEY_NAME,
+      GATEWAY_MASTER_KEY_FILE: "/run/topos/gateway-master.key",
+      GOOGLE_APPLICATION_CREDENTIALS: "/run/topos/sa.json",
+    });
+    expect(env.GATEWAY_KEY_BACKEND).toBe("gcp-kms");
+    expect(env.GATEWAY_MASTER_KEY_FILE).toBe("/run/topos/gateway-master.key");
+  });
+});
+
+describe("the boot proof", () => {
+  const base = {
+    DATABASE_URL: "postgres://topos_gateway@localhost/topos",
+    GATEWAY_PUBLIC_URL: "https://gateway.example.com",
+    TOPOS_PUBLIC_URL: "https://topos.example.com",
+  };
+
+  it("builds a gcp-kms backend from the environment and proves it round-trips", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    const env = parseGatewayEnv({
+      ...base,
+      GATEWAY_KEY_BACKEND: "gcp-kms",
+      GATEWAY_KMS_KEY: KEY_NAME,
+      GATEWAY_GCP_ACCESS_TOKEN: "ya29.test",
+    });
+    const lines: { message: string; fields?: Record<string, string | number> }[] = [];
+    const backend = createMasterKeyBackend(env, quiet, { fetch: fake.fetch });
+    await proveMasterKeyBackend(backend, (_level, message, fields) => lines.push({ message, fields }));
+    expect(fake.calls.map((call) => call.target)).toEqual(["encrypt", "decrypt"]);
+    expect(lines[0]?.message).toBe("master key backend ready");
+    expect(lines[0]?.fields?.envelope).toBe("0x02");
+  });
+
+  it("builds a file backend from the environment", async () => {
+    const path = join(dir, "master.key");
+    writeFileSync(path, randomBytes(32), { mode: 0o600 });
+    const env = parseGatewayEnv({ ...base, GATEWAY_MASTER_KEY_FILE: path });
+    const backend = createMasterKeyBackend(env, quiet);
+    expect(backend.formatVersion).toBe(0x01);
+    await proveMasterKeyBackend(backend, quiet);
+  });
+
+  it("fails the boot when the key service refuses", async () => {
+    const fake = fakeGcpKms({ keyName: KEY_NAME });
+    for (let i = 0; i < 3; i += 1) {
+      fake.failures.push({
+        status: 403,
+        body: { error: { message: "denied", status: "PERMISSION_DENIED" } },
+      });
+    }
+    const env = parseGatewayEnv({
+      ...base,
+      GATEWAY_KEY_BACKEND: "gcp-kms",
+      GATEWAY_KMS_KEY: KEY_NAME,
+      GATEWAY_GCP_ACCESS_TOKEN: "ya29.test",
+    });
+    await expect(
+      proveMasterKeyBackend(createMasterKeyBackend(env, quiet, { fetch: fake.fetch }), quiet),
+    ).rejects.toThrow(/PERMISSION_DENIED/);
+  });
+});
+
+describe("the boot check against what is already stored", () => {
+  it("passes trivially when nothing is stored yet", async () => {
+    const seen: string[] = [];
+    await assertStoredWrapsOpen([], { canOpenWorkspaceKey: async () => true }, (_l, m) => {
+      seen.push(m);
+    });
+    expect(seen).toContain("no stored workspace keys to verify");
+  });
+
+  it("refuses to serve when a stored wrap cannot be opened by the configured backend", async () => {
+    // The half-finished migration: the key works (the boot proof passed) but it is not the key
+    // that wrapped these rows, so every credential would fail at an agent's first tool call.
+    const rows = [
+      { workspace_id: "ws_ok", wrapped_key: Buffer.from([1]) },
+      { workspace_id: "ws_stale", wrapped_key: Buffer.from([2]) },
+    ];
+    await expect(
+      assertStoredWrapsOpen(
+        rows,
+        { canOpenWorkspaceKey: async (ws) => ws === "ws_ok" },
+        () => {},
+      ),
+    ).rejects.toThrow(/1 of 2 stored workspace keys cannot be opened/);
+  });
+
+  it("passes when every stored wrap opens", async () => {
+    const rows = [{ workspace_id: "ws_a", wrapped_key: Buffer.from([1]) }];
+    await expect(
+      assertStoredWrapsOpen(rows, { canOpenWorkspaceKey: async () => true }, () => {}),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("the AWS key ARN's partition", () => {
+  it("refuses a partition whose endpoint this client would dial wrongly", () => {
+    // arn:aws-cn keys live at .amazonaws.com.cn; accepting one here would boot against a host
+    // that does not serve it. Refuse rather than dial wrong.
+    expect(() =>
+      awsRegionFromKeyArn("arn:aws-cn:kms:cn-north-1:123456789012:key/abc-def"),
+    ).toThrow();
+  });
+
+  it("accepts a commercial ARN and names its region", () => {
+    expect(awsRegionFromKeyArn("arn:aws:kms:us-west-2:123456789012:key/abc-def")).toBe("us-west-2");
+  });
+});

--- a/gateway/tests/service-lane.test.ts
+++ b/gateway/tests/service-lane.test.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import pg from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { EnvelopeCrypto } from "../service/crypto";
+import { EnvelopeCrypto, FileMasterKey } from "../service/crypto";
 import { createInternalHandler } from "../service/internal";
 import { PgStore } from "../service/store";
 import {
@@ -42,7 +42,7 @@ function lane(
 beforeAll(async () => {
   db = await createServiceDb();
   pool = new pg.Pool({ connectionString: db.gatewayUrl, max: 5 });
-  store = new PgStore(pool, new EnvelopeCrypto(randomBytes(32)), CONFIG.toposPublicUrl, () => {});
+  store = new PgStore(pool, new EnvelopeCrypto(new FileMasterKey(randomBytes(32))), CONFIG.toposPublicUrl, () => {});
   await seedIdentity(db, "ws1", "u1");
   const deps = {
     store,

--- a/gateway/tests/service-oauth.test.ts
+++ b/gateway/tests/service-oauth.test.ts
@@ -4,7 +4,7 @@ import type { AddressInfo } from "node:net";
 import pg from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { GatewayContext, GatewayStore } from "../core/ports";
-import { EnvelopeCrypto } from "../service/crypto";
+import { EnvelopeCrypto, FileMasterKey } from "../service/crypto";
 import { createGuardedFetch } from "../service/guarded-fetch";
 import { beginAuthorize, type OauthStore } from "../service/oauth";
 import { createPublicHandler } from "../service/server";
@@ -154,7 +154,7 @@ function fixtureStore(urlByServerId: Map<string, string>): GatewayStore & OauthS
 beforeAll(async () => {
   db = await createServiceDb();
   pool = new pg.Pool({ connectionString: db.gatewayUrl, max: 5 });
-  realStore = new PgStore(pool, new EnvelopeCrypto(randomBytes(32)), CONFIG.toposPublicUrl, quiet);
+  realStore = new PgStore(pool, new EnvelopeCrypto(new FileMasterKey(randomBytes(32))), CONFIG.toposPublicUrl, quiet);
   await seedIdentity(db, "ws1", "u1");
   base = await startFixture();
 }, 120_000);

--- a/gateway/tests/service-rewrap.test.ts
+++ b/gateway/tests/service-rewrap.test.ts
@@ -1,0 +1,208 @@
+import { randomBytes } from "node:crypto";
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { EnvelopeCrypto, FileMasterKey, type MasterKeyBackend } from "../service/crypto";
+import { KmsMasterKey } from "../service/kms";
+import { GcpKms } from "../service/kms-gcp";
+import { planRewrap, rewrapWorkspaceKeys } from "../service/rewrap";
+import { PgStore } from "../service/store";
+import { createServiceDb, seedConnectedServer, seedIdentity, type ServiceDb } from "./helpers/service-db";
+import { fakeGcpKms } from "./helpers/fake-kms";
+
+/**
+ * The file → KMS migration against a real database. The credential written under the old backend
+ * must still decrypt after the sweep, because the DATA key never changes — only its wrap does.
+ */
+
+const KEY_NAME = "projects/topos-test/locations/us-east1/keyRings/gateway/cryptoKeys/master";
+const TOPOS_PUBLIC_URL = "https://team.example.com";
+const quiet = () => {};
+
+let db: ServiceDb;
+let pool: pg.Pool;
+let fileBackend: MasterKeyBackend;
+let kmsBackend: MasterKeyBackend;
+
+beforeAll(async () => {
+  db = await createServiceDb();
+  pool = new pg.Pool({ connectionString: db.gatewayUrl, max: 5 });
+  fileBackend = new FileMasterKey(randomBytes(32));
+  kmsBackend = new KmsMasterKey(
+    new GcpKms({
+      keyName: KEY_NAME,
+      tokens: { describe: "a test token", token: async () => "test-token" },
+      fetch: fakeGcpKms({ keyName: KEY_NAME }).fetch,
+      sleep: async () => {},
+    }),
+  );
+}, 120_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await db?.drop();
+});
+
+/** One workspace with a stored credential, sealed under whichever backend is given. */
+async function seedCredential(
+  workspaceId: string,
+  backend: MasterKeyBackend,
+  secret: string,
+): Promise<string> {
+  await seedIdentity(db, workspaceId, `u-${workspaceId}`);
+  const server = await seedConnectedServer(db, workspaceId, workspaceId.replaceAll("-", ""));
+  const store = new PgStore(pool, new EnvelopeCrypto(backend), TOPOS_PUBLIC_URL, quiet);
+  await store.storeCredential({
+    workspaceId,
+    serverId: server.serverId,
+    userId: `u-${workspaceId}`,
+    authKind: "manual",
+    payload: { secret },
+    createdByDisplay: "test",
+  });
+  return server.serverId;
+}
+
+async function wrappedKey(workspaceId: string): Promise<Buffer> {
+  const rows = await db.q<{ wrapped_key: Buffer }>(
+    "SELECT wrapped_key FROM gateway.workspace_key WHERE workspace_id = $1",
+    [workspaceId],
+  );
+  const key = rows[0]?.wrapped_key;
+  if (key === undefined) {
+    throw new Error("no workspace key");
+  }
+  return key;
+}
+
+describe("re-wrapping workspace keys from the file backend to a KMS", () => {
+  it("converts every row, and the credentials still open afterwards", async () => {
+    const serverA = await seedCredential("rw-a", fileBackend, "secret-a");
+    const serverB = await seedCredential("rw-b", fileBackend, "secret-b");
+    expect((await wrappedKey("rw-a"))[0]).toBe(0x01);
+
+    const summary = await rewrapWorkspaceKeys(pool, {
+      from: fileBackend,
+      to: kmsBackend,
+      dryRun: false,
+      log: quiet,
+    });
+    expect(summary).toEqual({ scanned: 2, converted: 2, alreadyThere: 0, failed: 0 });
+    expect((await wrappedKey("rw-a"))[0]).toBe(0x02);
+    expect((await wrappedKey("rw-b"))[0]).toBe(0x02);
+
+    // The proof that matters: a store on the NEW backend reads the credential written under the
+    // old one, byte for byte, because only the wrap moved.
+    const after = new PgStore(pool, new EnvelopeCrypto(kmsBackend), TOPOS_PUBLIC_URL, quiet);
+    expect((await after.credentialFor("rw-a", serverA, "u-rw-a"))?.secret).toBe("secret-a");
+    expect((await after.credentialFor("rw-b", serverB, "u-rw-b"))?.secret).toBe("secret-b");
+
+    // And the old backend can no longer open them — the move is real, not additive.
+    const before = new PgStore(pool, new EnvelopeCrypto(fileBackend), TOPOS_PUBLIC_URL, quiet);
+    await expect(before.credentialFor("rw-a", serverA, "u-rw-a")).rejects.toThrow(
+      /written by a KMS key backend/,
+    );
+  });
+
+  it("is idempotent — a second run converts nothing and breaks nothing", async () => {
+    const server = await seedCredential("rw-idem", fileBackend, "secret-idem");
+    const first = await rewrapWorkspaceKeys(pool, {
+      from: fileBackend,
+      to: kmsBackend,
+      dryRun: false,
+      log: quiet,
+    });
+    expect(first.converted).toBeGreaterThanOrEqual(1);
+    const wrappedAfterFirst = await wrappedKey("rw-idem");
+
+    const second = await rewrapWorkspaceKeys(pool, {
+      from: fileBackend,
+      to: kmsBackend,
+      dryRun: false,
+      log: quiet,
+    });
+    expect(second.converted).toBe(0);
+    expect(second.failed).toBe(0);
+    expect(second.alreadyThere).toBe(second.scanned);
+    // Untouched, not merely re-converted to something equivalent.
+    expect(await wrappedKey("rw-idem")).toEqual(wrappedAfterFirst);
+    const after = new PgStore(pool, new EnvelopeCrypto(kmsBackend), TOPOS_PUBLIC_URL, quiet);
+    expect((await after.credentialFor("rw-idem", server, "u-rw-idem"))?.secret).toBe("secret-idem");
+  });
+
+  it("a dry run proves the whole path and writes nothing", async () => {
+    const server = await seedCredential("rw-dry", fileBackend, "secret-dry");
+    const before = await wrappedKey("rw-dry");
+    const summary = await rewrapWorkspaceKeys(pool, {
+      from: fileBackend,
+      to: kmsBackend,
+      dryRun: true,
+      log: quiet,
+    });
+    expect(summary.converted).toBeGreaterThanOrEqual(1);
+    expect(summary.failed).toBe(0);
+    expect(await wrappedKey("rw-dry")).toEqual(before);
+    // Still readable by the backend that is actually configured.
+    const store = new PgStore(pool, new EnvelopeCrypto(fileBackend), TOPOS_PUBLIC_URL, quiet);
+    expect((await store.credentialFor("rw-dry", server, "u-rw-dry"))?.secret).toBe("secret-dry");
+  });
+
+  it("leaves a row neither backend can open untouched, and reports it", async () => {
+    await seedIdentity(db, "rw-alien", "u-rw-alien");
+    // A key wrapped under a THIRD master key — a restored-from-elsewhere row, or a lost key file.
+    const alien = await new FileMasterKey(randomBytes(32)).wrapDataKey(
+      randomBytes(32),
+      "topos:gateway:workspace-key:rw-alien",
+    );
+    await db.q("INSERT INTO gateway.workspace_key (workspace_id, wrapped_key) VALUES ($1, $2)", [
+      "rw-alien",
+      alien,
+    ]);
+    const lines: string[] = [];
+    const summary = await rewrapWorkspaceKeys(pool, {
+      from: fileBackend,
+      to: kmsBackend,
+      dryRun: false,
+      log: (_level, message) => lines.push(message),
+    });
+    expect(summary.failed).toBe(1);
+    expect(lines).toContain("workspace key opens under neither backend; left untouched");
+    expect(await wrappedKey("rw-alien")).toEqual(alien);
+    // The row has made its point; the next case asserts an exact, clean summary.
+    await db.q("DELETE FROM gateway.workspace_key WHERE workspace_id = $1", ["rw-alien"]);
+  });
+
+  it("moves back to the file backend the same way", async () => {
+    const server = await seedCredential("rw-back", kmsBackend, "secret-back");
+    expect((await wrappedKey("rw-back"))[0]).toBe(0x02);
+    const summary = await rewrapWorkspaceKeys(pool, {
+      from: kmsBackend,
+      to: fileBackend,
+      dryRun: false,
+      log: quiet,
+    });
+    expect(summary.failed).toBe(0);
+    expect((await wrappedKey("rw-back"))[0]).toBe(0x01);
+    const store = new PgStore(pool, new EnvelopeCrypto(fileBackend), TOPOS_PUBLIC_URL, quiet);
+    expect((await store.credentialFor("rw-back", server, "u-rw-back"))?.secret).toBe("secret-back");
+  });
+});
+
+describe("what a re-wrap run was asked to do", () => {
+  it("reads --from and --dry-run", () => {
+    expect(planRewrap(["--from", "file"], "gcp-kms")).toEqual({ from: "file", dryRun: false });
+    expect(planRewrap(["--from", "file", "--dry-run"], "gcp-kms")).toEqual({
+      from: "file",
+      dryRun: true,
+    });
+    expect(planRewrap(["--dry-run", "--from", "gcp-kms"], "file").from).toBe("gcp-kms");
+  });
+
+  it("refuses a run with nothing to move or nothing named", () => {
+    expect(() => planRewrap([], "gcp-kms")).toThrow(/--from is required/);
+    expect(() => planRewrap(["--from", "azure"], "gcp-kms")).toThrow(/--from must be one of/);
+    expect(() => planRewrap(["--from", "file", "--force"], "gcp-kms")).toThrow(
+      /unrecognized argument: --force/,
+    );
+    expect(() => planRewrap(["--from", "file"], "file")).toThrow(/nothing to move/);
+  });
+});

--- a/gateway/tests/service-store.test.ts
+++ b/gateway/tests/service-store.test.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import pg from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { EnvelopeCrypto } from "../service/crypto";
+import { EnvelopeCrypto, FileMasterKey } from "../service/crypto";
 import { PgStore, secretHeaderFromDocument } from "../service/store";
 import { BufferedUsageSink } from "../service/usage";
 import {
@@ -23,7 +23,7 @@ let store: PgStore;
 beforeAll(async () => {
   db = await createServiceDb();
   pool = new pg.Pool({ connectionString: db.gatewayUrl, max: 5 });
-  store = new PgStore(pool, new EnvelopeCrypto(randomBytes(32)), TOPOS_PUBLIC_URL, () => {});
+  store = new PgStore(pool, new EnvelopeCrypto(new FileMasterKey(randomBytes(32))), TOPOS_PUBLIC_URL, () => {});
   await seedIdentity(db, "ws1", "u1");
   await seedIdentity(db, "ws1", "u2");
 }, 120_000);
@@ -235,6 +235,23 @@ describe("credential custody", () => {
     expect(await store.credentialFor("ws1", seeded.serverId, "u1")).toBeNull();
   });
 
+  it("revocation lands immediately even with the workspace's data key already cached", async () => {
+    const seeded = await seedConnectedServer(db, "ws1", "revcache");
+    const id = await store.storeCredential({
+      workspaceId: "ws1",
+      serverId: seeded.serverId,
+      userId: "u1",
+      authKind: "manual",
+      payload: { secret: "live" },
+      createdByDisplay: "u1",
+    });
+    // This read warms the data-key cache for ws1 — the row is then deleted out from under it.
+    expect((await store.credentialFor("ws1", seeded.serverId, "u1"))?.secret).toBe("live");
+    expect(await store.deleteCredential(id)).toBe(true);
+    // No key was consulted: the row is simply gone, which is what makes revocation a row change.
+    expect(await store.credentialFor("ws1", seeded.serverId, "u1")).toBeNull();
+  });
+
   it("saveRotatedCredential re-encrypts and stamps last_refreshed_at", async () => {
     const seeded = await seedConnectedServer(db, "ws1", "rot");
     const id = await store.storeCredential({
@@ -361,7 +378,7 @@ describe("recordObservedTools", () => {
     // by dropping to a poisoned pool) must resolve, not reject.
     const closed = new pg.Pool({ connectionString: db.gatewayUrl, max: 1 });
     await closed.end();
-    const poisoned = new PgStore(closed, new EnvelopeCrypto(randomBytes(32)), TOPOS_PUBLIC_URL, () => {});
+    const poisoned = new PgStore(closed, new EnvelopeCrypto(new FileMasterKey(randomBytes(32))), TOPOS_PUBLIC_URL, () => {});
     await expect(
       poisoned.recordObservedTools("ws1", "msrv_x", [{ name: "t" }]),
     ).resolves.toBeUndefined();

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -10,5 +10,5 @@
     "skipLibCheck": true,
     "types": []
   },
-  "include": ["core/**/*.ts", "service/**/*.ts", "tests/**/*.ts"]
+  "include": ["core/**/*.ts", "service/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Makes the gateway's master key a **backend seam** rather than a file, so a deployment holding other people's credentials can keep its key in a real key service.

### What changes

- `MasterKeyBackend` with two implementations. `FileMasterKey` is today's behavior, **byte-identical** — a frozen fixture generated from the previous code proves existing wraps still open. `KmsMasterKey` performs wrap/unwrap as calls to **Google Cloud KMS** or **AWS KMS**, so the master key never enters this process.
- These are **thin vendor clients** over the documented REST APIs. Nothing here implements key management or invents crypto; the reviewed AES-GCM envelope and its AAD row-binding are unchanged.
- Wrapped keys gain envelope version `0x02` + a provider tag, so a row's bytes say which backend wrote it; a mismatch is refused by name rather than shipped to the wrong cloud.
- A **data-key cache** (absolute TTL, bounded, keyed by workspace *and* a hash of the wrapped bytes) keeps a KMS round trip off every proxied tool call. A re-wrapped row cannot be served a stale key. Revocation is unaffected — it deletes a row, read before any key is used.
- **Boot fails closed twice**: the backend must wrap/unwrap a probe before anything binds, *and* every wrap already in the database must open under it. Without the second check, a deployment switched to a KMS without its re-wrap would authenticate and then fail every credential at an agent's first tool call.
- A **re-wrap script** for migrating an existing deployment: locked per row, verified by re-opening what it wrote, idempotent, interruptible, dry-run.

Default is unchanged: a self-hoster still gets a file key minted on first boot.

### Verified against real Cloud KMS

An HSM-protected key was created and the whole path exercised end to end through this code: Google accepted the RFC 7523 assertion, IAM allowed both operations, the wire format agreed, and **the AAD binding holds against the real cloud** — a different workspace id cannot open the envelope.

### Review

One codex pass. Both P1s fixed here: all new files are included (they were untracked, so absent from the reviewed diff), and the boot check now validates stored wraps, not just a fresh probe. The P2 is fixed by refusing non-commercial AWS partitions rather than dialing an endpoint we would build wrongly. A dedicated security review is running; anything it finds lands before merge.

### Honesty

The README states what each backend does and does not protect against — notably that a KMS does **not** defend against code executing inside this process, and that a stolen service-account key plus the database is back to decrypting rows. It narrows "forever, offline, silently" to "while this credential is valid, online, and logged".

Tests: 226 (was 164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)