### PR TITLE
A connected server lists its tools at once, and narrowing cannot silently disable them all

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -37,10 +37,23 @@ call. Revocation is a row change, effective next call.
   method → the engine), `/oauth/callback`, `/healthz`. Everything else is a uniform 404.
 - **Internal** (`GATEWAY_INTERNAL_BIND`, default `127.0.0.1:8789`): the web app's lane —
   `POST /internal/v1/authorize/begin`, `POST /internal/v1/credentials/manual`,
-  `DELETE /internal/v1/credentials/{id}`. A SEPARATE socket, so the lane is unreachable from
-  the public bind by construction; compose publishes only the public one. Gate: with no
-  `GATEWAY_INTERNAL_TOKEN` the whole lane answers 404; a wrong bearer answers 401; only the
-  token's sha256 survives boot and the compare is constant-time.
+  `DELETE /internal/v1/credentials/{id}`, `POST /internal/v1/tools/refresh`. A SEPARATE socket, so
+  the lane is unreachable from the public bind by construction; compose publishes only the public
+  one. Gate: with no `GATEWAY_INTERNAL_TOKEN` the whole lane answers 404; a wrong bearer answers
+  401; only the token's sha256 survives boot and the compare is constant-time.
+
+## The tool probe
+
+A tool policy is a checklist over what a server offers, so the list has to exist before anyone can
+narrow it. `core/probe.ts` walks `tools/list` (following cursors, recorded whole or not at all)
+through the SAME client the live path uses — era detection, credential attach, refresh-once retry,
+guarded fetch — and writes the UNFILTERED result to `gateway.observed_tool`. It runs right after a
+credential is stored, on both paths (`credentials/manual` and the OAuth callback), and again
+whenever the web calls `tools/refresh`. `service/tool-probe.ts` bounds it (8s: an abort signal on
+every fetch plus a race, because a 2024-11-05 request waits on its SSE pump rather than a socket)
+and hands it a usage sink that DROPS — a probe is the product's bookkeeping, not an agent's call, so
+it leaves no usage row and invents no session. A probe that fails leaves the list untouched and
+never fails the connect.
 
 ## Custody
 

--- a/gateway/core/filter.ts
+++ b/gateway/core/filter.ts
@@ -12,6 +12,21 @@ export function isToolAllowed(policy: ToolPolicy, name: string): boolean {
   return policy.mode === "all" || policy.selected.has(name);
 }
 
+/** The named tool entries of a tools/list result. Non-array or nameless entries fail closed out. */
+export function toolEntries(result: Record<string, unknown>): Record<string, unknown>[] {
+  const raw = Array.isArray(result["tools"]) ? (result["tools"] as unknown[]) : [];
+  return raw.filter((t): t is Record<string, unknown> => typeof t === "object" && t !== null && typeof (t as Record<string, unknown>)["name"] === "string");
+}
+
+/** What gets written down about those entries — the name and the sentence, nothing else. ONE
+ *  reader, so the live path and the connect-time probe can never observe different things. */
+export function observedToolsOf(tools: readonly Record<string, unknown>[]): ObservedTool[] {
+  return tools.map((t) => ({
+    name: t["name"] as string,
+    ...(typeof t["description"] === "string" ? { description: t["description"] as string } : {}),
+  }));
+}
+
 /**
  * Filter one tools/list result page in place-shape (a rebuilt object, source untouched) and
  * record what the upstream actually advertised. Non-array `tools` fails closed to an empty list.
@@ -23,13 +38,8 @@ export async function filterToolsListResult(
   policy: ToolPolicy,
   result: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const raw = Array.isArray(result["tools"]) ? (result["tools"] as unknown[]) : [];
-  const tools = raw.filter((t): t is Record<string, unknown> => typeof t === "object" && t !== null && typeof (t as Record<string, unknown>)["name"] === "string");
-
-  const observed: ObservedTool[] = tools.map((t) => ({
-    name: t["name"] as string,
-    ...(typeof t["description"] === "string" ? { description: t["description"] as string } : {}),
-  }));
+  const tools = toolEntries(result);
+  const observed: ObservedTool[] = observedToolsOf(tools);
   try {
     // Fire-and-forget semantics: an observation write must never fail the live call.
     await ctx.store.recordObservedTools(workspaceId, serverId, observed);

--- a/gateway/core/probe.ts
+++ b/gateway/core/probe.ts
@@ -1,0 +1,162 @@
+/**
+ * The TOOL PROBE — one `tools/list` walk toward an upstream server, run because a credential was
+ * just connected (or because somebody asked to see the list again), never because an agent called.
+ *
+ * Why it exists: a tool policy is a checklist over what the server offers, and nobody can narrow a
+ * list they cannot see. Before this, the list only filled in after the first real call through the
+ * gateway, so the panel's honest "nothing observed yet" doubled as a trap — narrowing to a checklist
+ * of zero disables every tool. The probe makes the list a fact of CONNECTING.
+ *
+ * It is the same client the live path uses: `ensureUpstream` + `sendUpstreamRequest`, so era
+ * detection, the credential attach, the refresh-once retry and the guarded fetch all behave exactly
+ * as they would for an agent. Two things a probe does differently, both deliberate:
+ *
+ *  - it records NO usage row. A usage row says a person's machine called this server; a probe is
+ *    the product's own bookkeeping. The host hands the probe a context whose sink drops, so this is
+ *    structural rather than a rule somebody has to remember.
+ *  - it TEARS ITS CONVERSATION DOWN. The probe stands in module memory under a synthetic session
+ *    id, and on the 2024-11-05 transport an upstream session owns a live SSE pump; leaving either
+ *    behind would be a leak nothing ever collects. The era VERDICT it learned is kept — that is
+ *    shared, re-probeable knowledge about the server, and the next real call is faster for it.
+ *
+ * Pagination is followed and the list is recorded WHOLE OR NOT AT ALL: a page that fails records
+ * nothing, because a half list written through `recordObservedTools` would mark the tools it never
+ * reached as no longer offered.
+ */
+
+import { observedToolsOf, toolEntries } from "./filter";
+import type { GatewayContext, ObservedTool, SessionRef } from "./ports";
+import { isResponse, nextGatewayId, type JsonRpcRequest } from "./protocol";
+import {
+  deleteUpstreamSession,
+  GATEWAY_IDENTITY,
+  responseFromSse,
+  sendUpstreamRequest,
+  type UpstreamCall,
+  type UpstreamReply,
+} from "./upstream";
+
+/** Which workspace's connection to probe, and whose sign-in to probe it with. */
+export interface ProbeTarget {
+  workspaceId: string;
+  serverId: string;
+  /** The person whose credential to prefer; null asks with the workspace's own sign-in. */
+  userId: string | null;
+}
+
+export type ProbeOutcome =
+  /** The list was read and written; `tools` is how many the server offers. */
+  | { kind: "recorded"; tools: number }
+  /** The server asks for a sign-in and this workspace has none it could have used. */
+  | { kind: "no_credential" }
+  /** The server did not answer, refused, or answered something that is not a tool list. */
+  | { kind: "unreachable" }
+  /** This workspace has no live connection to that server. */
+  | { kind: "not_connected" };
+
+/** Pages a probe walks before it stops asking — a cursor loop needs a floor under it. */
+const MAX_PAGES = 20;
+
+/**
+ * The probe's stand-in caller. It is NOT a session anybody signed in with: the id exists so the
+ * upstream machinery can key its module memory, and it never reaches a usage row (the sink drops)
+ * or an upstream request (only the credential does). Stable per (workspace, server) so repeat
+ * probes reuse one key instead of growing the map a synthetic id at a time.
+ */
+function probeSession(target: ProbeTarget): SessionRef {
+  return {
+    sessionId: `probe:${target.workspaceId}:${target.serverId}`,
+    workspaceId: target.workspaceId,
+    // The store resolves a person's own credential first and the workspace's second; the empty
+    // string belongs to nobody, so a workspace-scoped probe asks with the workspace sign-in.
+    userId: target.userId ?? "",
+    displayName: "tool probe",
+  };
+}
+
+/** Read one upstream reply envelope down to its result, whatever transport carried it. */
+async function resultOf(
+  call: UpstreamCall,
+  reply: UpstreamReply,
+  id: string | number,
+): Promise<Record<string, unknown> | null> {
+  if (reply.kind === "json") {
+    return isResponse(reply.message) && "result" in reply.message ? reply.message.result : null;
+  }
+  if (reply.kind === "sse") {
+    const message = await responseFromSse(reply.body, id, call.ctx.env.now);
+    return message !== null && isResponse(message) && "result" in message ? message.result : null;
+  }
+  return null;
+}
+
+/** Every tool the server advertises, across pages; null when any page failed to answer. */
+async function listAllTools(call: UpstreamCall): Promise<ObservedTool[] | null> {
+  const tools: ObservedTool[] = [];
+  const seen = new Set<string>();
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const id = nextGatewayId();
+    const msg: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      id,
+      method: "tools/list",
+      params: cursor === null ? {} : { cursor },
+    };
+    const result = await resultOf(call, await sendUpstreamRequest(call, msg, { identity: GATEWAY_IDENTITY }), id);
+    if (result === null) return null;
+    for (const tool of observedToolsOf(toolEntries(result))) {
+      // A name repeated across pages must not reach the upsert twice — one INSERT touching a row
+      // twice is an error, and the whole write would be lost with it.
+      if (seen.has(tool.name)) continue;
+      seen.add(tool.name);
+      tools.push(tool);
+    }
+    const next = result["nextCursor"];
+    if (typeof next !== "string" || next === "") return tools;
+    cursor = next;
+  }
+  return tools;
+}
+
+/**
+ * Probe one connected server and record what it offers. Never throws: every outcome is a value the
+ * caller can log or render, because the act this follows (a sign-in landing) must not fail on it.
+ */
+export async function probeServerTools(
+  ctx: GatewayContext,
+  target: ProbeTarget,
+): Promise<ProbeOutcome> {
+  const server = await ctx.store.connectedServer(target.workspaceId, target.serverId);
+  if (server === null) {
+    return { kind: "not_connected" };
+  }
+  const session = probeSession(target);
+  const credential = await ctx.store.credentialFor(
+    target.workspaceId,
+    target.serverId,
+    session.userId,
+  );
+  if (credential === null && server.authMode !== "none") {
+    return { kind: "no_credential" };
+  }
+  const call: UpstreamCall = {
+    ctx,
+    session,
+    server,
+    auth: { credential, secret: credential?.secret ?? null, refreshed: false },
+  };
+  try {
+    const tools = await listAllTools(call);
+    if (tools === null) {
+      return { kind: "unreachable" };
+    }
+    await ctx.store.recordObservedTools(target.workspaceId, target.serverId, tools);
+    return { kind: "recorded", tools: tools.length };
+  } catch {
+    return { kind: "unreachable" };
+  } finally {
+    // The probe's own conversation goes with the probe — see the module note.
+    await deleteUpstreamSession(call).catch(() => {});
+  }
+}

