### PR TITLE
add: a bundle's page URL names the bundle; cold-reader refusals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3959,7 +3959,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "topos"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "base64",
  "clap",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "sha2",
  "unicode-normalization",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "axum",
  "plane-store",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "diffy",
  "flate2",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "hex",
  "jsonc-parser",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "anyhow",
  "axum",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.48" # members inherit via `version.workspace = true`; bump to match the tag before tagging
+version = "0.1.49" # members inherit via `version.workspace = true`; bump to match the tag before tagging
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/bins/topos/src/error.rs
+++ b/bins/topos/src/error.rs
@@ -619,8 +619,9 @@ pub(crate) enum ClientError {
     /// that name sits in any known harness dir. Usage guidance shown VERBATIM (the name is the user's own
     /// argv token). Distinct from [`ClientError::NoSuchSkill`] (which is about *tracked* skills).
     #[error(
-        "no untracked skill named '{name}' — run `topos list` to see what's adoptable, or adopt a \
-         directory by path (`topos add ./<dir>`)"
+        "no untracked bundle named '{name}' here — run `topos list` to see what's adoptable, adopt \
+         a directory by path (`topos add ./<dir>`), or name a workspace's bundle by its address \
+         (`topos add topos.sh/<workspace>/{name}` — its page URL works too)"
     )]
     NoUntrackedSkill { name: String },
     /// `add <skill>` named a skill that is already tracked (so discovery excludes it) — the right move is

--- a/bins/topos/src/manifest/keys.rs
+++ b/bins/topos/src/manifest/keys.rs
@@ -267,9 +267,20 @@ pub(crate) fn classify_key(key: &str) -> Result<KeyShape, KeyError> {
                 workspace: (*ws).to_string(),
                 channel: (*name).to_string(),
             }),
