### PR TITLE
sessions: MCP currency by revision; prove the drain-listener fix on the serving path (v0.1.51 web)

### DIFF
--- a/web/app/lib/db/queries.sessions.server.ts
+++ b/web/app/lib/db/queries.sessions.server.ts
@@ -5,7 +5,6 @@ import { getDb } from "@/lib/db/index.server";
 import type { ReportedHarnessState } from "@/lib/db/queries.lane.server";
 import { MCP_RESOLVED_REVISION } from "@/lib/db/queries.mcp-catalog.server";
 import { bundle, cliSession, sessionBundleState, workspace } from "@/lib/db/schema.app";
-import { planeCurrentPointer } from "@/lib/db/schema.custody";
 
 /**
  * The SESSIONS data access layer — a session is user × workspace × installation, the ONE
@@ -73,18 +72,21 @@ export async function sessionsFor(actor: UserActor): Promise<AccountSession[]> {
 
 // ── The workspace sessions page ─────────────────────────────────────────────────────────────
 
-/** How this session's copy of one bundle sits against the workspace's current pointer. */
+/** How this session's copy of one bundle sits against what the workspace serves for it. */
 export type SessionSkillStatus = "current" | "behind";
 
-/** One (session × bundle) applied-state row, joined to the catalog and the current pointer. */
+/** One (session × bundle) applied-state row, joined to the catalog and to what is served. */
 export interface SessionSkillState {
   skillId: string;
   /** The catalog name, or null when the id is no longer cataloged (a purged tombstone). */
   skillName: string | null;
   skillStatus: "active" | "archived" | "deleted" | null;
-  /** The version this session last applied. */
+  /** The version this session last applied — a file bundle's vault commit, or a connected
+   * server's catalog revision (`mcpr_…`). One field, because a report is one snapshot. */
   appliedVersionId: string;
-  /** The workspace's current version, or null when nothing is published (or withdrawn). */
+  /** What this workspace SERVES for the bundle, in the same spelling the machine reports: the
+   * resolved catalog revision for a connected server, the vault pointer for a file bundle.
+   * Null when nothing is published (or withdrawn). */
   currentVersionId: string | null;
   status: SessionSkillStatus;
   /** The per-harness applied states a CONFIG-placed ('mcp') bundle reports — which detected
@@ -202,28 +204,47 @@ export async function workspaceSessions(actor: MemberActor): Promise<WorkspaceSe
   }
 
   const sessionIds = sessions.map((s) => s.id);
-  const stateRows = await db
-    .select({
-      sessionId: sessionBundleState.sessionId,
-      skillId: sessionBundleState.bundleId,
-      appliedVersionId: sessionBundleState.appliedVersionId,
-      harnessState: sessionBundleState.harnessState,
-      reportedAtMs: sql<string>`(extract(epoch from ${sessionBundleState.reportedAt}) * 1000)::bigint`,
-      skillName: bundle.name,
-      skillStatus: bundle.status,
-      currentVersionId: planeCurrentPointer.versionId,
-    })
-    .from(sessionBundleState)
-    .innerJoin(bundle, and(eq(bundle.id, sessionBundleState.bundleId), eq(bundle.workspaceId, ws)))
-    .leftJoin(
-      planeCurrentPointer,
-      and(
-        eq(planeCurrentPointer.workspaceId, ws),
-        eq(planeCurrentPointer.bundleId, sessionBundleState.bundleId),
-      ),
-    )
-    .where(inArray(sessionBundleState.sessionId, sessionIds))
-    .orderBy(asc(sessionBundleState.sessionId), asc(bundle.name));
+  // Every id its own bind parameter: a bare JS array in a template renders as a parenthesised
+  // list, which is not an array value and is refused by the server.
+  const sessionIdList = sql.join(
+    sessionIds.map((id) => sql`${id}`),
+    sql`, `,
+  );
+
+  // WHAT EACH MACHINE SHOULD BE HOLDING, in the SAME spelling it reports — the comparison is
+  // only honest when both sides name the same thing. A file bundle is served by vault version;
+  // a connected MCP server is served BY REVISION (`mcpr_…`), so its machines report a revision
+  // id and a pointer comparison would call every up-to-date machine behind. The CONNECTION
+  // comes first for the same reason `yourSessionsApplying` puts it first: a bundle that predates
+  // the catalog still carries a pointer nobody is served from any more, and reading that one
+  // inverts the whole page — a machine that just updated reads behind while a stale one, still
+  // reporting the abandoned pointer, reads current.
+  const stateRows = (
+    await db.execute(sql`
+      SELECT st.session_id, st.bundle_id, st.applied_version_id, st.harness_state,
+             (extract(epoch from st.reported_at) * 1000)::bigint AS reported_ms,
+             b.name AS skill_name, b.status AS skill_status,
+             COALESCE(${MCP_RESOLVED_REVISION}, cp.version_id) AS current_version_id
+      FROM web.session_bundle_state st
+      JOIN web.bundle b ON b.id = st.bundle_id AND b.workspace_id = ${ws}
+      LEFT JOIN plane.current_pointer cp
+        ON cp.workspace_id = ${ws} AND cp.bundle_id = st.bundle_id
+      LEFT JOIN web.bundle_mcp bm
+        ON bm.workspace_id = ${ws} AND bm.bundle_id = st.bundle_id
+      LEFT JOIN web.mcp_server ms ON ms.id = bm.server_id
+      WHERE st.session_id IN (${sessionIdList})
+      ORDER BY st.session_id, b.name
+    `)
+  ).rows as unknown as {
+    session_id: string;
+    bundle_id: string;
+    applied_version_id: string;
+    harness_state: unknown;
+    reported_ms: string;
+    skill_name: string | null;
+    skill_status: string | null;
+    current_version_id: string | null;
+  }[];
 
   // The declined-but-still-applied gap: a bundle this session reports holding whose OWNER has
   // declined it. One query over the same session set, keyed by session so the page can say it
@@ -235,12 +256,7 @@ export async function workspaceSessions(actor: MemberActor): Promise<WorkspaceSe
     JOIN web.bundle b ON b.id = st.bundle_id AND b.workspace_id = ${ws}
     JOIN web.decline d ON d.workspace_id = ${ws} AND d.user_id = cs.user_id
                       AND d.bundle_id = st.bundle_id
-    WHERE cs.workspace_id = ${ws} AND st.session_id IN (${sql.join(
-      // Every id its own bind parameter: a bare JS array in a template renders as a
-      // parenthesised list, which is not an array value and is refused by the server.
-      sessionIds.map((id) => sql`${id}`),
-      sql`, `,
-    )})
+    WHERE cs.workspace_id = ${ws} AND st.session_id IN (${sessionIdList})
     ORDER BY b.name
   `);
   const declinedBySession = new Map<string, string[]>();
@@ -253,22 +269,22 @@ export async function workspaceSessions(actor: MemberActor): Promise<WorkspaceSe
   const statesBySession = new Map<string, SessionSkillState[]>();
   for (const row of stateRows) {
     const status: SessionSkillStatus =
-      row.currentVersionId !== null && row.appliedVersionId === row.currentVersionId
+      row.current_version_id !== null && row.applied_version_id === row.current_version_id
         ? "current"
         : "behind";
     const state: SessionSkillState = {
-      skillId: row.skillId,
-      skillName: row.skillName,
-      skillStatus: row.skillStatus as SessionSkillState["skillStatus"],
-      appliedVersionId: row.appliedVersionId,
-      currentVersionId: row.currentVersionId,
+      skillId: row.bundle_id,
+      skillName: row.skill_name,
+      skillStatus: row.skill_status as SessionSkillState["skillStatus"],
+      appliedVersionId: row.applied_version_id,
+      currentVersionId: row.current_version_id,
       status,
-      harnesses: harnessesOf(row.harnessState),
-      reportedAtMs: Number(row.reportedAtMs),
+      harnesses: harnessesOf(row.harness_state),
+      reportedAtMs: Number(row.reported_ms),
     };
-    const list = statesBySession.get(row.sessionId);
+    const list = statesBySession.get(row.session_id);
     if (list === undefined) {
-      statesBySession.set(row.sessionId, [state]);
+      statesBySession.set(row.session_id, [state]);
     } else {
       list.push(state);
     }

--- a/web/patches/README.md
+++ b/web/patches/README.md
@@ -13,13 +13,27 @@ writer sees the COMPRESSED stream's backpressure — but it never proxied remova
 stream kept it forever. `res.once('drain', …)` is caught by the same asymmetry: node's
 once-wrapper registers through the patched `on` and unregisters through `removeListener`.
 
-The write loop underneath this app (`@remix-run/node-fetch-server`) awaits a drain once per chunk a
-streamed response could not take, so a large document accumulated one permanent listener per chunk
-and production logged `MaxListenersExceededWarning: 11 drain listeners added to [Gzip]`.
+The write loop underneath this app awaits a drain once per chunk a streamed response could not
+take — `@react-router/express` hands the response body to `writeReadableStreamToWritable`, which
+does exactly that pair per chunk — so a large document accumulated one permanent listener per
+chunk and production logged `MaxListenersExceededWarning: 11 drain listeners added to [Gzip]`.
 
 Both halves are inside dependencies — the app hands React Router a `Response` and never touches the
 Node response object — so there is no seam of ours to fix it at. The patch adds the missing
 `removeListener`/`off` proxy and nothing else.
 
 Proved by `tests/unit/compression-drain.test.ts`, which drives the very module the production
-server loads.
+server loads: the middleware's own add/remove symmetry, and then the whole serving path — real
+gzip, real socket backpressure, a slow reader — where an unpatched install piles up hundreds of
+drain listeners and a patched one holds at one.
+
+## A composed build must carry this folder
+
+`@topos/web` is composed by supersets, and a superset that runs its own `bun install` gets its own
+`node_modules` — including its own copy of `compression`, which is what its server actually loads
+at runtime. `patchedDependencies` is per-manifest and does not travel with an imported module, so
+such a build must mirror the entry in ITS `package.json` and ship a copy of the patch file beside
+its own lockfile. Without that the composed image runs the unpatched dependency no matter how
+correct this tree is, and the only visible symptom is the warning line above in its logs. The
+end-to-end case in `tests/unit/compression-drain.test.ts` is the check that tells the two apart —
+run it in the tree whose `node_modules` the deployed server loads.

--- a/web/tests/unit/compression-drain.test.ts
+++ b/web/tests/unit/compression-drain.test.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { createRequire } from "node:module";
-import type { AddressInfo } from "node:net";
+import { type AddressInfo, connect } from "node:net";
+import { writeReadableStreamToWritable } from "@react-router/node";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 /**
@@ -127,4 +128,96 @@ describe("a response compression is holding", () => {
       expect(res.listenerCount("close")).toBe(0);
     });
   });
+});
+
+/**
+ * THE SAME INVARIANT, END TO END — the leak as production meets it, not as the middleware
+ * describes itself.
+ *
+ * The cases above pin compression's own semantics; this one runs the whole serving path: the
+ * middleware `react-router-serve` mounts, the write loop `@react-router/express` uses
+ * (`writeReadableStreamToWritable`, which awaits one drain per chunk the response could not
+ * take), and a client that reads slowly enough to make the gzip stream fill and drain over and
+ * over. That combination is the only thing that reproduces the production line
+ * (`MaxListenersExceededWarning: 11 drain listeners added to [Gzip]`), and it is what tells an
+ * UNPATCHED install apart from a patched one — module semantics look fine either way until the
+ * listeners actually pile up.
+ */
+describe("a streamed response written back under real backpressure", () => {
+  /** Chunky, and compressible enough to be worth gzipping — a real page, scaled up. */
+  const CHUNK = Buffer.from("<p>the quick brown fox jumps over the lazy dog</p>\n".repeat(1400));
+  const CHUNKS = 400;
+
+  it("leaves the Gzip stream with no accumulated drain listeners, and warns about none", async () => {
+    const warnings: string[] = [];
+    const onWarning = (w: Error) => {
+      if (w.name === "MaxListenersExceededWarning") {
+        warnings.push(w.message);
+      }
+    };
+    process.on("warning", onWarning);
+
+    let peakOnGzip = 0;
+    const middleware = compression();
+    const streaming = createServer((req, res) => {
+      middleware(req, res, () => {
+        res.writeHead(200, { "content-type": "text/html" });
+        // `res.on('drain', …)` hands back whatever compression parked the listener on — the gzip
+        // stream itself, which is the emitter the production warning names.
+        const probe = () => undefined;
+        const gzip = res.on("drain", probe) as unknown as NodeJS.EventEmitter;
+        res.removeListener("drain", probe);
+        const sample = setInterval(() => {
+          peakOnGzip = Math.max(peakOnGzip, gzip.listenerCount("drain"));
+        }, 2);
+
+        let sent = 0;
+        const body = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent++ >= CHUNKS) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(CHUNK);
+          },
+        });
+        void writeReadableStreamToWritable(body, res).finally(() => clearInterval(sample));
+      });
+    });
+    await new Promise<void>((resolve) => streaming.listen(0, "127.0.0.1", resolve));
+    const streamingPort = (streaming.address() as AddressInfo).port;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const socket = connect(streamingPort, "127.0.0.1", () => {
+          socket.write(
+            "GET / HTTP/1.1\r\nHost: x\r\nAccept-Encoding: gzip\r\nConnection: close\r\n\r\n",
+          );
+          // A slow reader: resume in short bursts so the socket — and behind it the gzip stream —
+          // fills and drains repeatedly, which is the only way a per-chunk drain wait recurs.
+          socket.pause();
+          const sip = setInterval(() => {
+            socket.resume();
+            setTimeout(() => socket.pause(), 1);
+          }, 4);
+          socket.on("close", () => {
+            clearInterval(sip);
+            resolve();
+          });
+          socket.on("error", (err) => {
+            clearInterval(sip);
+            reject(err);
+          });
+        });
+      });
+    } finally {
+      process.off("warning", onWarning);
+      await new Promise<void>((resolve) => streaming.close(() => resolve()));
+    }
+
+    // One wait at a time is the whole shape: the loop adds a listener, the drain resolves it, and
+    // the wait is cleaned up before the next chunk. Anything that climbs is the leak.
+    expect(peakOnGzip).toBeLessThanOrEqual(2);
+    expect(warnings).toEqual([]);
+  }, 60000);
 });