--- a/gateway/service/internal.ts
+++ b/gateway/service/internal.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
+import type { GatewayStore } from "../core/ports";
 import { digestsEqual, sha256Hex } from "./crypto";
 import type { Logger } from "./log";
 import { beginAuthorize, type OauthConfig, type OauthStore } from "./oauth";
+import { probeToolsForServer } from "./tool-probe";
 
 /**
  * The web→gateway internal lane — the plane lane's twin. Served on its OWN listener (never the
@@ -9,8 +11,13 @@ import { beginAuthorize, type OauthConfig, type OauthStore } from "./oauth";
  * whole lane answers a uniform 404 (invisible); wrong or missing bearer ⇒ an honest 401. Only
  * the token's sha256 survives boot, and the compare is constant-time over digests.
  *
- * Three routes, exactly: authorize/begin, credentials/manual (the ONE route a secret rides —
- * never logged), DELETE credentials/{id}. Everything else on the lane is the uniform 404.
+ * Four routes, exactly: authorize/begin, credentials/manual (the ONE route a secret rides —
+ * never logged), DELETE credentials/{id}, tools/refresh. Everything else on the lane is the
+ * uniform 404.
+ *
+ * A stored secret is followed by a TOOL PROBE (tool-probe.ts): the tool list is what a policy is
+ * written against, so it must exist the moment a sign-in does. The probe is bounded and its outcome
+ * never changes this route's answer — the credential landed either way.
  */
 
 const SMALL_BODY_LIMIT = 64 * 1024;
@@ -48,6 +55,12 @@ const manualSchema = z.object({
   createdByDisplay: z.string().min(1),
 });
 
+const refreshSchema = z.object({
+  workspaceId: z.string().min(1),
+  serverId: z.string().min(1),
+  userId: z.string().min(1).nullable(),
+});
+
 async function parseBody<T>(request: Request, schema: z.ZodType<T>): Promise<T | null> {
   try {
     const text = await request.text();
@@ -60,8 +73,11 @@ async function parseBody<T>(request: Request, schema: z.ZodType<T>): Promise<T |
   }
 }
 
-/** The lane's store surface — OauthStore plus the one delete the lane serves. */
-export interface LaneStore extends OauthStore {
+/**
+ * The lane's store surface — OauthStore plus the one delete the lane serves, over the engine's own
+ * GatewayStore, which the probe speaks through. One object satisfies all three (PgStore does).
+ */
+export interface LaneStore extends OauthStore, GatewayStore {
   deleteCredential(credentialId: string): Promise<boolean>;
 }
 
@@ -149,7 +165,41 @@ export function createInternalHandler(deps: InternalLaneDeps): (request: Request
       deps.log("info", "manual credential stored", {
         route: "POST /internal/v1/credentials/manual",
       });
+      // The list this secret unlocks, read now rather than at some agent's first call. Bounded and
+      // non-fatal: whatever it answers, the credential above is stored.
+      await probeToolsForServer(deps, {
+        workspaceId: body.workspaceId,
+        serverId: body.serverId,
+        userId: body.userId,
+      });
       return Response.json({ credentialId });
+    }
+
+    if (
+      request.method === "POST" &&
+      segments.length === 4 &&
+      segments[0] === "internal" &&
+      segments[1] === "v1" &&
+      segments[2] === "tools" &&
+      segments[3] === "refresh"
+    ) {
+      // ASK AGAIN. A server's tools change over time, and the list a policy is written against is
+      // only ever as fresh as the last time somebody looked. The outcome is the answer — the caller
+      // renders it — and an unconnected server is the same uniform 404 every other route gives.
+      const body = await parseBody(request, refreshSchema);
+      if (body === null) {
+        return Response.json({ code: "BAD_REQUEST" }, { status: 400 });
+      }
+      const outcome = await probeToolsForServer(deps, body);
+      if (outcome.kind === "not_connected") {
+        return notFound();
+      }
+      deps.log("info", "tools refreshed", { route: "POST /internal/v1/tools/refresh" });
+      return Response.json(
+        outcome.kind === "recorded"
+          ? { outcome: outcome.kind, tools: outcome.tools }
+          : { outcome: outcome.kind },
+      );
     }
 
     if (

--- a/gateway/service/oauth.ts
+++ b/gateway/service/oauth.ts
@@ -360,7 +360,16 @@ export async function beginAuthorize(
 }
 
 export type CallbackOutcome =
-  | { ok: true; returnTo: string }
+  | {
+      ok: true;
+      returnTo: string;
+      /**
+       * The connection a credential just landed on, or null when the walk ended without one. The
+       * caller uses it to probe the server's tools before the person is sent back to the page that
+       * renders them; this module does no probing of its own — its business is the ceremony.
+       */
+      stored: { workspaceId: string; serverId: string; userId: string | null } | null;
+    }
   | { ok: false; status: 400 };
 
 /**
@@ -389,7 +398,7 @@ export async function completeCallback(
   const code = params.get("code");
   if (code === null || code === "" || params.get("error") !== null) {
     // The AS refused (or answered without a code). The ceremony is over; the page tells the truth.
-    return { ok: true, returnTo: flow.returnTo };
+    return { ok: true, returnTo: flow.returnTo, stored: null };
   }
   const body = new URLSearchParams({
     grant_type: "authorization_code",
@@ -421,7 +430,7 @@ export async function completeCallback(
     (typeof tokenType === "string" && tokenType.toLowerCase() !== "bearer")
   ) {
     deps.log("warn", "token exchange failed", { serverId: flow.serverId });
-    return { ok: true, returnTo: flow.returnTo };
+    return { ok: true, returnTo: flow.returnTo, stored: null };
   }
   const payload: CredentialPayload = {
     secret: accessToken,
@@ -439,5 +448,9 @@ export async function completeCallback(
     payload,
     createdByDisplay: flow.userId ?? "workspace",
   });
-  return { ok: true, returnTo: flow.returnTo };
+  return {
+    ok: true,
+    returnTo: flow.returnTo,
+    stored: { workspaceId: flow.workspaceId, serverId: flow.serverId, userId: flow.userId },
+  };
 }

--- a/gateway/service/server.ts
+++ b/gateway/service/server.ts
@@ -1,12 +1,18 @@
 import type { GatewayContext, GatewayRequest } from "../core/ports";
 import type { Logger } from "./log";
 import { completeCallback, type OauthConfig, type OauthStore } from "./oauth";
+import { probeToolsForServer } from "./tool-probe";
 
 /**
  * The PUBLIC listener's routes: `/{sessionId}/{serverId}` (every method — the engine answers),
  * `/oauth/callback`, `/healthz`. Anything else is the uniform 404 — no path echo, no existence
  * signal. The internal lane is NOT here: it lives on its own listener (internal.ts), so no
  * public request can reach it whatever this router does.
+ *
+ * A callback that STORED a credential probes that server's tools before redirecting, the internal
+ * lane's manual route's twin: the person is on their way to the page whose Tools section the list
+ * fills, so the list should be there when they arrive. Bounded and non-fatal — a probe that fails
+ * costs the redirect nothing.
  */
 
 export type EngineHandler = (ctx: GatewayContext, req: GatewayRequest) => Promise<Response>;
@@ -56,6 +62,12 @@ export function createPublicHandler(deps: PublicDeps): (request: Request) => Pro
       });
       if (!outcome.ok) {
         return new Response("This sign-in link is no longer valid.", { status: 400 });
+      }
+      if (outcome.stored !== null) {
+        await probeToolsForServer(
+          { store: deps.context.store, guardedFetch: deps.guardedFetch, log: deps.log },
+          outcome.stored,
+        );
       }
       return new Response(null, { status: 302, headers: { location: outcome.returnTo } });
     }