+            // The bundle's PAGE URL — what `publish` hands out as the share line and what a
+            // browser's address bar shows (`…/skills/<bundle>`, `…/mcp/<server>`): the same
+            // bundle, spelled by its page. Recorded in the canonical `<host>/<ws>/<bundle>` form.
+            [host, ws, "skills" | "mcp", bundle] if is_name(ws) && is_name(bundle) => {
+                Ok(KeyShape::WorkspaceBundle {
+                    host: (*host).to_string(),
+                    workspace: (*ws).to_string(),
+                    bundle: (*bundle).to_string(),
+                })
+            }
             [host, ws, mid, _] if is_name(ws) && *mid != "channels" => Err(err(format!(
-                "`{key}` is not a reference — only `channels` sits third \
-                 (`{host}/{ws}/channels/<name>`); a bundle is `{host}/{ws}/<bundle>`",
+                "`{key}` is not a reference — a bundle is `{host}/{ws}/<bundle>` (its page URL, \
+                 `{host}/{ws}/skills/<bundle>` or `{host}/{ws}/mcp/<server>`, names the same \
+                 bundle); a channel is `{host}/{ws}/channels/<name>`",
             ))),
             _ => Err(err(format!(
                 "`{key}` is not a reference — `<host>/<workspace>` (the feed), \
@@ -631,12 +642,40 @@ mod tests {
         // `host/ws/channels` never classifies as a bundle named `channels` …
         let e = classify_key("topos.sh/acme/channels").unwrap_err();
         assert!(e.message.contains("channels/<name>"), "{e}");
-        // … and only `channels` may sit third on a four-segment workspace key.
-        let e = classify_key("topos.sh/acme/skills/deploy").unwrap_err();
-        assert!(e.message.contains("only `channels` sits third"), "{e}");
+        // … and an unknown third segment on a four-segment workspace key refuses, teaching the
+        // page-URL forms that DO name a bundle.
+        let e = classify_key("topos.sh/acme/things/deploy").unwrap_err();
+        assert!(e.message.contains("skills/<bundle>"), "{e}");
         assert!(
             classify_key("topos.sh/acme/channels/backend").is_ok(),
             "the four-segment channel form stays valid"
+        );
+    }
+
+    #[test]
+    fn a_bundle_page_url_names_the_bundle() {
+        // The share line `publish` prints and the browser's address bar — both classify as the
+        // bundle itself, recorded canonically.
+        for spelled in ["topos.sh/acme/skills/deploy", "topos.sh/acme/mcp/deploy"] {
+            assert_eq!(
+                classify_key(spelled).unwrap(),
+                KeyShape::WorkspaceBundle {
+                    host: "topos.sh".into(),
+                    workspace: "acme".into(),
+                    bundle: "deploy".into()
+                },
+                "{spelled}"
+            );
+        }
+        // The pasted form, scheme and all — the share line verbatim.
+        let pasted = parse_input("https://topos.sh/acme/skills/deploy", None).unwrap();
+        assert_eq!(
+            pasted.shape,
+            KeyShape::WorkspaceBundle {
+                host: "topos.sh".into(),
+                workspace: "acme".into(),
+                bundle: "deploy".into()
+            }
         );
     }
 

--- a/bins/topos/src/ops/add.rs
+++ b/bins/topos/src/ops/add.rs
@@ -2816,11 +2816,11 @@ fn distinct_sorted_readers(entries: &[&UntrackedEntry]) -> Vec<String> {
 fn harness_not_found_message(name: &str, harness: &str, available: &[String]) -> String {
     if available.is_empty() {
         format!(
-            "no untracked skill named '{name}' in harness '{harness}' — run `topos list` to see what's adoptable"
+            "no untracked bundle named '{name}' in harness '{harness}' — run `topos list` to see what's adoptable"
         )
     } else {
         format!(
-            "no untracked skill named '{name}' in harness '{harness}' — it is available in: {} (try `topos add {name}@<harness>`)",
+            "no untracked bundle named '{name}' in harness '{harness}' — it is available in: {} (try `topos add {name}@<harness>`)",
             available.join(", ")
         )
     }

--- a/bins/topos/src/ops/reference.rs
+++ b/bins/topos/src/ops/reference.rs
@@ -142,10 +142,10 @@ fn add_feed(
     if !global {
         // The SAME teaching the manifest grammar gives a feed row written into a project file.
         return Err(ClientError::InvalidArgument(format!(
-            "`{reference}` is a feed row — personal by nature, so it lives in the global manifest \
-             (`~/.topos/topos.toml`) only; a project manifest is a repo fact, identical for every \
-             contributor, and a channel (`{reference}/channels/<name>`) is the repo-shaped set to \
-             name here"
+            "`{reference}` is a whole workspace — that is a machine-wide subscription, not a \
+             project line. Machine-wide: `topos add -g {reference}`. In this project, name one \
+             bundle (`topos add {reference}/<bundle>`) or a channel \
+             (`topos add {reference}/channels/<name>`)"
         )));
     }
     let connected = medit::connected_workspaces(ctx);

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -1553,18 +1553,18 @@ pub(crate) fn list_tty(out: &ListOutcome) -> String {
         // `--untracked`: each tracked scope is ONE summary line (never invisible, never dumped).
         let machine_alone = data.scopes.len() == 1;
         for scope in &data.scopes {
-            let skills = scope.rows.len() as u64;
+            let bundles = scope.rows.len() as u64;
             let line = if scope.scope == "project" {
                 format!(
                     "{} tracked in this folder — `topos list`",
-                    counted(skills, "skill")
+                    counted(bundles, "bundle")
                 )
             } else if machine_alone {
-                format!("{} machine-wide — `topos list`", counted(skills, "skill"))
+                format!("{} machine-wide — `topos list`", counted(bundles, "bundle"))
             } else {
                 format!(
                     "{} machine-wide — `topos list -g`",
-                    counted(skills, "skill")
+                    counted(bundles, "bundle")
                 )
             };
             s.push_str(&line);
@@ -1616,7 +1616,7 @@ pub(crate) fn list_tty(out: &ListOutcome) -> String {
                 s.push_str(&format!(
                     "    {} — {}{adopted}\n",
                     c.name,
-                    counted(c.skills, "skill")
+                    counted(c.skills, "bundle")
                 ));
             }
         }
@@ -1637,7 +1637,7 @@ pub(crate) fn list_tty(out: &ListOutcome) -> String {
         };
         s.push_str(&format!(
             "{} machine-wide{updates} — `{}`\n",
-            counted(m.skills, "skill"),
+            counted(m.skills, "bundle"),
             m.command
         ));
     }
@@ -7991,7 +7991,7 @@ mod tests {
         assert!(!text.contains("fresh@000000"), "{text}");
         // EXACTLY one summary line each, ending in the backticked command.
         assert!(
-            text.contains("2 skills machine-wide, 1 update pending — `topos list -g`"),
+            text.contains("2 bundles machine-wide, 1 update pending — `topos list -g`"),
             "{text}"
         );
         assert!(
@@ -9124,11 +9124,11 @@ mod tests {
         let text = list_tty(&out);
         // One summary line per tracked scope — nothing invisible beside the listing.
         assert!(
-            text.contains("0 skills tracked in this folder — `topos list`"),
+            text.contains("0 bundles tracked in this folder — `topos list`"),
             "{text}"
         );
         assert!(
-            text.contains("0 skills machine-wide — `topos list -g`"),
+            text.contains("0 bundles machine-wide — `topos list -g`"),
             "{text}"
         );
         // The full listing, grouped by folder: the readers ride the FOLDER line (every installed
@@ -9207,10 +9207,10 @@ mod tests {
         assert!(text.contains("topos.sh/acme:"), "{text}");
         // Channels: the count + the adopting file when a manifest row adopts one.
         assert!(
-            text.contains("backend — 3 skills  (adopted in ~/.topos/topos.toml)"),
+            text.contains("backend — 3 bundles  (adopted in ~/.topos/topos.toml)"),
             "{text}"
         );
-        assert!(text.contains("everyone — 5 skills"), "{text}");
+        assert!(text.contains("everyone — 5 bundles"), "{text}");
         // The four adoption markers, each honest about the way forward.
         assert!(
             text.contains("deploy@abababababab  skill  (adopted here)  2 open proposal(s)"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   plane:
     # Pinned to one release (see the header). Override with TOPOS_VERSION, or build from source with
     # the docker-compose.build.yml override.
-    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.48}
+    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.49}
     restart: unless-stopped
     mem_limit: 1g
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
@@ -186,7 +186,7 @@ services:
   gateway:
     # The same release as the other two — one TOPOS_VERSION moves all three, and they are only ever
     # tested together.
-    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.48}
+    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.49}
     restart: unless-stopped
     mem_limit: 1g
     # WHAT THIS BOUNDS IS CONCURRENT MCP STREAMS, NOT MEMORY (mem_limit above is the memory
@@ -253,7 +253,7 @@ services:
   web:
     # The same release as the plane and the gateway — one TOPOS_VERSION moves all three, and they are
     # only ever tested together.
-    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.48}
+    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.49}
     restart: unless-stopped
     mem_limit: 1g
     depends_on:

--- a/web/app/lib/plane/contract/version.ts
+++ b/web/app/lib/plane/contract/version.ts
@@ -4,7 +4,7 @@
  */
 
 /** The release version of the build serving this app — what the protocol card declares. */
-export const SERVER_RELEASE_VERSION = "0.1.48";
+export const SERVER_RELEASE_VERSION = "0.1.49";
 
 /** The wire contract's version — stamped on every document this tier emits. */
 export const WIRE_SCHEMA_VERSION = 2;


### PR DESCRIPTION
Found by a by-hand production journey (a user, not a test) after v0.1.48:

- `publish` prints `share_line = <address>/skills/<bundle>` — the bundle's page URL — and `topos add` refused that exact form ("only `channels` sits third"), breaking the publish → share → add loop. The reference grammar now reads `<host>/<ws>/skills/<bundle>` and `<host>/<ws>/mcp/<server>` as the bundle itself (canonical `<host>/<ws>/<bundle>` recorded); the pasted `https://` spelling rides the existing scheme strip. Other third segments still refuse, teaching the forms that do name a bundle.
- `topos add topos.sh/<ws>` inside a project refused in internal vocabulary with no command; it now says what the address is and gives the runnable moves (`-g` machine-wide, or one bundle / a channel here).
- A bare name that matches nothing adoptable also points at the workspace address form; `list` summaries say bundles.

Gates: `cargo xtask ci` 8/8, `cargo test -p topos` (1350), `cargo test -p topos-e2e` (real-binary suites incl. the MinIO store leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