--- a/web/tests/unit/sessions-currency.test.ts
+++ b/web/tests/unit/sessions-currency.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { mcpRevisionId } from "../helpers/mcp-ids";
+import {
+  asMember,
+  asSession,
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedBundle,
+  seedSession,
+  seedUser,
+  versionIdFor,
+} from "./helpers/scratch-db";
+
+/**
+ * WHAT "current" MEANS ON THE SESSIONS PAGE, for both kinds of bundle.
+ *
+ * A file bundle is served by VERSION — the vault's content-addressed commit — so a machine
+ * reports a 64-hex id and the page compares it against the workspace's current pointer. A
+ * connected MCP server is served BY REVISION (`mcpr_…`, the catalog's own mint), so a machine
+ * reports a revision id and the page must compare it against the RESOLVED revision.
+ *
+ * Comparing a reported revision against a pointer does not merely fail to match — it INVERTS the
+ * page, because an MCP bundle written before the catalog existed still carries a pointer nobody
+ * is served from: a machine that just updated reads "behind", while a machine so stale it still
+ * reports that abandoned pointer reads "current". The page's whole promise ("watch until every
+ * non-stale session reads current") is only true when both sides name the same thing, so every
+ * case below is pinned against a bundle that carries BOTH a legacy pointer and a live revision.
+ */
+
+let session: { user: { id: string; name: string; email: string } } | null = null;
+vi.mock("@/lib/auth/server", () => ({
+  getAuth: () => ({ api: { getSession: async () => session } }),
+}));
+
+const ORIGIN = "http://x";
+
+let db: ScratchDb;
+let ws = "";
+
+const OWNER = { id: "u_owner", name: "Olive Owner", email: "olive@example.com" };
+
+/** The connected server's bundle — kind 'mcp', and it carries the legacy pointer too. */
+const SERVER = { id: "s_srv", name: "fleet" };
+/** An ordinary file bundle, so the same page is proven for both kinds in one read. */
+const SKILL = { id: "s_doc", name: "release-guide" };
+
+const CURRENT_REVISION = mcpRevisionId("fleet_current");
+const OLD_REVISION = mcpRevisionId("fleet_old");
+
+/** The machine that just ran `topos update` — it reports what the workspace serves. */
+const UPDATED = "cs_updated";
+/** The stale machine that still reports the pointer the catalog superseded. */
+const STALE = "cs_stale";
+
+async function report(
+  sessionId: string,
+  applied: { skillId: string; versionId: string }[],
+): Promise<string> {
+  const lane = await import("@/lib/db/queries.lane.server");
+  return await lane.reportApplied(asSession(ws, OWNER.id, sessionId, "owner"), applied);
+}
+
+/** The Sessions page's own view of one machine's copy of one bundle. */
+async function pageState(
+  sessionId: string,
+  bundleId: string,
+): Promise<{ status: string; appliedVersionId: string; currentVersionId: string | null }> {
+  const sessions = await import("@/lib/db/queries.sessions.server");
+  const view = await sessions.workspaceSessions(asMember(ws, OWNER.id, "owner"));
+  const machine = view.sessions.find((s) => s.sessionId === sessionId);
+  const state = machine?.skills.find((s) => s.skillId === bundleId);
+  if (state === undefined) {
+    throw new Error(`no state for ${sessionId} × ${bundleId}`);
+  }
+  return {
+    status: state.status,
+    appliedVersionId: state.appliedVersionId,
+    currentVersionId: state.currentVersionId,
+  };
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_sessions_currency", { TOPOS_WEB_RATELIMIT: "off" });
+  ws = await bootWorkspace();
+  await seedUser(db, OWNER.id, OWNER.name, OWNER.email);
+  await seatUser(db, ws, OWNER.id, "owner");
+  await seedSession(db, UPDATED, ws, OWNER.id, "active", "laptop");
+  await seedSession(db, STALE, ws, OWNER.id, "active", "old-desktop");
+  // The MCP bundle keeps its plane pointer on purpose: that is the shape every server written
+  // before the catalog has, and it is exactly what a pointer comparison reads by mistake.
+  await seedBundle(db, ws, SERVER.id, SERVER.name, { kind: "mcp" });
+  await seedBundle(db, ws, SKILL.id, SKILL.name);
+
+  await db.q(
+    `INSERT INTO web.mcp_server (id, workspace_id, name, display_name, auth_mode, status)
+     VALUES ('mcps_fleet', NULL, 'com.example/fleet', 'Fleet', 'none', 'active')`,
+  );
+  for (const [id, seq, upstream] of [
+    [OLD_REVISION, 1, "1.0.0"],
+    [CURRENT_REVISION, 2, "1.1.0"],
+  ] as const) {
+    await db.q(
+      `INSERT INTO web.mcp_server_revision
+         (id, server_id, seq, upstream_version, document, transport, url, published_at, published_by)
+       VALUES ($1, 'mcps_fleet', $2, $3, '{"name":"com.example/fleet"}'::jsonb,
+               'streamable-http', 'https://fleet.example/mcp', now(), 'Staff')`,
+      [id, seq, upstream],
+    );
+  }
+  // The pointer moves only once both revisions exist — `current_revision_id` is a real FK.
+  await db.q(`UPDATE web.mcp_server SET current_revision_id = $1 WHERE id = 'mcps_fleet'`, [
+    CURRENT_REVISION,
+  ]);
+  await db.q(
+    `INSERT INTO web.bundle_mcp (bundle_id, workspace_id, server_id) VALUES ($1, $2, 'mcps_fleet')`,
+    [SERVER.id, ws],
+  );
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("the Sessions page reads currency in the spelling each kind is served by", () => {
+  it("a machine holding the RESOLVED revision of a connected server reads current", async () => {
+    expect(await report(UPDATED, [{ skillId: SERVER.id, versionId: CURRENT_REVISION }])).toBe("ok");
+    const state = await pageState(UPDATED, SERVER.id);
+    expect(state.status).toBe("current");
+    // …and the "current is …" the page would print names the revision, not the abandoned pointer.
+    expect(state.currentVersionId).toBe(CURRENT_REVISION);
+  });
+
+  it("a machine still reporting the bundle's abandoned POINTER reads behind", async () => {
+    // The 11-day-stale machine: it reports the vault version an MCP bundle carries from before
+    // the catalog existed. That is not what this workspace serves, so it is behind.
+    expect(await report(STALE, [{ skillId: SERVER.id, versionId: versionIdFor(SERVER.id) }])).toBe(
+      "ok",
+    );
+    const state = await pageState(STALE, SERVER.id);
+    expect(state.status).toBe("behind");
+    expect(state.appliedVersionId).toBe(versionIdFor(SERVER.id));
+    expect(state.currentVersionId).toBe(CURRENT_REVISION);
+  });
+
+  it("a machine on an EARLIER revision reads behind against the current one", async () => {
+    expect(await report(STALE, [{ skillId: SERVER.id, versionId: OLD_REVISION }])).toBe("ok");
+    expect((await pageState(STALE, SERVER.id)).status).toBe("behind");
+  });
+
+  it("a PINNED connection is measured against its pin, not the server's current", async () => {
+    await db.q(`UPDATE web.bundle_mcp SET pinned_revision_id = $1 WHERE bundle_id = $2`, [
+      OLD_REVISION,
+      SERVER.id,
+    ]);
+    try {
+      expect((await pageState(STALE, SERVER.id)).status).toBe("current");
+      expect((await pageState(UPDATED, SERVER.id)).status).toBe("behind");
+    } finally {
+      await db.q(`UPDATE web.bundle_mcp SET pinned_revision_id = NULL WHERE bundle_id = $1`, [
+        SERVER.id,
+      ]);
+    }
+  });
+
+  it("a FILE bundle is still measured against the vault pointer", async () => {
+    await report(UPDATED, [
+      { skillId: SERVER.id, versionId: CURRENT_REVISION },
+      { skillId: SKILL.id, versionId: versionIdFor(SKILL.id) },
+    ]);
+    await report(STALE, [
+      { skillId: SERVER.id, versionId: OLD_REVISION },
+      { skillId: SKILL.id, versionId: "b7".repeat(32) },
+    ]);
+    expect((await pageState(UPDATED, SKILL.id)).status).toBe("current");
+    expect((await pageState(STALE, SKILL.id)).status).toBe("behind");
+  });
+});
+
+describe("the Sessions route", () => {
+  it("serves the same verdict the page renders — the machine on the revision reads current", async () => {
+    session = { user: OWNER };
+    await report(UPDATED, [{ skillId: SERVER.id, versionId: CURRENT_REVISION }]);
+    const { loader } = await import("@/routes/sessions");
+    const result = (await loader({
+      request: new Request(`${ORIGIN}/settings/sessions`, { headers: { accept: "text/html" } }),
+      params: {},
+      context: {},
+    } as unknown as Parameters<typeof loader>[0])) as {
+      view: {
+        sessions: {
+          sessionId: string;
+          skills: { skillId: string; status: string; currentVersionId: string | null }[];
+        }[];
+      };
+    };
+    const rendered = result.view.sessions
+      .find((s) => s.sessionId === UPDATED)
+      ?.skills.find((s) => s.skillId === SERVER.id);
+    expect(rendered?.status).toBe("current");
+    expect(rendered?.currentVersionId).toBe(CURRENT_REVISION);
+  });
+});


### PR DESCRIPTION
Round 2 (web) from the production journey on v0.1.50:

- The Sessions page read every MCP bundle's currency against the vault pointer while machines are served MCP bundles by revision since v0.1.47 — a machine that had just updated read "behind" and a stale one "current". The workspace-sessions read now resolves the served revision for MCP bundles (the same `COALESCE` every other delivery read uses) and the vault pointer for file bundles; a pinned connection is measured against its pin.
- The `MaxListenersExceededWarning` on the hosted deployment is not this tree's: the `compression` patch applies here (self-host image correct), but a superset build that installs its own `node_modules` must mirror `patchedDependencies` and carry the patch. Added the end-to-end serving-path test that distinguishes a patched install from an unpatched one, and the composition rule in `web/patches/README.md`.

Gates: web check, unit (1267), build, bundle scan, Playwright (161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