--- a/gateway/service/tool-probe.ts
+++ b/gateway/service/tool-probe.ts
@@ -1,0 +1,84 @@
+import type { GatewayContext, GatewayStore } from "../core/ports";
+import { probeServerTools, type ProbeOutcome, type ProbeTarget } from "../core/probe";
+import type { Logger } from "./log";
+
+/**
+ * THE HOST'S SIDE OF THE TOOL PROBE — the deadline, the dropping usage sink, and the one log line.
+ *
+ * The engine owns no clock beyond `now()` and schedules no timer of its own, so the bound on a
+ * probe is the host's to impose. Two halves, both needed:
+ *
+ *  - an ABORT SIGNAL merged into every fetch the probe makes, which is what actually stops the work;
+ *  - a RACE against the same deadline, because one upstream path (a 2024-11-05 request waiting on
+ *    its SSE pump) resolves only when an answer arrives, so aborting the socket alone would leave
+ *    the caller waiting forever.
+ *
+ * Nothing here can fail the act it follows. A probe that times out, refuses, or throws answers
+ * `unreachable`, the tool list stays exactly as it was, and the sign-in that just landed is still
+ * connected. A raced-out probe may still finish in the background and write the truth it found a
+ * moment late; that is the only trace it leaves.
+ */
+
+/** How long a connect waits on the probe before giving up and leaving the list as it was. */
+export const PROBE_DEADLINE_MS = 8_000;
+
+export interface ToolProbeDeps {
+  store: GatewayStore;
+  guardedFetch: typeof fetch;
+  log: Logger;
+}
+
+/** Every probe fetch carries the deadline, on top of whatever signal the caller already passed. */
+function deadlineFetch(inner: typeof fetch, deadline: AbortSignal): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    inner(input, {
+      ...init,
+      signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+    })) as typeof fetch;
+}
+
+/**
+ * Probe one server's tools, bounded. A probe is not an agent's call, so the context it runs under
+ * carries a sink that DROPS — there is no session to attribute a usage row to and none is invented.
+ */
+export async function probeToolsForServer(
+  deps: ToolProbeDeps,
+  target: ProbeTarget,
+): Promise<ProbeOutcome> {
+  const abort = new AbortController();
+  const ctx: GatewayContext = {
+    store: deps.store,
+    usage: { record: () => {} },
+    env: {
+      fetch: deadlineFetch(deps.guardedFetch, abort.signal),
+      now: () => Date.now(),
+      log: deps.log,
+    },
+  };
+  let expire: (outcome: ProbeOutcome) => void = () => {};
+  const expired = new Promise<ProbeOutcome>((resolve) => {
+    expire = resolve;
+  });
+  const timer = setTimeout(() => {
+    abort.abort();
+    expire({ kind: "unreachable" });
+  }, PROBE_DEADLINE_MS);
+  try {
+    const outcome = await Promise.race([probeServerTools(ctx, target), expired]);
+    deps.log("info", "tool probe finished", {
+      serverId: target.serverId,
+      outcome: outcome.kind,
+      ...(outcome.kind === "recorded" ? { tools: outcome.tools } : {}),
+    });
+    return outcome;
+  } catch (error) {
+    deps.log("warn", "tool probe failed", {
+      serverId: target.serverId,
+      error: error instanceof Error ? error.name : "unknown",
+    });
+    return { kind: "unreachable" };
+  } finally {
+    clearTimeout(timer);
+    abort.abort();
+  }
+}

