### PR TITLE
history: authorship per version; proposals dated (v0.1.50 batch 2b)

### DIFF
--- a/bins/topos/src/app.rs
+++ b/bins/topos/src/app.rs
@@ -3275,7 +3275,10 @@ fn session_login_pending_disclosure(
         verification_uri: p.verification_uri.clone(),
         user_code: p.user_code.clone(),
         interval_secs: p.interval_secs,
-        expires_at_millis: p.expires_at.as_deref().and_then(parse_rfc3339_utc_millis),
+        expires_at_millis: p
+            .expires_at
+            .as_deref()
+            .and_then(crate::ops::parse_rfc3339_utc_millis),
     })
 }
 
@@ -3333,33 +3336,6 @@ fn finish_session_logout(
         }
         Err(e) => emit_err(json, command, &e, diag),
     }
-}
-
-/// Parse the client's own RFC 3339 UTC spelling (`YYYY-MM-DDTHH:MM:SSZ` — what the pending
-/// disclosures carry) back to epoch millis. Anything else answers `None` (the waiting line then
-/// shows elapsed time only).
-fn parse_rfc3339_utc_millis(s: &str) -> Option<i64> {
-    let bytes = s.as_bytes();
-    if bytes.len() != 20 || bytes[4] != b'-' || bytes[7] != b'-' || bytes[10] != b'T' {
-        return None;
-    }
-    if bytes[13] != b':' || bytes[16] != b':' || bytes[19] != b'Z' {
-        return None;
-    }
-    let num = |r: std::ops::Range<usize>| -> Option<i64> { s.get(r)?.parse().ok() };
-    let (y, m, d) = (num(0..4)?, num(5..7)?, num(8..10)?);
-    let (hh, mm, ss) = (num(11..13)?, num(14..16)?, num(17..19)?);
-    if !(1..=12).contains(&m) || !(1..=31).contains(&d) || hh > 23 || mm > 59 || ss > 60 {
-        return None;
-    }
-    // Howard Hinnant's days-from-civil (the inverse of `render::civil_from_days`).
-    let yy = if m <= 2 { y - 1 } else { y };
-    let era = if yy >= 0 { yy } else { yy - 399 } / 400;
-    let yoe = yy - era * 400;
-    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146_097 + doe - 719_468;
-    Some((days * 86_400 + hh * 3600 + mm * 60 + ss) * 1000)
 }
 
 /// The waiting line — ONE static print, no timer. The device-flow precedent waits without a