--- a/gateway/tests/core-probe.test.ts
+++ b/gateway/tests/core-probe.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { probeServerTools } from "../core/probe";
+import { memory, resetEngineMemoryForTests } from "../core/state";
+import {
+  fake2411,
+  FakeStore,
+  FakeUsage,
+  legacyFake,
+  makeCtx,
+  modernFake,
+  oauthCredential,
+  resolvedServer,
+  SERVER_ID,
+  UPSTREAM_URL,
+  USER,
+  WS,
+  type FetchHandler,
+  type TestCtx,
+} from "./core-helpers";
+
+/**
+ * THE TOOL PROBE — the list has to exist before a policy can narrow it, so connecting a sign-in
+ * reads it rather than waiting for some agent's first call.
+ *
+ * What this suite holds still:
+ *  - the probe records the UNFILTERED list, whatever the standing policy says, because the panel's
+ *    checklist must show what the server offers and not what policy already allows;
+ *  - it writes NO usage row — the sink it is handed here is the real recording one, and it stays
+ *    empty, so "no usage row" is a property of the probe rather than of how a host wires it;
+ *  - a server that refuses, is unreachable, or answers something that is not a tool list leaves the
+ *    observed list untouched and answers a value, never a throw;
+ *  - the credential is attached exactly as a live call attaches it;
+ *  - the conversation it opened goes with it: no upstream session is left standing under the
+ *    synthetic probe id, and a 2024-11-05 SSE pump is not left running.
+ */
+
+const PROBE_SESSION = `probe:${WS}:${SERVER_ID}`;
+
+let t: TestCtx;
+let store: FakeStore;
+let usage: FakeUsage;
+
+function boot(routes: Record<string, FetchHandler>): void {
+  store = new FakeStore();
+  usage = new FakeUsage();
+  t = makeCtx(store, usage, routes);
+}
+
+beforeEach(() => {
+  resetEngineMemoryForTests();
+});
+afterEach(() => resetEngineMemoryForTests());
+
+describe("what a probe records", () => {
+  it("records the full list a legacy server offers, and no usage row", async () => {
+    const upstream = legacyFake("2025-06-18", { secret: "up-secret-1" });
+    boot({ [UPSTREAM_URL]: upstream.handler });
+    store.setServer(WS, resolvedServer());
+    store.setCredential(WS, SERVER_ID, USER, oauthCredential());
+
+    const outcome = await probeServerTools(t.ctx, {
+      workspaceId: WS,
+      serverId: SERVER_ID,
+      userId: USER,
+    });
+
+    expect(outcome).toEqual({ kind: "recorded", tools: 3 });
+    expect(store.observed).toHaveLength(1);
+    expect(store.observed[0]?.tools.map((tool) => tool.name)).toEqual([
+      "issue_create",
+      "issue_delete",
+      "issue_list",
+    ]);
+    expect(store.observed[0]?.tools[0]?.description).toBe("Create an issue");
+    // The whole point of the sink being real here: a probe is not an agent's call.
+    expect(usage.events).toEqual([]);
+  });
+
+  it("records the UNFILTERED list even where policy already narrows the server to one tool", async () => {
+    const upstream = legacyFake("2025-11-25");
+    boot({ [UPSTREAM_URL]: upstream.handler });
+    store.setServer(WS, resolvedServer({ authMode: "none" }));
+    store.setPolicy(WS, SERVER_ID, { mode: "selected", selected: new Set(["issue_list"]) });
+
+    await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER });
+
+    expect(store.observed[0]?.tools.map((tool) => tool.name)).toEqual([
+      "issue_create",
+      "issue_delete",
+      "issue_list",
+    ]);
+  });
+
+  it("reads a modern server through the same detection the live path uses", async () => {
+    const upstream = modernFake();
+    boot({ [UPSTREAM_URL]: upstream.handler });
+    store.setServer(WS, resolvedServer({ authMode: "none" }));
+
+    expect(
+      await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER }),
+    ).toEqual({ kind: "recorded", tools: 3 });
+    expect(upstream.discoverCount).toBe(1);
+    expect(store.observed[0]?.tools).toHaveLength(3);
+  });
+
+  it("attaches the credential — a server that demands the secret answers the probe", async () => {
+    const upstream = legacyFake("2025-06-18", { secret: "api-key-9", secretHeader: "x-api-key" });
+    boot({ [UPSTREAM_URL]: upstream.handler });
+    store.setServer(WS, resolvedServer({ authMode: "manual", secretHeader: "x-api-key" }));
+    store.setCredential(WS, SERVER_ID, USER, {
+      id: "cred_manual",
+      kind: "manual",
+      secret: "api-key-9",
+    });
+
+    expect(
+      (await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER })).kind,
+    ).toBe("recorded");
+  });
+
+  it("asks with the WORKSPACE sign-in when the connect was a workspace one", async () => {
+    const upstream = legacyFake("2025-06-18", { secret: "workspace-secret" });
+    boot({ [UPSTREAM_URL]: upstream.handler });
+    store.setServer(WS, resolvedServer());
+    store.setCredential(WS, SERVER_ID, null, oauthCredential({ secret: "workspace-secret" }));
+
+    expect(
+      (await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: null })).kind,
+    ).toBe("recorded");
+  });
+});
+
+describe("pages", () => {
+  /** A server that hands the list out in two pages and refuses an unknown cursor. */
+  function pagedUpstream(): FetchHandler {
+    return async (req) => {
+      const body = (await req.json()) as Record<string, unknown>;
+      const id = body["id"];
+      const method = body["method"];
+      if (method === "initialize") {
+        return Response.json({
+          jsonrpc: "2.0",
+          id,
+          result: { protocolVersion: "2025-06-18", capabilities: { tools: {} }, serverInfo: { name: "paged" } },
+        });
+      }
+      if (method !== "tools/list") {
+        return new Response(null, { status: 202 });
+      }
+      const cursor = (body["params"] as Record<string, unknown> | undefined)?.["cursor"];
+      if (cursor === undefined) {
+        return Response.json({
+          jsonrpc: "2.0",
+          id,
+          result: { tools: [{ name: "one" }, { name: "two" }], nextCursor: "page-2" },
+        });
+      }
+      // A name repeated across pages is a real shape; the write must not see it twice.
+      return Response.json({
+        jsonrpc: "2.0",
+        id,
+        result: { tools: [{ name: "two" }, { name: "three" }] },
+      });
+    };
+  }
+
+  it("follows the cursor and writes ONE list, deduped", async () => {
+    boot({ [UPSTREAM_URL]: pagedUpstream() });
+    store.setServer(WS, resolvedServer({ authMode: "none" }));
+
+    expect(
+      await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER }),
+    ).toEqual({ kind: "recorded", tools: 3 });
+    expect(store.observed).toHaveLength(1);
+    expect(store.observed[0]?.tools.map((tool) => tool.name)).toEqual(["one", "two", "three"]);
+  });
+
+  it("records NOTHING when a later page fails — a half list would retire the tools it never read", async () => {
+    let calls = 0;
+    boot({
+      [UPSTREAM_URL]: async (req) => {
+        const body = (await req.json()) as Record<string, unknown>;
+        if (body["method"] === "initialize") {
+          return Response.json({
+            jsonrpc: "2.0",
+            id: body["id"],
+            result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "x" } },
+          });
+        }
+        calls += 1;
+        if (calls === 1) {
+          return Response.json({
+            jsonrpc: "2.0",
+            id: body["id"],
+            result: { tools: [{ name: "one" }], nextCursor: "page-2" },
+          });
+        }
+        return new Response("gone", { status: 500 });
+      },
+    });
+    store.setServer(WS, resolvedServer({ authMode: "none" }));
+
+    expect(
+      await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER }),
+    ).toEqual({ kind: "unreachable" });
+    expect(store.observed).toEqual([]);
+  });
+});
+
+describe("what a probe cannot do", () => {
+  it("leaves the list untouched when the upstream refuses, and never throws", async () => {
+    boot({ [UPSTREAM_URL]: () => new Response("no", { status: 500 }) });
+    store.setServer(WS, resolvedServer({ authMode: "none" }));
+
+    expect(
+      await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER }),
+    ).toEqual({ kind: "unreachable" });
+    expect(store.observed).toEqual([]);
+    expect(usage.events).toEqual([]);
+  });
+
+  it("says so when the address answers nothing at all", async () => {
+    boot({});
+    store.setServer(WS, resolvedServer({ authMode: "none", url: "https://nowhere.test/mcp" }));
+
+    expect(
+      (await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER })).kind,
+    ).toBe("unreachable");
+  });
+
+  it("says a server needing a sign-in that nobody connected is not probeable", async () => {
+    const upstream = legacyFake("2025-06-18");
+    boot({ [UPSTREAM_URL]: upstream.handler });
+    store.setServer(WS, resolvedServer());
+
+    expect(
+      await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER }),
+    ).toEqual({ kind: "no_credential" });
+    expect(upstream.calls).toEqual([]);
+  });
+
+  it("says so when the workspace has no connection to that server", async () => {
+    boot({});
+    expect(
+      await probeServerTools(t.ctx, { workspaceId: WS, serverId: "srv_nobody", userId: USER }),
+    ).toEqual({ kind: "not_connected" });
+  });
+});
+
+describe("what a probe leaves behind", () => {
+  it("keeps the era verdict but not its own conversation", async () => {
+    const upstream = legacyFake("2025-06-18");
+    boot({ [UPSTREAM_URL]: upstream.handler });
+    store.setServer(WS, resolvedServer({ authMode: "none" }));
+
+    await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER });
+
+    // The verdict is shared knowledge about the server — the next real call is faster for it.
+    expect(memory.verdict(SERVER_ID)?.version).toBe("2025-06-18");
+    // The conversation is the probe's own, and it is gone.
+    expect(memory.upstream(PROBE_SESSION, SERVER_ID)).toBeNull();
+  });
+
+  it("does not leave a 2024-11-05 SSE pump running", async () => {
+    const base = "https://old.test";
+    const upstream = fake2411(base);
+    boot({ [base]: upstream.handler });
+    store.setServer(WS, resolvedServer({ authMode: "none", url: `${base}/sse` }));
+
+    expect(
+      (await probeServerTools(t.ctx, { workspaceId: WS, serverId: SERVER_ID, userId: USER })).kind,
+    ).toBe("recorded");
+    expect(memory.upstream(PROBE_SESSION, SERVER_ID)).toBeNull();
+  });
+});

--- a/gateway/tests/service-lane.test.ts
+++ b/gateway/tests/service-lane.test.ts
@@ -23,6 +23,50 @@ let store: PgStore;
 let armed: (request: Request) => Promise<Response>;
 let unarmed: (request: Request) => Promise<Response>;
 
+/**
+ * The lane's outbound fetch, stubbed. Two reasons it must be: the credential routes now PROBE the
+ * server they just got a sign-in for, and a unit suite that dialled the real internet would be
+ * testing the internet. Each case installs the upstream it wants to meet.
+ */
+let upstream: (request: Request) => Promise<Response> = async () =>
+  new Response("no upstream installed", { status: 599 });
+const stubFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
+  upstream(new Request(input, init))) as typeof fetch;
+
+/** A 2025-06-18 server that answers `initialize` and hands back exactly these tools. */
+function serverOffering(...tools: string[]): (request: Request) => Promise<Response> {
+  return async (request) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    if (body["method"] === "initialize") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body["id"],
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "lane-fake" },
+        },
+      });
+    }
+    if (body["method"] === "tools/list") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body["id"],
+        result: { tools: tools.map((name) => ({ name, description: `What ${name} does.` })) },
+      });
+    }
+    return new Response(null, { status: 202 });
+  };
+}
+
+async function observedNames(serverId: string): Promise<string[]> {
+  const rows = await db.q<{ name: string }>(
+    "SELECT name FROM gateway.observed_tool WHERE server_id = $1 ORDER BY name",
+    [serverId],
+  );
+  return rows.map((row) => row.name);
+}
+
 function lane(
   method: string,
   path: string,
@@ -47,7 +91,7 @@ beforeAll(async () => {
   const deps = {
     store,
     config: CONFIG,
-    guardedFetch: fetch,
+    guardedFetch: stubFetch,
     log: () => {},
   };
   armed = createInternalHandler({ ...deps, internalToken: TOKEN });
@@ -141,6 +185,132 @@ describe("credentials/manual", () => {
     );
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ code: "BAD_REQUEST" });
+  });
+});
+
+describe("the tool probe a stored sign-in triggers", () => {
+  it("reads the server's tools down the moment a secret is stored", async () => {
+    const seeded = await seedConnectedServer(db, "ws1", "probed", { authMode: "manual" });
+    upstream = serverOffering("search", "create_issue");
+
+    const response = await armed(
+      lane("POST", "/internal/v1/credentials/manual", {
+        body: {
+          workspaceId: "ws1",
+          serverId: seeded.serverId,
+          userId: "u1",
+          secret: "sk-probed",
+          createdByDisplay: "Person One",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    // The whole point: the checklist has something to check BEFORE any agent has called.
+    expect(await observedNames(seeded.serverId)).toEqual(["create_issue", "search"]);
+    // And the probe is not a call — nothing in the ledger says a person's machine did this.
+    const usage = await db.q<{ n: string }>(
+      "SELECT count(*) AS n FROM gateway.usage_event WHERE server_id = $1",
+      [seeded.serverId],
+    );
+    expect(usage[0]?.n).toBe("0");
+  });
+
+  it("stores the credential even when the server cannot be reached", async () => {
+    const seeded = await seedConnectedServer(db, "ws1", "offline", { authMode: "manual" });
+    upstream = async () => new Response("down", { status: 503 });
+
+    const response = await armed(
+      lane("POST", "/internal/v1/credentials/manual", {
+        body: {
+          workspaceId: "ws1",
+          serverId: seeded.serverId,
+          userId: "u1",
+          secret: "sk-offline",
+          createdByDisplay: "Person One",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()) as { credentialId: string }).toMatchObject({
+      credentialId: expect.stringMatching(/^cred_[0-9a-f]{32}$/),
+    });
+    expect(await store.credentialFor("ws1", seeded.serverId, "u1")).not.toBeNull();
+    expect(await observedNames(seeded.serverId)).toEqual([]);
+  });
+});
+
+describe("tools/refresh", () => {
+  it("asks the server again and answers how many it now offers", async () => {
+    const seeded = await seedConnectedServer(db, "ws1", "refresh", { authMode: "none" });
+    upstream = serverOffering("alpha", "beta", "gamma");
+
+    const response = await armed(
+      lane("POST", "/internal/v1/tools/refresh", {
+        body: { workspaceId: "ws1", serverId: seeded.serverId, userId: "u1" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ outcome: "recorded", tools: 3 });
+    expect(await observedNames(seeded.serverId)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("says a server needing a sign-in nobody connected cannot be read", async () => {
+    const seeded = await seedConnectedServer(db, "ws1", "unsigned", { authMode: "oauth" });
+    upstream = serverOffering("never-reached");
+
+    const response = await armed(
+      lane("POST", "/internal/v1/tools/refresh", {
+        body: { workspaceId: "ws1", serverId: seeded.serverId, userId: "u1" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ outcome: "no_credential" });
+  });
+
+  it("says so when the server does not answer, and leaves the standing list alone", async () => {
+    const seeded = await seedConnectedServer(db, "ws1", "silent", { authMode: "none" });
+    upstream = serverOffering("kept");
+    await armed(
+      lane("POST", "/internal/v1/tools/refresh", {
+        body: { workspaceId: "ws1", serverId: seeded.serverId, userId: null },
+      }),
+    );
+    upstream = async () => new Response("nope", { status: 500 });
+
+    const response = await armed(
+      lane("POST", "/internal/v1/tools/refresh", {
+        body: { workspaceId: "ws1", serverId: seeded.serverId, userId: null },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ outcome: "unreachable" });
+    expect(await observedNames(seeded.serverId)).toEqual(["kept"]);
+  });
+
+  it("is the uniform 404 for a server this workspace is not connected to", async () => {
+    const response = await armed(
+      lane("POST", "/internal/v1/tools/refresh", {
+        body: { workspaceId: "ws1", serverId: "msrv_ghost", userId: null },
+      }),
+    );
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ code: "NOT_FOUND" });
+  });
+
+  it("refuses a malformed body typed, and is invisible on an unarmed lane", async () => {
+    const bad = await armed(lane("POST", "/internal/v1/tools/refresh", { body: { serverId: 1 } }));
+    expect(bad.status).toBe(400);
+    const off = await unarmed(
+      lane("POST", "/internal/v1/tools/refresh", {
+        body: { workspaceId: "ws1", serverId: "msrv_x", userId: null },
+      }),
+    );
+    expect(off.status).toBe(404);
   });
 });
 

--- a/gateway/tests/service-oauth.test.ts
+++ b/gateway/tests/service-oauth.test.ts
@@ -91,6 +91,37 @@ function startFixture(): Promise<string> {
             registration_endpoint: `${base}/plainas/register`,
             code_challenge_methods_supported: ["plain"],
           });
+        // The MCP endpoint itself — reached by the tool probe the callback runs once a credential
+        // has landed. Bearer-gated, so the probe proves it attached the token it just stored.
+        case "/mcp": {
+          if (request.method !== "POST") {
+            return json(405, { error: "method_not_allowed" });
+          }
+          if (request.headers.authorization !== "Bearer at-live") {
+            return json(401, { error: "unauthorized" });
+          }
+          const rpc = JSON.parse(body) as Record<string, unknown>;
+          if (rpc.method === "initialize") {
+            return json(200, {
+              jsonrpc: "2.0",
+              id: rpc.id,
+              result: {
+                protocolVersion: "2025-06-18",
+                capabilities: { tools: {} },
+                serverInfo: { name: "oauth-fixture" },
+              },
+            });
+          }
+          if (rpc.method === "tools/list") {
+            return json(200, {
+              jsonrpc: "2.0",
+              id: rpc.id,
+              result: { tools: [{ name: "list_issues" }, { name: "create_issue" }] },
+            });
+          }
+          response.writeHead(202);
+          return response.end();
+        }
         case "/as/register": {
           const parsed = JSON.parse(body) as Record<string, unknown>;
           registrations.push(parsed);
@@ -237,6 +268,14 @@ describe("the authorize walk + callback ceremony", () => {
 
     // The token request carried PKCE + the RFC 8707 resource.
     expect(tokenRequests.at(-1)?.resource).toBe(`${base}/mcp`);
+
+    // AND the server's tools were read down before the person was sent back, with the token that
+    // had just been stored — so the Tools panel has a checklist the moment the page renders.
+    const observed = await db.q<{ name: string }>(
+      "SELECT name FROM gateway.observed_tool WHERE server_id = $1 ORDER BY name",
+      [seeded.serverId],
+    );
+    expect(observed.map((row) => row.name)).toEqual(["create_issue", "list_issues"]);
 
     // The credential landed, personal, decryptable, refresh material intact.
     const credential = await realStore.credentialFor("ws1", seeded.serverId, "u1");

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -22,11 +22,17 @@ caller.
   gateway service, MCP sign-ins live there (never here): `app/lib/gateway/client.server.ts` is its
   one transport — `gatewayFetch` + a route allowlist, the custody transport's twin, same shared
   bearer, same boundary-gate treatment — with three typed wrappers in `credentials.server.ts`
-  (begin an authorize walk · store a pasted secret · revoke). This tier reads the gateway's
+  (begin an authorize walk · store a pasted secret · revoke) and one in `tools.server.ts` (ask the
+  server for its tool list again; the gateway probes it automatically the moment a sign-in lands,
+  so this is for a list that has since changed). This tier reads the gateway's
   non-secret rows through a second read-only mirror (`app/lib/db/schema.gateway.ts`: credential
   METADATA, observed tools, usage events — the ciphertext table has no grant and no mirror), and
   owns the tool policy itself (`web.mcp_tool_policy` + `mcp_tool_selection`, hanging off the
-  connection). Three env vars, all optional and none defaulted: `GATEWAY_INTERNAL_URL` +
+  connection). ONE policy state is refused rather than written: `selected` with nothing selected
+  means every tool off, which is switching a server off and never what an empty checklist meant —
+  so the checklist renders STARTING FULL (narrowing is unchecking; a standing selection is
+  preserved) and the write answers `empty_selection`. Three env vars, all optional and none
+  defaulted: `GATEWAY_INTERNAL_URL` +
   `GATEWAY_INTERNAL_TOKEN` (paired — half a lane refuses at parse time) arm the lane and the
   server-page sections; `GATEWAY_PUBLIC_URL` arms the DELIVERY FLIP
   (`app/lib/gateway/delivery.server.ts`), where an addressable server's delivered document gets ONE

--- a/web/app/components/skill/mcp-gateway.tsx
+++ b/web/app/components/skill/mcp-gateway.tsx
@@ -147,18 +147,53 @@ function SignInSection({ view }: { view: McpGatewayView }) {
 }
 
 /**
+ * WHICH TOOLS A FRESHLY RENDERED CHECKLIST STARTS CHECKED.
+ *
+ * THE CHECKLIST STARTS FULL. Narrowing is switching tools OFF, never hunting for what to switch on:
+ * a workspace that has never narrowed this server sees every tool checked, so the radio and the
+ * checklist agree before anything is touched, and the act of narrowing is unchecking.
+ *
+ * A workspace with a STANDING SELECTION sees that selection instead — its answer is never
+ * overwritten by opening the page. A `selected` policy carrying no observed tool is the state this
+ * rule exists to heal: it has nothing to preserve, so it starts full like any other, and the way
+ * out of it is one click on All tools or one Save.
+ */
+export function startingToolChecks(tools: readonly McpGatewayToolRow[]): ReadonlySet<string> {
+  const standing = tools.filter((tool) => tool.selected);
+  return new Set((standing.length > 0 ? standing : tools).map((tool) => tool.name));
+}
+
+/**
  * TOOLS. The radio is the whole policy: every tool, or only the checked ones. The second line says
  * outright what happens to a tool the server adds later, because that is the question a reader has
- * the moment they narrow anything.
+ * the moment they narrow anything. Saving an empty checklist under `selected` is refused
+ * server-side, with the sentence that says what it would have done.
  */
 function ToolsSection({ view }: { view: McpGatewayView }) {
-  const busy = useSubmittingIntent() === "gateway-tools";
-  const refusal = useArmRefusal("gateway-tools");
+  const flying = useSubmittingIntent();
+  const busy = flying === "gateway-tools";
+  const refreshing = flying === "gateway-tools-refresh";
+  // Both hooks run every render (a `??` would short-circuit the second one out of the call order).
+  const saveRefusal = useArmRefusal("gateway-tools");
+  const refreshRefusal = useArmRefusal("gateway-tools-refresh");
+  const refusal = saveRefusal ?? refreshRefusal;
+  const startsChecked = startingToolChecks(view.tools);
   return (
     <section aria-labelledby="mcp-tools-heading" className="space-y-3">
-      <SectionHeading>
-        <span id="mcp-tools-heading">Tools</span>
-      </SectionHeading>
+      <div className="flex items-center justify-between gap-3">
+        <SectionHeading>
+          <span id="mcp-tools-heading">Tools</span>
+        </SectionHeading>
+        {/* Its own form, outside the policy form — a form cannot nest inside another. */}
+        <Form method="post">
+          <input type="hidden" name="intent" value="gateway-tools-refresh" />
+          <BusyFields busy={refreshing}>
+            <button type="submit" className={buttonClasses("quiet")}>
+              Refresh tools
+            </button>
+          </BusyFields>
+        </Form>
+      </div>
       <Card className="px-4 py-3">
         <Form method="post" className="space-y-3">
           <input type="hidden" name="intent" value="gateway-tools" />
@@ -193,7 +228,8 @@ function ToolsSection({ view }: { view: McpGatewayView }) {
             </fieldset>
             {view.tools.length === 0 ? (
               <p className="text-faint text-sm" data-testid="mcp-tools-empty">
-                No tools observed yet. The list fills in after the first call through the gateway.
+                No tools observed yet. The list fills in when a sign-in is connected, or when you
+                refresh it.
               </p>
             ) : (
               <ul className="space-y-2" data-testid="mcp-tools-list">
@@ -203,7 +239,7 @@ function ToolsSection({ view }: { view: McpGatewayView }) {
                       type="checkbox"
                       name="tool"
                       value={tool.name}
-                      defaultChecked={tool.selected}
+                      defaultChecked={startsChecked.has(tool.name)}
                       id={`mcp-tool-${tool.name}`}
                       className="mt-1"
                     />

--- a/web/app/lib/db/queries.gateway.server.ts
+++ b/web/app/lib/db/queries.gateway.server.ts
@@ -175,7 +175,7 @@ export async function mcpToolsView(actor: MemberActor, serverId: string): Promis
   };
 }
 
-export type ToolPolicyOutcome = "saved" | "not_connected";
+export type ToolPolicyOutcome = "saved" | "not_connected" | "empty_selection";
 
 /**
  * SET THE POLICY — member-writable, and one transaction: the policy row is upserted, the selection
@@ -186,6 +186,11 @@ export type ToolPolicyOutcome = "saved" | "not_connected";
  * complete state rather than two half-applied edits. A server this workspace is not connected to
  * has no policy to set — the composite FK refuses it, and that refusal is typed back rather than
  * thrown.
+ *
+ * ONE STATE IS REFUSED: `selected` with nothing selected. It is spellable, and it means every tool
+ * on the server is off — which is a thing a person may well want, but never a thing they meant by
+ * saving an empty checklist. It reads as "narrow this" and lands as "switch this server off", so
+ * the write refuses and the caller says why. Turning a whole server off is disconnecting it.
  */
 export async function setMcpToolPolicy(
   actor: MemberActor,
@@ -193,6 +198,9 @@ export async function setMcpToolPolicy(
   next: { mode: "all" | "selected"; tools: readonly string[] },
 ): Promise<ToolPolicyOutcome> {
   const wanted = [...new Set(next.tools)].sort();
+  if (next.mode === "selected" && wanted.length === 0) {
+    return "empty_selection";
+  }
   return await getDb().transaction(async (tx) => {
     const connected = await tx.execute(sql`
       SELECT 1 FROM web.bundle_mcp

--- a/web/app/lib/gateway/client.server.ts
+++ b/web/app/lib/gateway/client.server.ts
@@ -23,6 +23,9 @@ export const ALLOWED_ROUTES = [
   "POST /internal/v1/credentials/manual",
   // Revoke: the row goes, and the next call through the gateway has no credential to attach.
   "DELETE /internal/v1/credentials/{credentialId}",
+  // Ask the server for its tool list again. The gateway holds the sign-in, so it is the only tier
+  // that can ask; what comes back is rows in its own schema, which this tier then reads.
+  "POST /internal/v1/tools/refresh",
 ] as const;
 
 const allowed = new Set<string>(ALLOWED_ROUTES);

--- a/web/app/lib/gateway/tools.server.ts
+++ b/web/app/lib/gateway/tools.server.ts
@@ -1,0 +1,54 @@
+import { gatewayFetch } from "./client.server";
+
+/**
+ * ASK THE SERVER FOR ITS TOOLS AGAIN — the one wrapper over the lane's `tools/refresh`.
+ *
+ * The tool list is written down by the gateway (it holds the sign-in, so it is the only tier that
+ * can speak to the server), and read from here through the gateway schema's mirror. It is filled in
+ * automatically the moment a sign-in is connected; this is the door for the other case — a server
+ * whose tools changed since, or one that was offline when its sign-in landed.
+ *
+ * The outcome is a value, never an exception into a ceremony: an unreachable gateway is `fault`,
+ * exactly as the sign-in wrappers spell it.
+ */
+
+export type RefreshToolsOutcome =
+  /** The list was read and written; `tools` is how many the server now offers. */
+  | { kind: "refreshed"; tools: number }
+  /** The server asks for a sign-in and this workspace has none to ask with. */
+  | { kind: "no_credential" }
+  /** The server did not answer, or answered something that is not a tool list. */
+  | { kind: "unreachable" }
+  /** The gateway has no live connection to that server, or could not be reached at all. */
+  | { kind: "fault" };
+
+export async function refreshObservedTools(args: {
+  workspaceId: string;
+  serverId: string;
+  userId: string | null;
+}): Promise<RefreshToolsOutcome> {
+  let res: Response;
+  try {
+    res = await gatewayFetch({
+      method: "POST",
+      template: "/internal/v1/tools/refresh",
+      body: args,
+    });
+  } catch {
+    return { kind: "fault" };
+  }
+  if (!res.ok) {
+    return { kind: "fault" };
+  }
+  const body = (await res.json().catch(() => null)) as {
+    outcome?: unknown;
+    tools?: unknown;
+  } | null;
+  if (body?.outcome === "recorded" && typeof body.tools === "number") {
+    return { kind: "refreshed", tools: body.tools };
+  }
+  if (body?.outcome === "no_credential") {
+    return { kind: "no_credential" };
+  }
+  return body?.outcome === "unreachable" ? { kind: "unreachable" } : { kind: "fault" };
+}

--- a/web/app/routes/skill-current.tsx
+++ b/web/app/routes/skill-current.tsx
@@ -50,6 +50,7 @@ import { resolveSkillName } from "@/lib/db/resolve.server";
 import { gatewayLane } from "@/lib/gateway/client.server";
 import { beginAuthorize, deleteCredential } from "@/lib/gateway/credentials.server";
 import { mcpGatewayView } from "@/lib/gateway/panel.server";
+import { refreshObservedTools } from "@/lib/gateway/tools.server";
 import { sendInviteEmail } from "@/lib/mail/invite-mail.server";
 import { mailDelivery } from "@/lib/mail/transport.server";
 import { canonicalServerJson } from "@/lib/mcp/fetch.server";
@@ -220,7 +221,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
   if (
     intent === "gateway-connect" ||
     intent === "gateway-disconnect" ||
-    intent === "gateway-tools"
+    intent === "gateway-tools" ||
+    intent === "gateway-tools-refresh"
   ) {
     return gatewayIntent(request, workspace, actor, bundleNameOf(params), intent, formData);
   }
@@ -229,7 +231,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 /** The reply every gateway arm answers with when it did not land — one honest sentence, scoped to
  *  the arm, rendered by the panel's own alert. A landed arm redirects or falls through to `ok`. */
-type GatewayIntent = "gateway-connect" | "gateway-disconnect" | "gateway-tools";
+type GatewayIntent =
+  | "gateway-connect"
+  | "gateway-disconnect"
+  | "gateway-tools"
+  | "gateway-tools-refresh";
 interface GatewayActionData {
   intent: GatewayIntent;
   status: "ok" | "error";
@@ -241,7 +247,8 @@ function gatewayRefusal(intent: GatewayIntent, message: string, status = 400) {
 }
 
 /**
- * THE GATEWAY ARMS — connect a sign-in, disconnect one, set the tool policy.
+ * THE GATEWAY ARMS — connect a sign-in, disconnect one, set the tool policy, ask for the tool list
+ * again.
  *
  * Member scope is the floor (the face's own guard ran above); the WORKSPACE-scoped sign-in
  * re-guards for an owner INSIDE the arm, the same way the assignment arms do, so its refusal is
@@ -278,9 +285,39 @@ async function gatewayIntent(
     // The checklist IS the answer: what the form posted replaces the selection wholesale.
     const tools = formData.getAll("tool").map((value) => String(value));
     const outcome = await setMcpToolPolicy(actor, server.serverId, { mode, tools });
-    return outcome === "saved"
-      ? data<GatewayActionData>({ intent, status: "ok" })
-      : gatewayRefusal(intent, "This workspace is no longer connected to that server.");
+    if (outcome === "saved") {
+      return data<GatewayActionData>({ intent, status: "ok" });
+    }
+    // Narrowing to nothing is not narrowing — it is switching the server off, and nobody means
+    // that by saving an empty checklist. The refusal names both ways out.
+    return gatewayRefusal(
+      intent,
+      outcome === "empty_selection"
+        ? "Selected tools with nothing checked would disable every tool on this server. Choose All tools, or check at least one."
+        : "This workspace is no longer connected to that server.",
+    );
+  }
+
+  if (intent === "gateway-tools-refresh") {
+    // A server's tools change over time. The gateway holds the sign-in, so asking again is its
+    // call to make; this tier asks it to, then re-reads the rows it wrote.
+    const outcome = await refreshObservedTools({
+      workspaceId: workspace.id,
+      serverId: server.serverId,
+      userId: actor.userId,
+    });
+    if (outcome.kind === "refreshed") {
+      return data<GatewayActionData>({ intent, status: "ok" });
+    }
+    return gatewayRefusal(
+      intent,
+      outcome.kind === "no_credential"
+        ? "Connect a sign-in first — this server won't list its tools without one."
+        : outcome.kind === "unreachable"
+          ? "This server didn't answer. The tool list is unchanged."
+          : "That didn't go through. Try again.",
+      outcome.kind === "fault" ? 500 : 400,
+    );
   }
 
   const scope = formData.get("scope") === "workspace" ? "workspace" : "mine";

--- a/web/tests/unit/gateway-lane.test.ts
+++ b/web/tests/unit/gateway-lane.test.ts
@@ -37,12 +37,13 @@ beforeEach(() => {
 });
 
 describe("the route allowlist", () => {
-  it("carries exactly the three internal routes this tier may call", async () => {
+  it("carries exactly the four internal routes this tier may call", async () => {
     const { ALLOWED_ROUTES } = await client();
     expect([...ALLOWED_ROUTES]).toEqual([
       "POST /internal/v1/authorize/begin",
       "POST /internal/v1/credentials/manual",
       "DELETE /internal/v1/credentials/{credentialId}",
+      "POST /internal/v1/tools/refresh",
     ]);
   });
 

--- a/web/tests/unit/gateway-panel.test.ts
+++ b/web/tests/unit/gateway-panel.test.ts
@@ -190,9 +190,11 @@ describe("the tool policy", () => {
   });
 
   it("refuses a server this workspace is not connected to, typed rather than thrown", async () => {
+    // `selected` with a real checklist — an EMPTY one is refused ahead of the connection check,
+    // and that refusal has its own suite (gateway-tool-selection.test.ts).
     const outcome = await (await dal()).setMcpToolPolicy(member(), "mcps_nobody", {
       mode: "selected",
-      tools: [],
+      tools: ["search"],
     });
     expect(outcome).toBe("not_connected");
   });

--- a/web/tests/unit/gateway-tool-selection.test.ts
+++ b/web/tests/unit/gateway-tool-selection.test.ts
@@ -1,0 +1,301 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyGatewayDdl } from "../helpers/gateway-ddl";
+import { mcpRevisionId } from "../helpers/mcp-ids";
+import {
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedBundle,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * THE SELECTION TRAP, CLOSED — the tool policy's one refusal and the checklist rule that makes it
+ * almost impossible to reach.
+ *
+ * `selected` with nothing checked is a spellable state that means every tool on the server is off.
+ * It reads as narrowing and lands as switching a server off, which is how a Linear connection got
+ * silently disabled in production the day the panel first shipped. Two things stop it:
+ *
+ *  - THE WRITE REFUSES IT, at the data layer, so no door can spell it — and the route says why in
+ *    the one sentence a person needs;
+ *  - THE CHECKLIST STARTS FULL, so narrowing is unchecking and the state is never the default one
+ *    a save would produce. A standing selection is preserved instead — opening the page is not an
+ *    answer, and re-saving what the page rendered must not widen a workspace's own narrowing.
+ */
+
+let session: { user: { id: string; name: string; email: string } } | null = null;
+vi.mock("@/lib/auth/server", () => ({
+  getAuth: () => ({ api: { getSession: async () => session } }),
+}));
+
+let db: ScratchDb;
+let ws = "";
+
+const ORIGIN = "http://x";
+const MEMBER = { id: "u_mem", name: "Mo Member", email: "mo@example.com" };
+const SERVER = "mcps_tools";
+const BUNDLE_NAME = "linear";
+
+/** What the gateway lane's `tools/refresh` answered last — the transport is stubbed, never dialed. */
+let laneAnswer: Response = Response.json({ outcome: "recorded", tools: 2 });
+const laneCalls: { url: string; body: unknown }[] = [];
+
+async function seedServer(): Promise<void> {
+  await db.q(
+    `INSERT INTO web.mcp_server (id, workspace_id, name, display_name, auth_mode, status)
+     VALUES ($1, NULL, 'com.example/linear', 'Linear', 'oauth', 'active')`,
+    [SERVER],
+  );
+  const revision = mcpRevisionId(SERVER);
+  await db.q(
+    `INSERT INTO web.mcp_server_revision
+       (id, server_id, seq, upstream_version, document, transport, url, published_at, published_by)
+     VALUES ($1, $2, 1, '1.0.0', $3::jsonb, 'streamable-http', 'https://mcp.example.com/mcp',
+             now(), 'Staff')`,
+    [revision, SERVER, JSON.stringify({ name: "com.example/linear", version: "1.0.0" })],
+  );
+  await db.q(`UPDATE web.mcp_server SET current_revision_id = $2 WHERE id = $1`, [
+    SERVER,
+    revision,
+  ]);
+  await seedBundle(db, ws, "b_linear", BUNDLE_NAME, { kind: "mcp", withPointer: false });
+  await db.q(
+    `INSERT INTO web.bundle_mcp (bundle_id, workspace_id, server_id) VALUES ($1, $2, $3)`,
+    ["b_linear", ws, SERVER],
+  );
+}
+
+async function seedTool(name: string): Promise<void> {
+  await db.q(
+    `INSERT INTO gateway.observed_tool (workspace_id, server_id, name, description)
+     VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+    [ws, SERVER, name, `What ${name} does.`],
+  );
+}
+
+/** Post one arm of the server face's action, exactly as the panel's forms do. */
+async function post(fields: [string, string][]): Promise<{ status: number; body: unknown }> {
+  const { action } = await import("@/routes/skill-current");
+  const form = new URLSearchParams(fields);
+  try {
+    const answer = (await action({
+      request: new Request(`${ORIGIN}/mcp/${BUNDLE_NAME}`, {
+        method: "POST",
+        // The same-origin guard is a write's floor here: a POST with no Origin is the house 404.
+        headers: { origin: ORIGIN, "content-type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+      }),
+      params: { server: BUNDLE_NAME },
+      context: {},
+    } as unknown as Parameters<typeof action>[0])) as {
+      init?: ResponseInit;
+      data?: unknown;
+    };
+    return { status: answer.init?.status ?? 200, body: answer.data ?? answer };
+  } catch (thrown) {
+    if (thrown instanceof Response) {
+      return { status: thrown.status, body: null };
+    }
+    throw thrown;
+  }
+}
+
+async function policyRow(): Promise<{ mode: string } | undefined> {
+  const rows = await db.q<{ mode: string }>(
+    `SELECT mode FROM web.mcp_tool_policy WHERE workspace_id = $1 AND server_id = $2`,
+    [ws, SERVER],
+  );
+  return rows[0];
+}
+
+async function selectedNames(): Promise<string[]> {
+  const rows = await db.q<{ tool_name: string }>(
+    `SELECT tool_name FROM web.mcp_tool_selection
+      WHERE workspace_id = $1 AND server_id = $2 ORDER BY tool_name`,
+    [ws, SERVER],
+  );
+  return rows.map((row) => row.tool_name);
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_gateway_tool_selection", {
+    // The arms live behind `gatewayLane() !== null`; a deployment with no gateway 404s them.
+    GATEWAY_INTERNAL_URL: "http://gateway.internal:8789",
+    GATEWAY_INTERNAL_TOKEN: "internal-token-unit",
+  });
+  await applyGatewayDdl(db.url);
+  ws = await bootWorkspace();
+  await seedUser(db, MEMBER.id, MEMBER.name, MEMBER.email);
+  await seatUser(db, ws, MEMBER.id, "member");
+  await seedServer();
+  await seedTool("search");
+  await seedTool("create_issue");
+  session = { user: MEMBER };
+  // No test here reaches the network: the lane's one transport is `fetch`, stubbed for the file.
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    laneCalls.push({
+      url: String(input),
+      body: init?.body === undefined ? null : JSON.parse(String(init.body)),
+    });
+    return laneAnswer.clone();
+  });
+}, 60000);
+
+afterAll(async () => {
+  vi.unstubAllGlobals();
+  await db.drop();
+});
+
+beforeEach(() => {
+  laneCalls.length = 0;
+});
+
+describe("saving the tool policy", () => {
+  it("refuses `selected` with nothing checked, and writes no policy at all", async () => {
+    const answer = await post([
+      ["intent", "gateway-tools"],
+      ["mode", "selected"],
+    ]);
+
+    expect(answer.status).toBe(400);
+    expect(answer.body).toEqual({
+      intent: "gateway-tools",
+      status: "error",
+      message:
+        "Selected tools with nothing checked would disable every tool on this server. Choose All tools, or check at least one.",
+    });
+    // The trap in one line: had this landed, every tool on the server would be off.
+    expect(await policyRow()).toBeUndefined();
+    expect(await selectedNames()).toEqual([]);
+  });
+
+  it("refuses it at the data layer too, so no other door can spell it", async () => {
+    const { setMcpToolPolicy } = await import("@/lib/db/queries.gateway.server");
+    const { asMember } = await import("./helpers/scratch-db");
+    expect(
+      await setMcpToolPolicy(asMember(ws, MEMBER.id, "member", MEMBER.name), SERVER, {
+        mode: "selected",
+        tools: [],
+      }),
+    ).toBe("empty_selection");
+    expect(await policyRow()).toBeUndefined();
+    // A refused write leaves no audit row either — nothing happened to record.
+    const audits = await db.q<{ n: string }>(
+      `SELECT count(*) AS n FROM web.audit_event WHERE workspace_id = $1 AND kind = 'mcp_tools_set'`,
+      [ws],
+    );
+    expect(audits[0]?.n).toBe("0");
+  });
+
+  it("lands `selected` the moment one tool is checked", async () => {
+    const answer = await post([
+      ["intent", "gateway-tools"],
+      ["mode", "selected"],
+      ["tool", "search"],
+    ]);
+    expect(answer).toEqual({ status: 200, body: { intent: "gateway-tools", status: "ok" } });
+    expect((await policyRow())?.mode).toBe("selected");
+    expect(await selectedNames()).toEqual(["search"]);
+  });
+
+  it("still lands `all` with nothing checked — widening was never the trap", async () => {
+    const answer = await post([
+      ["intent", "gateway-tools"],
+      ["mode", "all"],
+    ]);
+    expect(answer.status).toBe(200);
+    expect((await policyRow())?.mode).toBe("all");
+    expect(await selectedNames()).toEqual([]);
+  });
+});
+
+describe("the checklist a fresh render starts with", () => {
+  async function checks(tools: { name: string; selected: boolean }[]): Promise<string[]> {
+    const { startingToolChecks } = await import("@/components/skill/mcp-gateway");
+    const rows = tools.map((tool) => ({ ...tool, description: null, currentlyOffered: true }));
+    return [...startingToolChecks(rows)].sort();
+  }
+
+  it("starts FULL for a workspace that has never narrowed this server", async () => {
+    expect(
+      await checks([
+        { name: "search", selected: false },
+        { name: "create_issue", selected: false },
+      ]),
+    ).toEqual(["create_issue", "search"]);
+  });
+
+  it("keeps a standing selection instead of widening it back out", async () => {
+    expect(
+      await checks([
+        { name: "search", selected: true },
+        { name: "create_issue", selected: false },
+      ]),
+    ).toEqual(["search"]);
+  });
+
+  it("starts full for a `selected` policy that selected nothing — the state that has to heal", async () => {
+    expect(
+      await checks([
+        { name: "search", selected: false },
+        { name: "create_issue", selected: false },
+      ]),
+    ).toEqual(["create_issue", "search"]);
+  });
+
+  it("is empty only when the server offers nothing", async () => {
+    expect(await checks([])).toEqual([]);
+  });
+});
+
+describe("asking the server for its tools again", () => {
+  it("calls the lane for THIS viewer and lands", async () => {
+    laneAnswer = Response.json({ outcome: "recorded", tools: 2 });
+    const answer = await post([["intent", "gateway-tools-refresh"]]);
+
+    expect(answer).toEqual({
+      status: 200,
+      body: { intent: "gateway-tools-refresh", status: "ok" },
+    });
+    expect(laneCalls).toHaveLength(1);
+    expect(laneCalls[0]?.url).toBe("http://gateway.internal:8789/internal/v1/tools/refresh");
+    expect(laneCalls[0]?.body).toEqual({
+      workspaceId: ws,
+      serverId: SERVER,
+      userId: MEMBER.id,
+    });
+  });
+
+  it("says a server with no sign-in cannot be read", async () => {
+    laneAnswer = Response.json({ outcome: "no_credential" });
+    const answer = await post([["intent", "gateway-tools-refresh"]]);
+    expect(answer.body).toEqual({
+      intent: "gateway-tools-refresh",
+      status: "error",
+      message: "Connect a sign-in first — this server won't list its tools without one.",
+    });
+  });
+
+  it("says the server did not answer, and does not claim the list changed", async () => {
+    laneAnswer = Response.json({ outcome: "unreachable" });
+    const answer = await post([["intent", "gateway-tools-refresh"]]);
+    expect(answer.body).toEqual({
+      intent: "gateway-tools-refresh",
+      status: "error",
+      message: "This server didn't answer. The tool list is unchanged.",
+    });
+  });
+
+  it("folds a gateway that answered nothing usable into the house refusal", async () => {
+    laneAnswer = new Response("no", { status: 500 });
+    const answer = await post([["intent", "gateway-tools-refresh"]]);
+    expect(answer.status).toBe(500);
+    expect(answer.body).toMatchObject({
+      intent: "gateway-tools-refresh",
+      status: "error",
+      message: "That didn't go through. Try again.",
+    });
+  });
+});


### PR DESCRIPTION
Two faults hit within minutes of connecting the first real sign-in in production.

### The tool list arrived too late to be useful

The checklist filled in only after an agent had already called through the gateway — so the one moment you most want to restrict a server, right after granting it a credential, was the one moment you could not see what it offers.

Connecting now **probes** the server and records what it advertises, on both paths that store a credential (the authorize callback and a pasted secret). The probe walks the **same upstream client a real call uses** — same era detection, same credential attach, same guarded fetch — so the checklist shows what an agent would actually reach. Paginated, deduped, and recorded whole or not at all (a partial write would mark unreached tools as withdrawn). It is bounded and **never fails the connect**: a server that will not answer just leaves the list empty. It writes **no usage row**, because a probe is not an agent's call. A refresh route and button exist too, since a server's tools change.

### The worse one: an empty selection silently disabled everything

With nothing observed, choosing the selected-tools mode saved a policy with an empty selection — which means exactly what it says: no tool is allowed. **Linear went dark with 53 tools filtered and no message anywhere.**

- The checklist now starts **full** — narrowing is unchecking, never hunting for what to switch on. An existing selection is preserved.
- An empty selection is **refused at the data layer**, where no door can spell the state, rather than politely written down.

Copy shipped:

> `Selected tools with nothing checked would disable every tool on this server. Choose All tools, or check at least one.`

The empty state stopped being true and now reads: `No tools observed yet. The list fills in when a sign-in is connected, or when you refresh it.`

### Tests

Gateway 248 (was 226), web 1,191. New coverage: the probe records the unfiltered list and writes zero usage rows even against a real recording sink; an unreachable upstream still stores the credential; cursor-follow and dedupe; a later-page failure records nothing; the upstream conversation and any legacy stream are torn down while the era verdict is kept; the exact refusal copy from both the route and the DAL; and the starting-checks rule in all four states.

Also swapped a test that dialled the real internet for a stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)