@@ -4022,13 +3998,15 @@ fn list_discovery() -> Option<ops::DiscoveryRoots> {
 mod tests {
     use super::{
         DEFAULT_WEB_ORIGIN, PendingDisclosure, WaitPolicy, block_on_pending, build_pull_scope,
-        claim_grammar, document_flag, list_page_argv, next_page_action, parse_rfc3339_utc_millis,
-        resolve_web_origin, waiting_line,
+        claim_grammar, document_flag, list_page_argv, next_page_action, resolve_web_origin,
+        waiting_line,
     };
     use std::process::ExitCode;
 
     use crate::ids::Clock;
-    use crate::ops::{self, PullScope, RowPage, StoreScope, TargetMode, VersionRef};
+    use crate::ops::{
+        self, PullScope, RowPage, StoreScope, TargetMode, VersionRef, parse_rfc3339_utc_millis,
+    };
 
     struct TestClock(u64);
     impl Clock for TestClock {

--- a/bins/topos/src/ops/connect.rs
+++ b/bins/topos/src/ops/connect.rs
@@ -205,6 +205,34 @@ pub(crate) fn fmt_rfc3339_millis(millis: i64) -> String {
     )
 }
 
+/// The exact INVERSE of [`fmt_rfc3339_millis`]: parse the RFC 3339 UTC spelling this app speaks
+/// (`YYYY-MM-DDTHH:MM:SSZ`) back to epoch millis. Anything else answers `None`, and every caller
+/// treats that as "no time recorded" rather than guessing one — a pending line shows elapsed
+/// time only; a log row stays undated.
+pub(crate) fn parse_rfc3339_utc_millis(s: &str) -> Option<i64> {
+    let bytes = s.as_bytes();
+    if bytes.len() != 20 || bytes[4] != b'-' || bytes[7] != b'-' || bytes[10] != b'T' {
+        return None;
+    }
+    if bytes[13] != b':' || bytes[16] != b':' || bytes[19] != b'Z' {
+        return None;
+    }
+    let num = |r: std::ops::Range<usize>| -> Option<i64> { s.get(r)?.parse().ok() };
+    let (y, m, d) = (num(0..4)?, num(5..7)?, num(8..10)?);
+    let (hh, mm, ss) = (num(11..13)?, num(14..16)?, num(17..19)?);
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) || hh > 23 || mm > 59 || ss > 60 {
+        return None;
+    }
+    // Howard Hinnant's days-from-civil (the inverse of `render::civil_from_days`).
+    let yy = if m <= 2 { y - 1 } else { y };
+    let era = if yy >= 0 { yy } else { yy - 399 } / 400;
+    let yoe = yy - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+    Some((days * 86_400 + hh * 3600 + mm * 60 + ss) * 1000)
+}
+
 /// The device-code CHALLENGE the loopback approval URL carries (hex sha256 of the flow's device
 /// code) — the approval card resolves with zero typing while the short code never rides a URL.
 pub(crate) fn device_challenge(device_code: &str) -> String {

--- a/bins/topos/src/ops/log.rs
+++ b/bins/topos/src/ops/log.rs
@@ -295,10 +295,17 @@ fn plane_version_event(v: &WireLogVersion) -> serde_json::Value {
 }
 
 /// A plane proposal event (open + every resolution).
+///
+/// `at` is WHEN THE PROPOSAL WAS OPENED — the one instant the row records for itself, and the one it
+/// always has (a resolution is rendered in the line's own words, and moving the row to the day it was
+/// rejected would file "proposed by X" away from when X did it). The server stamps it as a string, so
+/// it is parsed here; a spelling this client cannot read leaves the row undated rather than dated
+/// wrong, and the merge keeps it beside the neighbour it arrived next to.
 fn plane_proposal_event(p: &WireLogProposal) -> serde_json::Value {
     json!({
         "action": "proposal",
         "source": "plane",
+        "at": super::parse_rfc3339_utc_millis(&p.created_at),
         "version_id": p.version_id,
         "proposer": p.proposer,
         "status": p.status,
@@ -442,6 +449,64 @@ mod tests {
     fn a_history_where_nothing_carries_a_time_is_left_exactly_as_it_was() {
         let events = order_newest_first(vec![undated("a"), undated("b"), undated("c")]);
         assert_eq!(tags(&events), ["a", "b", "c"]);
+    }
+
+    fn proposal(created_at: &str) -> WireLogProposal {
+        WireLogProposal {
+            version_id: "f".repeat(64),
+            proposer: "Mia <mia@topos.sh>".to_owned(),
+            status: "open".to_owned(),
+            resolved_by: None,
+            resolved_reason: None,
+            resolved_at: None,
+            created_at: created_at.to_owned(),
+        }
+    }
+
+    #[test]
+    fn a_proposal_is_dated_by_when_it_was_opened() {
+        // The server stamps `created_at` as a string; the merge orders by `at`, so a proposal that
+        // stayed undated could sort ahead of an action that happened after it.
+        let event = plane_proposal_event(&proposal("2023-11-15T22:13:20Z"));
+        assert_eq!(event["at"].as_i64(), Some(1_700_086_400_000));
+    }
+
+    #[test]
+    fn a_stamp_this_client_cannot_read_leaves_the_proposal_undated() {
+        // Undated beats dated-wrong: the merge then keeps the row beside the neighbour it arrived
+        // next to, rather than filing it under a guess.
+        for unreadable in [
+            "",
+            "yesterday",
+            "2023-11-15T22:13:20.500Z",
+            "2023-11-15 22:13:20Z",
+        ] {
+            let event = plane_proposal_event(&proposal(unreadable));
+            assert!(event["at"].is_null(), "{unreadable}: {event}");
+        }
+    }
+
+    #[test]
+    fn an_old_proposal_sinks_below_the_action_that_happened_after_it() {
+        // The exact symptom the stamp fixes. Proposals arrive LAST in the merge, so an undated one
+        // inherited the key of the newest thing above it — the plane version here — and rode up
+        // past a local action it predates by a day. Its own date puts it where it belongs.
+        let events = assemble_log_events(
+            vec![dated("add", 1_700_000_000_000)],
+            Vec::new(),
+            vec![dated("v", 1_700_086_400_000)],
+            vec![plane_proposal_event(&proposal("2023-11-13T22:13:20Z"))],
+            &HashSet::new(),
+        );
+        let order: Vec<&str> = events
+            .iter()
+            .map(|e| {
+                e.get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or_else(|| e.get("action").and_then(Value::as_str).unwrap_or("?"))
+            })
+            .collect();
+        assert_eq!(order, ["v", "add", "proposal"], "{events:?}");
     }
 
     #[test]

--- a/bins/topos/src/ops/mod.rs
+++ b/bins/topos/src/ops/mod.rs
@@ -80,9 +80,12 @@ pub(crate) use claim::claim;
 pub(crate) use claim::digest_in_history;
 pub(crate) use connect::device_challenge;
 pub(crate) use dest_select::Selection;
-// The RFC-3339 emitter round-trips against the render parser's test.
+// The RFC-3339 pair: the parser reads the server's stamped strings (a proposal's `created_at`, a
+// pending flow's expiry); the emitter is used inside `connect` itself and re-exported for the
+// round-trip test alone.
 #[cfg(test)]
 pub(crate) use connect::fmt_rfc3339_millis;
+pub(crate) use connect::parse_rfc3339_utc_millis;
 // The built-in suite drives the refresh seam + the provenance matcher directly.
 pub(crate) use auth::{AuthConnectors, AuthStatusData, status};
 #[cfg(test)]

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -61,9 +61,11 @@ caller.
   baseline everyone-row is unassignable at the data layer), upstream provenance
   (`bundle_upstream`/`version_upstream`), the MCP SERVER CATALOG (`mcp_server` +
   `mcp_server_revision` + `bundle_mcp` — see the MCP lane below), notices, proposals + comments,
-  op receipts, `device_owner` (which PERSON a machine publishes as — a version's author is part of
-  its identity and is never rewritten, so who signed it is resolved at render time from what the
-  publishing session knew), `audit_event`, `mail_event`.
+  op receipts, `version_author` (WHO published each version — the commit frame's author is part of
+  the version's identity and is never rewritten, so the acting person is recorded per version, in
+  the same transaction as the accepted write, and resolved at render time; `device_owner` is its
+  append-only fallback for versions written before it, and names a person only for a machine this
+  workspace has seen publish as exactly one), `audit_event`, `mail_event`.
 - **The DAL** (`app/lib/db/queries*.server.ts`) is the one sanctioned door to `web` AND the
   read-only `plane` custody mirror. Every function REQUIRES a branded actor as its first
   argument; mutating ops emit their audit row in the SAME transaction. One named exception: the

--- a/web/app/lib/api/publish-flow.server.ts
+++ b/web/app/lib/api/publish-flow.server.ts
@@ -19,8 +19,8 @@ import {
   openProposalInTx,
   placeIntoChannelInTx,
   publishTargetOf,
+  recordVersionAuthorInTx,
   registerGenesisBundleInTx,
-  rememberDeviceOwner,
 } from "@/lib/db/queries.custody.server";
 import { commitVersion, publishVersion } from "@/lib/plane/custody.server";
 
@@ -114,10 +114,6 @@ export async function publishFlow(args: PublishFlowArgs): Promise<Response> {
     // Two-parent author merges stay unaccepted (the custody lane commits one parent).
     return badRequest("two-parent author merges are not accepted");
   }
-  // The session names the person and the frame names the machine — the only place the two are
-  // seen together. Remembering the pairing is what lets this version's author render as a person
-  // later, without a byte of the identity-bearing commit frame changing.
-  await rememberDeviceOwner(actor, candidate.author);
   const createdAt = receiptNow();
   const target = await publishTargetOf(actor, skillId);
   const isGenesis = target === undefined;
@@ -219,6 +215,15 @@ export async function publishFlow(args: PublishFlowArgs): Promise<Response> {
     }
     const envelope = await inFinalTx(async (tx) => {
       await openProposalInTx(tx, actor, target.bundleId, committed.value.version_id);
+      // The candidate is committed — this person authored THAT version, whatever the review
+      // decides about it later, and whoever this machine belongs to next.
+      await recordVersionAuthorInTx(
+        tx,
+        actor,
+        target.bundleId,
+        committed.value.version_id,
+        candidate.author,
+      );
       const details: Record<string, unknown> = args.forceProposal ? {} : { downgraded: true };
       if (channel !== null) {
         details.placement = await placeIntoChannelInTx(tx, actor, target.bundleId, channel);
@@ -273,6 +278,13 @@ export async function publishFlow(args: PublishFlowArgs): Promise<Response> {
       destination: channel,
       alsoInTx: async (tx, registered) => {
         const details: Record<string, unknown> = {};
+        await recordVersionAuthorInTx(
+          tx,
+          actor,
+          registered.bundleId,
+          registered.versionId,
+          candidate.author,
+        );
         if (registered.placement !== undefined) {
           details.placement = registered.placement;
         }
@@ -403,6 +415,13 @@ export async function publishFlow(args: PublishFlowArgs): Promise<Response> {
 
   const details: Record<string, unknown> = {};
   const landed = await inFinalTx(async (tx) => {
+    await recordVersionAuthorInTx(
+      tx,
+      actor,
+      bundleId,
+      published.value.version_id,
+      candidate.author,
+    );
     if (isGenesis) {
       const registration = await registerGenesisBundleInTx(
         tx,

--- a/web/app/lib/browse/version-files.server.ts
+++ b/web/app/lib/browse/version-files.server.ts
@@ -1,5 +1,5 @@
 import type { MemberActor } from "@/lib/auth/guards.server";
-import { authorDisplayMap, displayAuthor } from "@/lib/db/queries.custody.server";
+import { displayAuthor, versionAuthorDisplays } from "@/lib/db/queries.custody.server";
 import { classifyBytes, decodeTextVerbatim } from "@/lib/diff/classify";
 import { MAX_BLOB_BYTES } from "@/lib/diff/model";
 import { custodyObjectCapped, custodyVersionMeta } from "@/lib/plane/reads.server";
@@ -54,8 +54,9 @@ export async function loadVersionFilesData(
   const version = meta.data;
   const entries = buildListing(version.files);
   const authorDisplay = displayAuthor(
+    versionId,
     version.author,
-    await authorDisplayMap(actor, [version.author]),
+    await versionAuthorDisplays(actor, skillId, [{ versionId, author: version.author }]),
   );
 
   const doc = docFileOf(version.files);

--- a/web/app/lib/db/queries.custody.server.ts
+++ b/web/app/lib/db/queries.custody.server.ts
@@ -11,6 +11,7 @@ import {
   notice,
   opReceipt,
   proposal,
+  versionAuthor,
   workspace,
 } from "@/lib/db/schema.app";
 import { user } from "@/lib/db/schema.auth";
@@ -330,7 +331,7 @@ export async function versionCreatedAtMap(
   return new Map(rows.map((r) => [r.versionId, r.createdAt]));
 }
 
-// ── Who a machine publishes as (the author display-time key) ────────────────────────────────
+// ── Who authored a version (the display-time key) ───────────────────────────────────────────
 
 /**
  * The commit-author string a client signs with: `d_` + 32 lowercase hex. Anything else is a
@@ -345,61 +346,120 @@ export function isDeviceAuthor(author: string): boolean {
 }
 
 /**
- * Remember that THIS machine publishes as THIS person, so a version signed with a machine id
- * can be rendered as its author afterwards.
+ * Record WHO published this version — the acting person against the one version they published.
  *
- * Called wherever the session lane accepts a candidate frame: the session names the person, the
- * frame names the machine, and the two are only ever seen together here. Deliberately outside
- * the publish's own transaction — the pairing is true whether or not the publish lands, and a
- * failure to record it must never fail a publish. Idempotent: a repeat only moves `last_seen_at`.
+ * Called from inside the transaction that lands an ACCEPTED write (a publish, a proposal's
+ * ingest, a revert's forward commit) and nowhere else, so a refused op records nothing and
+ * authorship is bound to a version rather than to a machine. The row is written once and never
+ * rewritten: the same machine signing in as someone else later authors ITS OWN versions and
+ * relabels none of the ones already here.
+ *
+ * The `device_owner` row beside it is the fallback for versions written BEFORE this table
+ * existed — an append-only observation, first write per person wins, and a machine seen as two
+ * people ends up naming neither (see [`versionAuthorDisplays`]).
  */
-export async function rememberDeviceOwner(actor: PublishActor, author: string): Promise<void> {
+export async function recordVersionAuthorInTx(
+  tx: Tx,
+  actor: PublishActor,
+  bundleId: string,
+  versionId: string,
+  author: string,
+): Promise<void> {
+  await tx
+    .insert(versionAuthor)
+    .values({ workspaceId: actor.workspaceId, bundleId, versionId, userId: actor.userId })
+    .onConflictDoNothing({ target: [versionAuthor.bundleId, versionAuthor.versionId] });
   if (!isDeviceAuthor(author)) {
     return;
   }
-  try {
-    await getDb()
-      .insert(deviceOwner)
-      .values({ workspaceId: actor.workspaceId, deviceId: author, userId: actor.userId })
-      .onConflictDoUpdate({
-        target: [deviceOwner.workspaceId, deviceOwner.deviceId],
-        set: { userId: actor.userId, lastSeenAt: new Date() },
-      });
-  } catch {
-    // A display convenience is never worth a failed publish.
-  }
+  await tx
+    .insert(deviceOwner)
+    .values({ workspaceId: actor.workspaceId, deviceId: author, userId: actor.userId })
+    .onConflictDoNothing();
+}
+
+/** One version as the display resolver reads it: its id and the author custody recorded. */
+export interface RecordedAuthor {
+  versionId: string;
+  author: string;
 }
 
 /**
- * The people behind a set of recorded authors — the display-time half. Authors that are not
- * machine ids pass through untouched (they are already a person's own attribution), and a
- * machine this workspace has never seen publish is simply absent, so the caller keeps the id
- * the version was signed with rather than inventing a name for it.
+ * WHO to show as each version's author, keyed by version id.
+ *
+ * Two sources, in order. `version_author` is the authority: it names the person who published
+ * that exact version, so a machine that has since changed hands cannot touch it. A version with
+ * no such row predates the table, and only then does the machine-level fallback speak — and only
+ * when it is unambiguous: a device this workspace has seen publish as exactly ONE person names
+ * them, a device seen as two names nobody. Versions absent from the returned map keep the author
+ * they were signed with, which for a machine id means the id itself.
  */
-export async function authorDisplayMap(
+export async function versionAuthorDisplays(
   // Every surface that renders an author reads it: the session lane's log (a SessionActor or a
   // machine token) and the web's own bundle pages (a MemberActor). Only the workspace scope is
   // used — this read asks no other question of the actor.
   actor: ReadActor | MemberActor,
-  authors: readonly string[],
+  bundleId: string,
+  versions: readonly RecordedAuthor[],
 ): Promise<Map<string, string>> {
-  const devices = [...new Set(authors.filter(isDeviceAuthor))];
-  if (devices.length === 0) {
-    return new Map();
+  const display = new Map<string, string>();
+  if (versions.length === 0) {
+    return display;
   }
-  const rows = await getDb()
+  const db = getDb();
+  const ids = [...new Set(versions.map((v) => v.versionId))];
+  const authored = await db
+    .select({ versionId: versionAuthor.versionId, name: user.name, email: user.email })
+    .from(versionAuthor)
+    .innerJoin(user, eq(user.id, versionAuthor.userId))
+    .where(
+      and(
+        eq(versionAuthor.workspaceId, actor.workspaceId),
+        eq(versionAuthor.bundleId, bundleId),
+        inArray(versionAuthor.versionId, ids),
+      ),
+    );
+  for (const row of authored) {
+    display.set(row.versionId, personAttribution(row.name, row.email));
+  }
+
+  // The fallback, for versions this app has no author row for at all.
+  const orphans = versions.filter((v) => !display.has(v.versionId) && isDeviceAuthor(v.author));
+  const devices = [...new Set(orphans.map((v) => v.author))];
+  if (devices.length === 0) {
+    return display;
+  }
+  const observed = await db
     .select({ deviceId: deviceOwner.deviceId, name: user.name, email: user.email })
     .from(deviceOwner)
     .innerJoin(user, eq(user.id, deviceOwner.userId))
     .where(
       and(eq(deviceOwner.workspaceId, actor.workspaceId), inArray(deviceOwner.deviceId, devices)),
     );
-  return new Map(rows.map((r) => [r.deviceId, personAttribution(r.name, r.email)]));
+  const byDevice = new Map<string, string | null>();
+  for (const row of observed) {
+    // A SECOND person on the same machine settles it as unknowable — never a coin toss.
+    byDevice.set(
+      row.deviceId,
+      byDevice.has(row.deviceId) ? null : personAttribution(row.name, row.email),
+    );
+  }
+  for (const orphan of orphans) {
+    const person = byDevice.get(orphan.author);
+    if (person != null) {
+      display.set(orphan.versionId, person);
+    }
+  }
+  return display;
 }
 
-/** One recorded author as a person, or the author verbatim when nothing names them. */
-export function displayAuthor(author: string, people: Map<string, string>): string {
-  return people.get(author) ?? author;
+/** One version's author as a person, or the author custody recorded when nothing names them. */
+export function displayAuthor(
+  versionId: string,
+  author: string,
+  people: Map<string, string>,
+): string {
+  return people.get(versionId) ?? author;
 }
 
 export interface GenesisRegistration {

--- a/web/app/lib/db/schema.app.ts
+++ b/web/app/lib/db/schema.app.ts
@@ -1242,22 +1242,60 @@ export const proposalComment = webSchema.table(
   ],
 );
 
-// ── Who a machine's commit-author id belongs to ─────────────────────────────────────────────
+// ── Who authored a version ──────────────────────────────────────────────────────────────────
 
 /**
- * WHICH PERSON A MACHINE PUBLISHES AS — the display-time key for a version's recorded author.
+ * WHO PUBLISHED THIS VERSION — the display-time key for a version's recorded author.
  *
  * A version's author is part of its identity: the client derives the version id from
  * `(parents, tree, author, message)` and verifies the server landed exactly that id, so what
  * the commit frame carries is the machine's own `d_…` id and can never be rewritten into a
  * person's name — not at publish time, and certainly not afterwards. But the session that sent
- * the candidate DOES know the person, so the app writes that pairing down here and resolves it
- * when it renders. The stored history is untouched; only the reading of it changes.
+ * the candidate DOES know the person, so the app writes it down HERE, against the one version
+ * that person actually published. The stored history is untouched; only the reading of it
+ * changes.
  *
- * One row per (workspace, machine). It outlives the session that taught it — a person logging a
- * machine out does not un-author their versions — and dies with the workspace or the person.
- * A machine that has not published since this table existed simply has no row, and its versions
- * keep showing the id they were signed with.
+ * ONE ROW PER VERSION, written in the same transaction as the accepted write and never
+ * rewritten. That is what makes authorship per-version: the same machine signing in as someone
+ * else later authors ITS OWN versions and relabels nobody else's, and an op that was refused
+ * leaves no row at all. The row outlives the session that wrote it — logging a machine out does
+ * not un-author its versions — and dies with the bundle or the person.
+ */
+export const versionAuthor = webSchema.table(
+  "version_author",
+  {
+    workspaceId: text("workspace_id").notNull(),
+    bundleId: text("bundle_id").notNull(),
+    versionId: text("version_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.bundleId, table.versionId] }),
+    index("version_author_user_idx").on(table.userId),
+    foreignKey({
+      name: "version_author_bundle_fk",
+      columns: [table.bundleId, table.workspaceId],
+      foreignColumns: [bundle.id, bundle.workspaceId],
+    }).onDelete("cascade"),
+  ],
+);
+
+/**
+ * WHICH PEOPLE A MACHINE HAS PUBLISHED AS — the FALLBACK for versions written before
+ * `version_author` existed, and only for those.
+ *
+ * A machine id is not a person and never became one: one laptop can be signed in as different
+ * people over its life. So this table does not claim a machine's owner, it OBSERVES: one
+ * append-only row per (workspace, machine, person), never updated, never deleted. A device with
+ * exactly one row names that person for its pre-table versions; a device with two rows names
+ * nobody, and those versions keep showing the id they were signed with. Guessing between two
+ * people is worse than showing the machine.
+ *
+ * Rows are written only where a write was ACCEPTED, beside the `version_author` row of the same
+ * op — so a refused publish teaches this table nothing either.
  */
 export const deviceOwner = webSchema.table(
   "device_owner",
@@ -1271,10 +1309,11 @@ export const deviceOwner = webSchema.table(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).defaultNow().notNull(),
-    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
-    primaryKey({ columns: [table.workspaceId, table.deviceId] }),
+    // The PERSON is part of the key: a second person on the same machine ADDS a row rather than
+    // taking the first one's place, which is what makes the ambiguity visible instead of silent.
+    primaryKey({ columns: [table.workspaceId, table.deviceId, table.userId] }),
     index("device_owner_user_idx").on(table.userId),
   ],
 );

--- a/web/app/routes/api.v1.reverts.ts
+++ b/web/app/routes/api.v1.reverts.ts
@@ -18,7 +18,7 @@ import {
   inFinalTx,
   insertReceiptInTx,
   publishTargetOf,
-  rememberDeviceOwner,
+  recordVersionAuthorInTx,
   versionOutsideHistoryWindow,
 } from "@/lib/db/queries.custody.server";
 import { revertPointer } from "@/lib/plane/custody.server";
@@ -156,9 +156,8 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
   // the forward id from `(parents, tree, author, message)` and will verify the served pointer
   // names exactly that version, so the custody lane records the wire's author + message
   // verbatim (a substituted display string would derive a different id and the client would
-  // refuse the OK). What CAN be recorded is who that machine is: the pairing lives beside the
-  // history, and the reading of the author resolves through it.
-  await rememberDeviceOwner(actor, author);
+  // refuse the OK). What CAN be recorded is who published the forward commit — beside the
+  // history, once it has landed, and the reading of the author resolves through it.
   const reverted = await revertPointer(actor.workspaceId, target.bundleId, {
     to_version_id: good,
     expected_generation: head.expected,
@@ -196,6 +195,7 @@ export async function action({ request }: ActionFunctionArgs): Promise<Response>
     return internalError();
   }
   const envelope = await inFinalTx(async (tx) => {
+    await recordVersionAuthorInTx(tx, actor, target.bundleId, reverted.value.version_id, author);
     await auditInTx(tx, {
       workspaceId: actor.workspaceId,
       actor: { userId: actor.userId, sessionId: actor.sessionId, display: actor.display },

--- a/web/app/routes/api.v1.skill-log.ts
+++ b/web/app/routes/api.v1.skill-log.ts
@@ -2,7 +2,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { laneGate } from "@/lib/api/compat.server";
 import { NO_STORE, uniformNotFound } from "@/lib/api/wire.server";
 import { requireSessionActor } from "@/lib/auth/guards.server";
-import { authorDisplayMap, displayAuthor } from "@/lib/db/queries.custody.server";
+import { displayAuthor, versionAuthorDisplays } from "@/lib/db/queries.custody.server";
 import { laneLogOf } from "@/lib/db/queries.lane.server";
 import { custodyLog } from "@/lib/plane/reads.server";
 
@@ -24,12 +24,15 @@ export async function loader({ request, params }: LoaderFunctionArgs): Promise<R
   const { identity, proposals } = decorated;
   const log = await custodyLog(actor.workspaceId, identity.bundleId);
   // A version's recorded author is the MACHINE that signed it — the commit frame's author is
-  // part of the version's identity and can never be rewritten. Who that machine publishes as is
-  // this tier's own record, so the author is resolved to a person on the way out; a machine this
-  // workspace has never seen publish keeps the id it signed with.
-  const people = await authorDisplayMap(
+  // part of the version's identity and can never be rewritten. WHO published each version is
+  // this tier's own record, so the author is resolved per version on the way out; a version
+  // nothing here names keeps the id it was signed with.
+  const people = await versionAuthorDisplays(
     actor,
-    log.ok ? log.data.versions.map((v) => v.author_display) : [],
+    identity.bundleId,
+    log.ok
+      ? log.data.versions.map((v) => ({ versionId: v.version_id, author: v.author_display }))
+      : [],
   );
   const iso = (d: Date) => d.toISOString().replace(/\.\d{3}Z$/, "Z");
   return Response.json(
@@ -47,7 +50,7 @@ export async function loader({ request, params }: LoaderFunctionArgs): Promise<R
             // WHEN it was committed, in the same field and units a `pull` event carries — the
             // custody row has always recorded it, and nothing downstream could show it.
             at: v.created_at_ms,
-            author: displayAuthor(v.author_display, people),
+            author: displayAuthor(v.version_id, v.author_display, people),
             message: v.message,
             current: index === 0,
             ...(v.purged_at_ms === undefined ? {} : { purged_at: v.purged_at_ms }),

--- a/web/app/routes/skill-history.tsx
+++ b/web/app/routes/skill-history.tsx
@@ -24,9 +24,9 @@ import {
 import { requireCanonicalBase } from "@/lib/bundle-base.server";
 import { recordAdminEvent } from "@/lib/db/audit.server";
 import {
-  authorDisplayMap,
   displayAuthor,
   historyWindowDays,
+  versionAuthorDisplays,
   versionCreatedAtMap,
   versionOutsideHistoryWindow,
 } from "@/lib/db/queries.custody.server";
@@ -150,12 +150,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }
     }
     // A version's recorded author is the MACHINE that signed it (the commit frame's author is
-    // part of the version's identity and is never rewritten). Who that machine publishes as is
-    // this tier's own record, so the rows render a person; a machine this workspace has never
-    // seen publish keeps the id it signed with.
-    const people = await authorDisplayMap(
+    // part of the version's identity and is never rewritten). WHO published each version is this
+    // tier's own record, so the rows render a person; a version nothing here names keeps the id
+    // it was signed with.
+    const people = await versionAuthorDisplays(
       actor,
-      page.steps.map((s) => s.author),
+      row.skillId,
+      page.steps.map((s) => ({ versionId: s.versionId, author: s.author })),
     );
     history = {
       published: true,
@@ -164,7 +165,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       expectedGeneration: String(row.generation),
       steps: page.steps.map((s) => ({
         ...s,
-        author: displayAuthor(s.author, people),
+        author: displayAuthor(s.versionId, s.author, people),
         locked: locked.has(s.versionId),
       })),
       cursor: page.cursor,

--- a/web/drizzle/0032_version-author.sql
+++ b/web/drizzle/0032_version-author.sql
@@ -1,0 +1,27 @@
+-- AUTHORSHIP IS PER VERSION. `device_owner` alone could not carry it: a machine id is not a
+-- person, so one laptop signing in as someone else re-pointed the mapping and relabelled every
+-- version that machine had ever published. `version_author` records the acting person against the
+-- one version they published, written in the same transaction as the accepted write and never
+-- rewritten.
+--
+-- `device_owner` stays as the fallback for versions written before this table, and becomes what it
+-- always should have been: an append-only OBSERVATION. The person joins its key, so a second
+-- person on the same machine adds a row instead of taking the first one's place — a device with
+-- two rows names nobody, and its pre-table versions keep showing the id they were signed with.
+-- `last_seen_at` goes with the updates that used to move it.
+
+CREATE TABLE "web"."version_author" (
+	"workspace_id" text NOT NULL,
+	"bundle_id" text NOT NULL,
+	"version_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "version_author_bundle_id_version_id_pk" PRIMARY KEY("bundle_id","version_id")
+);
+--> statement-breakpoint
+ALTER TABLE "web"."device_owner" DROP CONSTRAINT "device_owner_workspace_id_device_id_pk";--> statement-breakpoint
+ALTER TABLE "web"."device_owner" ADD CONSTRAINT "device_owner_workspace_id_device_id_user_id_pk" PRIMARY KEY("workspace_id","device_id","user_id");--> statement-breakpoint
+ALTER TABLE "web"."version_author" ADD CONSTRAINT "version_author_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "web"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "web"."version_author" ADD CONSTRAINT "version_author_bundle_fk" FOREIGN KEY ("bundle_id","workspace_id") REFERENCES "web"."bundle"("id","workspace_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "version_author_user_idx" ON "web"."version_author" USING btree ("user_id");--> statement-breakpoint
+ALTER TABLE "web"."device_owner" DROP COLUMN "last_seen_at";

--- a/web/drizzle/meta/0032_snapshot.json
+++ b/web/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,4518 @@
+{
+  "id": "d3236ec6-b97b-427c-8c5a-49b7e653b1a5",
+  "prevId": "467cced7-9ecf-4e46-ac0c-3492ee8ed21d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "web.account": {
+      "name": "account",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.session": {
+      "name": "session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_idx": {
+          "name": "session_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.user": {
+      "name": "user",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_email_lowercase": {
+          "name": "user_email_lowercase",
+          "value": "\"web\".\"user\".\"email\" = lower(\"web\".\"user\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.verification": {
+      "name": "verification",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expires_idx": {
+          "name": "verification_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.approval": {
+      "name": "approval",
+      "schema": "web",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer": {
+          "name": "reviewer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_reviewer_idx": {
+          "name": "approval_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_proposal_id_proposal_id_fk": {
+          "name": "approval_proposal_id_proposal_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "proposal",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_reviewer_user_id_fk": {
+          "name": "approval_reviewer_user_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "reviewer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "approval_proposal_id_reviewer_pk": {
+          "name": "approval_proposal_id_reviewer_pk",
+          "columns": [
+            "proposal_id",
+            "reviewer"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.assignment": {
+      "name": "assignment",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self": {
+          "name": "self",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_person_bundle_once": {
+          "name": "assignment_person_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_bundle_once": {
+          "name": "assignment_everyone_bundle_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "bundle_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_person_channel_once": {
+          "name": "assignment_person_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "self",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_everyone_channel_once": {
+          "name": "assignment_everyone_channel_once",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "channel_id is not null and user_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_ws_user_idx": {
+          "name": "assignment_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_bundle_idx": {
+          "name": "assignment_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_channel_idx": {
+          "name": "assignment_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_workspace_id_workspace_id_fk": {
+          "name": "assignment_workspace_id_workspace_id_fk",
+          "tableFrom": "assignment",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_seat_fk": {
+          "name": "assignment_seat_fk",
+          "tableFrom": "assignment",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_bundle_fk": {
+          "name": "assignment_bundle_fk",
+          "tableFrom": "assignment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_channel_fk": {
+          "name": "assignment_channel_fk",
+          "tableFrom": "assignment",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assignment_target_check": {
+          "name": "assignment_target_check",
+          "value": "(\"web\".\"assignment\".\"bundle_id\" is null) <> (\"web\".\"assignment\".\"channel_id\" is null)"
+        },
+        "assignment_self_check": {
+          "name": "assignment_self_check",
+          "value": "\"web\".\"assignment\".\"user_id\" is not null or not \"web\".\"assignment\".\"self\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.audit_event": {
+      "name": "audit_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "audit_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_session_id": {
+          "name": "actor_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display": {
+          "name": "actor_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_ws_time": {
+          "name": "audit_ws_time",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_user": {
+          "name": "audit_actor_user",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_user_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_actor_session": {
+          "name": "audit_actor_session",
+          "columns": [
+            {
+              "expression": "actor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "actor_session_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_invite_subject": {
+          "name": "audit_invite_subject",
+          "columns": [
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "kind = 'invitation_created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_event_actor_user_id_user_id_fk": {
+          "name": "audit_event_actor_user_id_user_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_event_actor_session_id_cli_session_id_fk": {
+          "name": "audit_event_actor_session_id_cli_session_id_fk",
+          "tableFrom": "audit_event",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "actor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle": {
+      "name": "bundle",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "protection": {
+          "name": "protection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_name": {
+          "name": "base_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundle_workspace_id_workspace_id_fk": {
+          "name": "bundle_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_created_by_user_id_fk": {
+          "name": "bundle_created_by_user_id_fk",
+          "tableFrom": "bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_workspace_id_name_unique": {
+          "name": "bundle_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "bundle_id_workspace_id_unique": {
+          "name": "bundle_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bundle_name_check": {
+          "name": "bundle_name_check",
+          "value": "\"web\".\"bundle\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"bundle\".\"name\") <= 200"
+        },
+        "bundle_kind_check": {
+          "name": "bundle_kind_check",
+          "value": "\"web\".\"bundle\".\"kind\" in ('skill', 'mcp')"
+        },
+        "bundle_status_check": {
+          "name": "bundle_status_check",
+          "value": "\"web\".\"bundle\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "bundle_protection_check": {
+          "name": "bundle_protection_check",
+          "value": "\"web\".\"bundle\".\"protection\" is null or \"web\".\"bundle\".\"protection\" in ('open', 'reviewed')"
+        },
+        "bundle_deleted_check": {
+          "name": "bundle_deleted_check",
+          "value": "(\"web\".\"bundle\".\"status\" = 'deleted') = (\"web\".\"bundle\".\"deleted_at\" is not null)"
+        },
+        "bundle_archived_check": {
+          "name": "bundle_archived_check",
+          "value": "\"web\".\"bundle\".\"status\" <> 'archived' or \"web\".\"bundle\".\"archived_at\" is not null"
+        },
+        "bundle_base_name_check": {
+          "name": "bundle_base_name_check",
+          "value": "\"web\".\"bundle\".\"base_name\" is null or \"web\".\"bundle\".\"status\" <> 'active'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.bundle_mcp": {
+      "name": "bundle_mcp",
+      "schema": "web",
+      "columns": {
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_revision_id": {
+          "name": "pinned_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_policy": {
+          "name": "gateway_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_mcp_server_idx": {
+          "name": "bundle_mcp_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_mcp_server_id_mcp_server_id_fk": {
+          "name": "bundle_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "mcp_server",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_created_by_user_id_fk": {
+          "name": "bundle_mcp_created_by_user_id_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_bundle_fk": {
+          "name": "bundle_mcp_bundle_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_mcp_pinned_revision_fk": {
+          "name": "bundle_mcp_pinned_revision_fk",
+          "tableFrom": "bundle_mcp",
+          "tableTo": "mcp_server_revision",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "pinned_revision_id",
+            "server_id"
+          ],
+          "columnsTo": [
+            "id",
+            "server_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bundle_mcp_workspace_server_unique": {
+          "name": "bundle_mcp_workspace_server_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bundle_mcp_gateway_policy_check": {
+          "name": "bundle_mcp_gateway_policy_check",
+          "value": "\"web\".\"bundle_mcp\".\"gateway_policy\" is null or \"web\".\"bundle_mcp\".\"gateway_policy\" in ('direct', 'required')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.bundle_name_hint": {
+      "name": "bundle_name_hint",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renamed_by": {
+          "name": "renamed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundle_name_hint_bundle_idx": {
+          "name": "bundle_name_hint_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_name_hint_workspace_id_workspace_id_fk": {
+          "name": "bundle_name_hint_workspace_id_workspace_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_bundle_id_bundle_id_fk": {
+          "name": "bundle_name_hint_bundle_id_bundle_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_name_hint_renamed_by_user_id_fk": {
+          "name": "bundle_name_hint_renamed_by_user_id_fk",
+          "tableFrom": "bundle_name_hint",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "renamed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_name_hint_workspace_id_old_name_pk": {
+          "name": "bundle_name_hint_workspace_id_old_name_pk",
+          "columns": [
+            "workspace_id",
+            "old_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.bundle_upstream": {
+      "name": "bundle_upstream",
+      "schema": "web",
+      "columns": {
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_commit": {
+          "name": "last_seen_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bundle_upstream_ws_idx": {
+          "name": "bundle_upstream_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundle_upstream_bundle_fk": {
+          "name": "bundle_upstream_bundle_fk",
+          "tableFrom": "bundle_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bundle_upstream_repo_check": {
+          "name": "bundle_upstream_repo_check",
+          "value": "\"web\".\"bundle_upstream\".\"repo\" ~ '^[^/]+/[^/]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel": {
+      "name": "channel",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_one_default": {
+          "name": "channel_one_default",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_workspace_id_workspace_id_fk": {
+          "name": "channel_workspace_id_workspace_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_created_by_user_id_fk": {
+          "name": "channel_created_by_user_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "channel_workspace_id_name_unique": {
+          "name": "channel_workspace_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "channel_id_workspace_id_unique": {
+          "name": "channel_id_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "channel_mode_check": {
+          "name": "channel_mode_check",
+          "value": "\"web\".\"channel\".\"mode\" in ('open', 'curated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.channel_bundle": {
+      "name": "channel_bundle",
+      "schema": "web",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bundle_bundle_idx": {
+          "name": "channel_bundle_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bundle_added_by_user_id_fk": {
+          "name": "channel_bundle_added_by_user_id_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_channel_fk": {
+          "name": "channel_bundle_channel_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "channel",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "channel_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_bundle_bundle_fk": {
+          "name": "channel_bundle_bundle_fk",
+          "tableFrom": "channel_bundle",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_bundle_channel_id_bundle_id_pk": {
+          "name": "channel_bundle_channel_id_bundle_id_pk",
+          "columns": [
+            "channel_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.cli_session": {
+      "name": "cli_session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_sha256": {
+          "name": "credential_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cli_session_workspace_idx": {
+          "name": "cli_session_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_session_user_idx": {
+          "name": "cli_session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_session_seat_fk": {
+          "name": "cli_session_seat_fk",
+          "tableFrom": "cli_session",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_session_credential_sha256_unique": {
+          "name": "cli_session_credential_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_session_status_check": {
+          "name": "cli_session_status_check",
+          "value": "\"web\".\"cli_session\".\"status\" in ('pending', 'active')"
+        },
+        "cli_session_credential_sha256_check": {
+          "name": "cli_session_credential_sha256_check",
+          "value": "octet_length(\"web\".\"cli_session\".\"credential_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.decline": {
+      "name": "decline",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "decline_ws_user_idx": {
+          "name": "decline_ws_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decline_seat_fk": {
+          "name": "decline_seat_fk",
+          "tableFrom": "decline",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "decline_bundle_fk": {
+          "name": "decline_bundle_fk",
+          "tableFrom": "decline",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decline_user_id_bundle_id_unique": {
+          "name": "decline_user_id_bundle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.device_owner": {
+      "name": "device_owner",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_owner_user_idx": {
+          "name": "device_owner_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_owner_workspace_id_workspace_id_fk": {
+          "name": "device_owner_workspace_id_workspace_id_fk",
+          "tableFrom": "device_owner",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_owner_user_id_user_id_fk": {
+          "name": "device_owner_user_id_user_id_fk",
+          "tableFrom": "device_owner",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "device_owner_workspace_id_device_id_user_id_pk": {
+          "name": "device_owner_workspace_id_device_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "device_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.invitation": {
+      "name": "invitation",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_sha256": {
+          "name": "token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_bundle_id": {
+          "name": "hint_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint_channel_id": {
+          "name": "hint_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_pending_once": {
+          "name": "invitation_pending_once",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_workspace_id_workspace_id_fk": {
+          "name": "invitation_workspace_id_workspace_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitation_accepted_by_user_id_fk": {
+          "name": "invitation_accepted_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_sha256_unique": {
+          "name": "invitation_token_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_email_check": {
+          "name": "invitation_email_check",
+          "value": "\"web\".\"invitation\".\"email\" = lower(\"web\".\"invitation\".\"email\")"
+        },
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"web\".\"invitation\".\"role\" in ('owner', 'reviewer', 'member')"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "\"web\".\"invitation\".\"status\" in ('pending', 'accepted', 'revoked', 'declined')"
+        },
+        "invitation_token_sha256_check": {
+          "name": "invitation_token_sha256_check",
+          "value": "\"web\".\"invitation\".\"token_sha256\" is null or octet_length(\"web\".\"invitation\".\"token_sha256\") = 32"
+        },
+        "invitation_hint_one_check": {
+          "name": "invitation_hint_one_check",
+          "value": "\"web\".\"invitation\".\"hint_bundle_id\" is null or \"web\".\"invitation\".\"hint_channel_id\" is null"
+        },
+        "invitation_accepted_check": {
+          "name": "invitation_accepted_check",
+          "value": "(\"web\".\"invitation\".\"status\" = 'accepted') = (\"web\".\"invitation\".\"accepted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.login_flow": {
+      "name": "login_flow",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_code_sha256": {
+          "name": "flow_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_name": {
+          "name": "requested_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preselect_workspace": {
+          "name": "preselect_workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_workspace_id": {
+          "name": "approved_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token_sha256": {
+          "name": "invite_token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "login_flow_live_code": {
+          "name": "login_flow_live_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "login_flow_expires_idx": {
+          "name": "login_flow_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "login_flow_approved_by_user_id_fk": {
+          "name": "login_flow_approved_by_user_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "login_flow_session_id_cli_session_id_fk": {
+          "name": "login_flow_session_id_cli_session_id_fk",
+          "tableFrom": "login_flow",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "login_flow_flow_code_sha256_unique": {
+          "name": "login_flow_flow_code_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flow_code_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "login_flow_flow_code_sha256_check": {
+          "name": "login_flow_flow_code_sha256_check",
+          "value": "octet_length(\"web\".\"login_flow\".\"flow_code_sha256\") = 32"
+        },
+        "login_flow_invite_token_sha256_check": {
+          "name": "login_flow_invite_token_sha256_check",
+          "value": "\"web\".\"login_flow\".\"invite_token_sha256\" is null or octet_length(\"web\".\"login_flow\".\"invite_token_sha256\") = 32"
+        },
+        "login_flow_status_check": {
+          "name": "login_flow_status_check",
+          "value": "\"web\".\"login_flow\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "login_flow_binding_check": {
+          "name": "login_flow_binding_check",
+          "value": "\"web\".\"login_flow\".\"binding\" in ('device', 'loopback')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.machine_token": {
+      "name": "machine_token",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_sha256": {
+          "name": "token_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machine_token_workspace_idx": {
+          "name": "machine_token_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_token_workspace_id_workspace_id_fk": {
+          "name": "machine_token_workspace_id_workspace_id_fk",
+          "tableFrom": "machine_token",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_token_created_by_user_id_fk": {
+          "name": "machine_token_created_by_user_id_fk",
+          "tableFrom": "machine_token",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_token_token_sha256_unique": {
+          "name": "machine_token_token_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "machine_token_sha256_check": {
+          "name": "machine_token_sha256_check",
+          "value": "octet_length(\"web\".\"machine_token\".\"token_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mail_event": {
+      "name": "mail_event",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_event_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_event_time_idx": {
+          "name": "mail_event_time_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mail_event_kind_check": {
+          "name": "mail_event_kind_check",
+          "value": "\"web\".\"mail_event\".\"kind\" in ('magic-link', 'invite', 'auth-verify', 'auth-reset')"
+        },
+        "mail_event_outcome_check": {
+          "name": "mail_event_outcome_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" in ('ok', 'failed')"
+        },
+        "mail_event_code_check": {
+          "name": "mail_event_code_check",
+          "value": "\"web\".\"mail_event\".\"code\" is null or \"web\".\"mail_event\".\"code\" in ('unconfigured', 'send_failed')"
+        },
+        "mail_event_code_on_failure_check": {
+          "name": "mail_event_code_on_failure_check",
+          "value": "\"web\".\"mail_event\".\"outcome\" = 'failed' or \"web\".\"mail_event\".\"code\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_gateway_optout": {
+      "name": "mcp_gateway_optout",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_gateway_optout_seat_fk": {
+          "name": "mcp_gateway_optout_seat_fk",
+          "tableFrom": "mcp_gateway_optout",
+          "tableTo": "seat",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_gateway_optout_connection_fk": {
+          "name": "mcp_gateway_optout_connection_fk",
+          "tableFrom": "mcp_gateway_optout",
+          "tableTo": "bundle_mcp",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "server_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "server_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_gateway_optout_workspace_id_server_id_user_id_pk": {
+          "name": "mcp_gateway_optout_workspace_id_server_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "server_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.mcp_server": {
+      "name": "mcp_server",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_note": {
+          "name": "auth_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_menu": {
+          "name": "scope_menu",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "manually_curated": {
+          "name": "manually_curated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_server_public_name": {
+          "name": "mcp_server_public_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "workspace_id is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_private_name": {
+          "name": "mcp_server_private_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "workspace_id is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_workspace_idx": {
+          "name": "mcp_server_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_workspace_id_workspace_id_fk": {
+          "name": "mcp_server_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_current_revision_fk": {
+          "name": "mcp_server_current_revision_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "mcp_server_revision",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "current_revision_id",
+            "id"
+          ],
+          "columnsTo": [
+            "id",
+            "server_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_server_auth_mode_check": {
+          "name": "mcp_server_auth_mode_check",
+          "value": "\"web\".\"mcp_server\".\"auth_mode\" is null or \"web\".\"mcp_server\".\"auth_mode\" in ('none', 'oauth', 'manual')"
+        },
+        "mcp_server_status_check": {
+          "name": "mcp_server_status_check",
+          "value": "\"web\".\"mcp_server\".\"status\" in ('active', 'delisted')"
+        },
+        "mcp_server_name_check": {
+          "name": "mcp_server_name_check",
+          "value": "\"web\".\"mcp_server\".\"name\" is null or \"web\".\"mcp_server\".\"name\" ~ '^[^/]+/[^/]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_server_revision": {
+      "name": "mcp_server_revision",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_version": {
+          "name": "upstream_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probe_outcome": {
+          "name": "probe_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probed_at": {
+          "name": "probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_versions": {
+          "name": "protocol_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification": {
+          "name": "verification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_server_revision_upstream_version": {
+          "name": "mcp_server_revision_upstream_version",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upstream_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "upstream_version is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_revision_server_idx": {
+          "name": "mcp_server_revision_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_revision_server_id_mcp_server_id_fk": {
+          "name": "mcp_server_revision_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_server_revision",
+          "tableTo": "mcp_server",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_revision_seq_unique": {
+          "name": "mcp_server_revision_seq_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "server_id",
+            "seq"
+          ]
+        },
+        "mcp_server_revision_id_server_unique": {
+          "name": "mcp_server_revision_id_server_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mcp_server_revision_id_shape_check": {
+          "name": "mcp_server_revision_id_shape_check",
+          "value": "\"web\".\"mcp_server_revision\".\"id\" ~ '^mcpr_[0-9a-f]{32}$'"
+        },
+        "mcp_server_revision_seq_check": {
+          "name": "mcp_server_revision_seq_check",
+          "value": "\"web\".\"mcp_server_revision\".\"seq\" >= 1"
+        },
+        "mcp_server_revision_probe_outcome_check": {
+          "name": "mcp_server_revision_probe_outcome_check",
+          "value": "\"web\".\"mcp_server_revision\".\"probe_outcome\" is null or \"web\".\"mcp_server_revision\".\"probe_outcome\" in ('responding', 'sign_in_required', 'not_verifiable', 'not_responding')"
+        },
+        "mcp_server_revision_probed_check": {
+          "name": "mcp_server_revision_probed_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"probe_outcome\" is null) = (\"web\".\"mcp_server_revision\".\"probed_at\" is null)"
+        },
+        "mcp_server_revision_remote_check": {
+          "name": "mcp_server_revision_remote_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"url\" is null) = (\"web\".\"mcp_server_revision\".\"transport\" is null)"
+        },
+        "mcp_server_revision_url_check": {
+          "name": "mcp_server_revision_url_check",
+          "value": "\"web\".\"mcp_server_revision\".\"url\" is null or \"web\".\"mcp_server_revision\".\"url\" ~ '^https://'"
+        },
+        "mcp_server_revision_published_by_check": {
+          "name": "mcp_server_revision_published_by_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"published_at\" is null) = (\"web\".\"mcp_server_revision\".\"published_by\" is null)"
+        },
+        "mcp_server_revision_dismissed_by_check": {
+          "name": "mcp_server_revision_dismissed_by_check",
+          "value": "(\"web\".\"mcp_server_revision\".\"dismissed_at\" is null) = (\"web\".\"mcp_server_revision\".\"dismissed_by\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_tool_policy": {
+      "name": "mcp_tool_policy",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_tool_policy_updated_by_user_id_fk": {
+          "name": "mcp_tool_policy_updated_by_user_id_fk",
+          "tableFrom": "mcp_tool_policy",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_tool_policy_connection_fk": {
+          "name": "mcp_tool_policy_connection_fk",
+          "tableFrom": "mcp_tool_policy",
+          "tableTo": "bundle_mcp",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "server_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "server_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_tool_policy_workspace_id_server_id_pk": {
+          "name": "mcp_tool_policy_workspace_id_server_id_pk",
+          "columns": [
+            "workspace_id",
+            "server_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_tool_policy_mode_check": {
+          "name": "mcp_tool_policy_mode_check",
+          "value": "\"web\".\"mcp_tool_policy\".\"mode\" in ('all', 'selected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.mcp_tool_selection": {
+      "name": "mcp_tool_selection",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_tool_selection_policy_fk": {
+          "name": "mcp_tool_selection_policy_fk",
+          "tableFrom": "mcp_tool_selection",
+          "tableTo": "mcp_tool_policy",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id",
+            "server_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "server_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_tool_selection_workspace_id_server_id_tool_name_pk": {
+          "name": "mcp_tool_selection_workspace_id_server_id_tool_name_pk",
+          "columns": [
+            "workspace_id",
+            "server_id",
+            "tool_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.notice": {
+      "name": "notice",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notice_id_seq",
+            "schema": "web",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notice_inbox": {
+          "name": "notice_inbox",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "acked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notice_ws_idx": {
+          "name": "notice_ws_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notice_user_id_user_id_fk": {
+          "name": "notice_user_id_user_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notice_workspace_id_workspace_id_fk": {
+          "name": "notice_workspace_id_workspace_id_fk",
+          "tableFrom": "notice",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.op_receipt": {
+      "name": "op_receipt",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_id": {
+          "name": "op_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_sha256": {
+          "name": "request_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "op_receipt_retention_idx": {
+          "name": "op_receipt_retention_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "op_receipt_session_id_cli_session_id_fk": {
+          "name": "op_receipt_session_id_cli_session_id_fk",
+          "tableFrom": "op_receipt",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "op_receipt_workspace_id_session_id_op_id_pk": {
+          "name": "op_receipt_workspace_id_session_id_op_id_pk",
+          "columns": [
+            "workspace_id",
+            "session_id",
+            "op_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "op_receipt_request_sha256_check": {
+          "name": "op_receipt_request_sha256_check",
+          "value": "octet_length(\"web\".\"op_receipt\".\"request_sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal": {
+      "name": "proposal",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_version_id": {
+          "name": "candidate_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason": {
+          "name": "resolved_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_open": {
+          "name": "proposal_open",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_one_open_per_candidate": {
+          "name": "proposal_one_open_per_candidate",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_proposed_by_user_id_fk": {
+          "name": "proposal_proposed_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_resolved_by_user_id_fk": {
+          "name": "proposal_resolved_by_user_id_fk",
+          "tableFrom": "proposal",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_bundle_fk": {
+          "name": "proposal_bundle_fk",
+          "tableFrom": "proposal",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_status_check": {
+          "name": "proposal_status_check",
+          "value": "\"web\".\"proposal\".\"status\" in ('open', 'approved', 'rejected', 'withdrawn')"
+        },
+        "proposal_resolved_check": {
+          "name": "proposal_resolved_check",
+          "value": "(\"web\".\"proposal\".\"status\" = 'open') = (\"web\".\"proposal\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.proposal_comment": {
+      "name": "proposal_comment",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display": {
+          "name": "author_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_comment_thread_idx": {
+          "name": "proposal_comment_thread_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_comment_author_user_id_user_id_fk": {
+          "name": "proposal_comment_author_user_id_user_id_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proposal_comment_bundle_fk": {
+          "name": "proposal_comment_bundle_fk",
+          "tableFrom": "proposal_comment",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_comment_body_check": {
+          "name": "proposal_comment_body_check",
+          "value": "char_length(\"web\".\"proposal_comment\".\"body\") between 1 and 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.seat": {
+      "name": "seat",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seat_user_idx": {
+          "name": "seat_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seat_workspace_id_workspace_id_fk": {
+          "name": "seat_workspace_id_workspace_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_user_id_user_id_fk": {
+          "name": "seat_user_id_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seat_invited_by_user_id_fk": {
+          "name": "seat_invited_by_user_id_fk",
+          "tableFrom": "seat",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "seat_workspace_id_user_id_pk": {
+          "name": "seat_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "seat_role_check": {
+          "name": "seat_role_check",
+          "value": "\"web\".\"seat\".\"role\" in ('owner', 'reviewer', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "web.service_session": {
+      "name": "service_session",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_session_token_name_idx": {
+          "name": "service_session_token_name_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_session_workspace_idx": {
+          "name": "service_session_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_session_token_id_machine_token_id_fk": {
+          "name": "service_session_token_id_machine_token_id_fk",
+          "tableFrom": "service_session",
+          "tableTo": "machine_token",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_session_workspace_id_workspace_id_fk": {
+          "name": "service_session_workspace_id_workspace_id_fk",
+          "tableFrom": "service_session",
+          "tableTo": "workspace",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.session_bundle_state": {
+      "name": "session_bundle_state",
+      "schema": "web",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_version_id": {
+          "name": "applied_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_state": {
+          "name": "harness_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_bundle_state_bundle_idx": {
+          "name": "session_bundle_state_bundle_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_bundle_state_session_id_cli_session_id_fk": {
+          "name": "session_bundle_state_session_id_cli_session_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "cli_session",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_bundle_state_bundle_id_bundle_id_fk": {
+          "name": "session_bundle_state_bundle_id_bundle_id_fk",
+          "tableFrom": "session_bundle_state",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_bundle_state_session_id_bundle_id_pk": {
+          "name": "session_bundle_state_session_id_bundle_id_pk",
+          "columns": [
+            "session_id",
+            "bundle_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.version_author": {
+      "name": "version_author",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "version_author_user_idx": {
+          "name": "version_author_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "version_author_user_id_user_id_fk": {
+          "name": "version_author_user_id_user_id_fk",
+          "tableFrom": "version_author",
+          "tableTo": "user",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "version_author_bundle_fk": {
+          "name": "version_author_bundle_fk",
+          "tableFrom": "version_author",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "version_author_bundle_id_version_id_pk": {
+          "name": "version_author_bundle_id_version_id_pk",
+          "columns": [
+            "bundle_id",
+            "version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.version_upstream": {
+      "name": "version_upstream",
+      "schema": "web",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "version_upstream_bundle_fk": {
+          "name": "version_upstream_bundle_fk",
+          "tableFrom": "version_upstream",
+          "tableTo": "bundle",
+          "schemaTo": "web",
+          "columnsFrom": [
+            "bundle_id",
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id",
+            "workspace_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "version_upstream_bundle_id_version_id_pk": {
+          "name": "version_upstream_bundle_id_version_id_pk",
+          "columns": [
+            "bundle_id",
+            "version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "web.workspace": {
+      "name": "workspace",
+      "schema": "web",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_code_sha256": {
+          "name": "claim_code_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protection_default": {
+          "name": "protection_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "staleness_window_ms": {
+          "name": "staleness_window_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800000
+        },
+        "registration": {
+          "name": "registration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_only'"
+        },
+        "session_approval": {
+          "name": "session_approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "session_max_age_ms": {
+          "name": "session_max_age_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_gateway": {
+          "name": "mcp_gateway",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_name_unique": {
+          "name": "workspace_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_name_check": {
+          "name": "workspace_name_check",
+          "value": "\"web\".\"workspace\".\"name\" ~ '^[a-z0-9][a-z0-9-]*$' and length(\"web\".\"workspace\".\"name\") <= 100"
+        },
+        "workspace_claim_code_sha256_check": {
+          "name": "workspace_claim_code_sha256_check",
+          "value": "\"web\".\"workspace\".\"claim_code_sha256\" is null or octet_length(\"web\".\"workspace\".\"claim_code_sha256\") = 32"
+        },
+        "workspace_protection_default_check": {
+          "name": "workspace_protection_default_check",
+          "value": "\"web\".\"workspace\".\"protection_default\" in ('open', 'reviewed')"
+        },
+        "workspace_registration_check": {
+          "name": "workspace_registration_check",
+          "value": "\"web\".\"workspace\".\"registration\" in ('invite_only', 'open')"
+        },
+        "workspace_session_approval_check": {
+          "name": "workspace_session_approval_check",
+          "value": "\"web\".\"workspace\".\"session_approval\" in ('off', 'on')"
+        },
+        "workspace_mcp_gateway_check": {
+          "name": "workspace_mcp_gateway_check",
+          "value": "\"web\".\"workspace\".\"mcp_gateway\" in ('off', 'on')"
+        },
+        "workspace_session_max_age_check": {
+          "name": "workspace_session_max_age_check",
+          "value": "\"web\".\"workspace\".\"session_max_age_ms\" is null or \"web\".\"workspace\".\"session_max_age_ms\" > 0"
+        },
+        "workspace_claim_state_check": {
+          "name": "workspace_claim_state_check",
+          "value": "(\"web\".\"workspace\".\"claimed_at\" is null) <> (\"web\".\"workspace\".\"claim_code_sha256\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "web": "web"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -224,6 +224,13 @@
       "when": 1787603617071,
       "tag": "0031_device-owner",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1787607277587,
+      "tag": "0032_version-author",
+      "breakpoints": true
     }
   ]
 }

--- a/web/tests/unit/skill-log-lane.test.ts
+++ b/web/tests/unit/skill-log-lane.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { CustodyLog, CustodyLogEntry } from "@/lib/plane/wire";
 import { laneHeaders } from "./helpers/lane";
@@ -29,6 +30,8 @@ import { type StubVault, startStubVault } from "./helpers/stub-vault";
  */
 
 const SESSION = "sn_log_lane";
+/** A SECOND person, on the very same machine — the laptop that changed hands. */
+const SESSION_B = "sn_log_lane_b";
 const BUNDLE = "s_loglane";
 const MINE = `d_${"a".repeat(32)}`;
 const STRANGER = `d_${"b".repeat(32)}`;
@@ -37,6 +40,7 @@ const V2 = "2".repeat(64);
 const V2_AT = 1_700_086_400_000;
 const V1_AT = 1_700_000_000_000;
 const PERSON = "Robert <robert@topos.sh>";
+const PERSON_B = "Mia <mia@topos.sh>";
 
 let db: ScratchDb;
 let vault: StubVault;
@@ -74,20 +78,32 @@ async function readLog(): Promise<LogBody> {
   return (await response.json()) as LogBody;
 }
 
-/** One publish over the session lane, signed the way a real client signs it: with its machine id. */
-async function publishAs(author: string, bundleId: string): Promise<void> {
+/**
+ * One publish over the session lane, signed the way a real client signs it: with its MACHINE id,
+ * by a named person. Answers the version the vault minted, or null when the op was refused.
+ */
+async function publishAs(args: {
+  author: string;
+  bundleId: string;
+  userId: string;
+  sessionId: string;
+  expected?: number;
+}): Promise<string | null> {
   const { publishFlow } = await import("@/lib/api/publish-flow.server");
-  const raw = JSON.stringify({ skill_id: bundleId, author });
-  await publishFlow({
-    actor: asSession(wsId, "u_log", SESSION, "owner"),
+  const before = vault.published.length;
+  const raw = JSON.stringify({ skill_id: args.bundleId, author: args.author, n: before });
+  const response = await publishFlow({
+    actor: asSession(wsId, args.userId, args.sessionId, "owner"),
     raw,
     opId: crypto.randomUUID(),
-    skillId: bundleId,
-    expected: 0,
+    skillId: args.bundleId,
+    expected: args.expected ?? 0,
     candidate: {
-      files: [{ path: "SKILL.md", mode: "100644", content_base64: "IyBs" }],
+      files: [
+        { path: "SKILL.md", mode: "100644", content_base64: Buffer.from(raw).toString("base64") },
+      ],
       parents: [],
-      author,
+      author: args.author,
       message: "genesis",
     },
     displayName: "Logbook",
@@ -96,6 +112,25 @@ async function publishAs(author: string, bundleId: string): Promise<void> {
     command: "publish",
     forceProposal: false,
   });
+  const envelope = (await response.json()) as {
+    ok?: boolean;
+    receipt?: { outcome?: string };
+    data?: { record?: { version_id?: string } };
+  };
+  // The version the POINTER now names — an op that did not land names none.
+  return envelope.ok === true && envelope.receipt?.outcome === "OK"
+    ? (envelope.data?.record?.version_id ?? null)
+    : null;
+}
+
+/** Every version this app has recorded an author for, as (version, person) pairs. */
+async function authoredRows(): Promise<[string, string][]> {
+  const rows = await db.q<{ version_id: string; user_id: string }>(
+    `SELECT version_id, user_id FROM web.version_author WHERE workspace_id = $1
+     ORDER BY version_id`,
+    [wsId],
+  );
+  return rows.map((r) => [r.version_id, r.user_id]);
 }
 
 beforeAll(async () => {
@@ -108,6 +143,9 @@ beforeAll(async () => {
   await seedUser(db, "u_log", "Robert", "robert@topos.sh");
   await seatUser(db, wsId, "u_log", "owner");
   await seedSession(db, SESSION, wsId, "u_log");
+  await seedUser(db, "u_mia", "Mia", "mia@topos.sh");
+  await seatUser(db, wsId, "u_mia", "owner");
+  await seedSession(db, SESSION_B, wsId, "u_mia");
   await seedBundle(db, wsId, BUNDLE, "logbook", { withPointer: false });
   served = [
     {
@@ -143,23 +181,146 @@ describe("the version entries a machine reads back", () => {
 });
 
 describe("the author a version is read back with", () => {
-  it("is the raw machine id until that machine has published here", async () => {
+  it("is the raw machine id until this app has recorded who published it", async () => {
     const body = await readLog();
     expect(body.versions.map((v) => v.author)).toEqual([MINE, STRANGER]);
   });
 
-  it("becomes the person once the machine publishes — the recorded frame untouched", async () => {
-    await publishAs(MINE, "s_logpub");
+  it("becomes the person who published it — the recorded frame untouched", async () => {
+    const versionId = await publishAs({
+      author: MINE,
+      bundleId: BUNDLE,
+      userId: "u_log",
+      sessionId: SESSION,
+    });
+    expect(versionId).not.toBeNull();
     // What the vault was told is still the MACHINE id: substituting a display string would
     // derive a different version id and the client would refuse the answer.
-    expect(vault.published.at(-1)?.bundle).toBe("s_logpub");
-    const pairing = await db.q<{ user_id: string }>(
-      `SELECT user_id FROM web.device_owner WHERE workspace_id = $1 AND device_id = $2`,
-      [wsId, MINE],
-    );
-    expect(pairing.map((r) => r.user_id)).toEqual(["u_log"]);
+    expect(vault.published.at(-1)?.files[0]?.content).toContain(MINE);
+    expect(await authoredRows()).toContainEqual([versionId, "u_log"]);
 
+    served = [
+      { version_id: versionId as string, message: "v", author_display: MINE, created_at_ms: V2_AT },
+    ];
     const body = await readLog();
-    expect(body.versions.map((v) => v.author)).toEqual([PERSON, STRANGER]);
+    expect(body.versions.map((v) => v.author)).toEqual([PERSON]);
+  });
+
+  it("stays with the person who published it after the machine changes hands", async () => {
+    // THE BUG THIS PINS: authorship keyed on the machine let a later sign-in relabel every
+    // version that machine had ever published. It is keyed on the VERSION.
+    const mine = await publishAs({
+      author: MINE,
+      bundleId: "s_handover",
+      userId: "u_log",
+      sessionId: SESSION,
+    });
+    const hers = await publishAs({
+      author: MINE,
+      bundleId: "s_handover",
+      userId: "u_mia",
+      sessionId: SESSION_B,
+      expected: 1,
+    });
+    expect(mine).not.toBeNull();
+    expect(hers).not.toBeNull();
+    expect(hers).not.toBe(mine);
+
+    const { loader } = await import("@/routes/api.v1.skill-log");
+    served = [
+      { version_id: hers as string, message: "hers", author_display: MINE, created_at_ms: V2_AT },
+      { version_id: mine as string, message: "mine", author_display: MINE, created_at_ms: V1_AT },
+    ];
+    const response = await (loader as unknown as RouteFn)({
+      request: new Request(
+        `http://localhost:3000/api/v1/workspaces/${wsId}/skills/s_handover/log`,
+        { headers: laneHeaders({ authorization: `Bearer ${SESSION}` }) },
+      ),
+      params: { ws: wsId, skill: "s_handover" },
+    });
+    const body = (await response.json()) as LogBody;
+    expect(body.versions.map((v) => v.author)).toEqual([PERSON_B, PERSON]);
+  });
+
+  it("records nothing for a publish the gate refused — no vault call, no author row", async () => {
+    // A kind whose bundles are not files refuses ahead of every custody call.
+    await seedBundle(db, wsId, "s_denied_kind", "denied-kind", {
+      kind: "mcp",
+      withPointer: false,
+    });
+    const before = vault.published.length;
+    const outcome = await publishAs({
+      author: MINE,
+      bundleId: "s_denied_kind",
+      userId: "u_log",
+      sessionId: SESSION,
+    });
+    expect(outcome).toBeNull();
+    expect(vault.published.length).toBe(before);
+    expect(
+      await db.q(`SELECT 1 FROM web.version_author WHERE bundle_id = $1`, ["s_denied_kind"]),
+    ).toEqual([]);
+  });
+
+  it("records nothing for a publish the VAULT refused — the write is what earns the row", async () => {
+    // The op reaches custody and is refused there (a lost pointer CAS). Nothing landed, so
+    // nothing is authored: the row rides the accepted write's own transaction.
+    await seedBundle(db, wsId, "s_conflict", "conflicted", { withPointer: false });
+    vault.conflictNextPublish(7);
+    const outcome = await publishAs({
+      author: MINE,
+      bundleId: "s_conflict",
+      userId: "u_log",
+      sessionId: SESSION,
+    });
+    expect(outcome).toBeNull();
+    expect(
+      await db.q(`SELECT 1 FROM web.version_author WHERE bundle_id = $1`, ["s_conflict"]),
+    ).toEqual([]);
+  });
+});
+
+describe("a version written before this app recorded authors", () => {
+  const OLD = "9".repeat(64);
+  const OLD_DEVICE = `d_${"c".repeat(32)}`;
+
+  /** Read the log of a bundle whose only version has no author row at all. */
+  async function readOldLog(): Promise<LogBody> {
+    const { loader } = await import("@/routes/api.v1.skill-log");
+    served = [
+      { version_id: OLD, message: "old", author_display: OLD_DEVICE, created_at_ms: V1_AT },
+    ];
+    const response = await (loader as unknown as RouteFn)({
+      request: new Request(`http://localhost:3000/api/v1/workspaces/${wsId}/skills/s_old/log`, {
+        headers: laneHeaders({ authorization: `Bearer ${SESSION}` }),
+      }),
+      params: { ws: wsId, skill: "s_old" },
+    });
+    return (await response.json()) as LogBody;
+  }
+
+  beforeAll(async () => {
+    await seedBundle(db, wsId, "s_old", "oldbook", { withPointer: false });
+  });
+
+  it("shows the machine id while nothing at all names that machine", async () => {
+    expect((await readOldLog()).versions.map((v) => v.author)).toEqual([OLD_DEVICE]);
+  });
+
+  it("falls back to the person when the machine has published as exactly one", async () => {
+    await db.q(
+      `INSERT INTO web.device_owner (workspace_id, device_id, user_id) VALUES ($1, $2, $3)`,
+      [wsId, OLD_DEVICE, "u_log"],
+    );
+    expect((await readOldLog()).versions.map((v) => v.author)).toEqual([PERSON]);
+  });
+
+  it("goes back to the machine id once that machine has published as two people", async () => {
+    // Two people, one laptop: guessing between them is worse than showing the machine.
+    await db.q(
+      `INSERT INTO web.device_owner (workspace_id, device_id, user_id) VALUES ($1, $2, $3)`,
+      [wsId, OLD_DEVICE, "u_mia"],
+    );
+    expect((await readOldLog()).versions.map((v) => v.author)).toEqual([OLD_DEVICE]);
   });
 });


### PR DESCRIPTION
Two correctness fixes to the history display that landed in #81:

- Authorship is per version, not per machine: a `version_author` row is written inside the transaction that lands each accepted publish/revert; `device_owner` is a first-write-wins fallback used only when a machine has published as exactly one person. A machine that changes hands no longer relabels its earlier versions, and a refused publish records nothing.
- A proposal is dated by when it was opened, so the merged `topos log` orders it correctly among local actions.

Gates: web check + unit (1260) + build + bundle scan + Playwright (161); `cargo test -p topos` (1369); `cargo xtask ci` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
