### PR TITLE
diff binaries, revert -g copy, short version URLs, /verify hardening (v0.1.52)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3959,7 +3959,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "topos"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "base64",
  "clap",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "sha2",
  "unicode-normalization",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "axum",
  "plane-store",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "diffy",
  "flate2",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "hex",
  "jsonc-parser",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "anyhow",
  "axum",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.51" # members inherit via `version.workspace = true`; bump to match the tag before tagging
+version = "0.1.52" # members inherit via `version.workspace = true`; bump to match the tag before tagging
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/bins/topos/src/error.rs
+++ b/bins/topos/src/error.rs
@@ -328,6 +328,34 @@ fn already_tracked_message(name: &str, dir: &str, claim: &Option<TrackedBy>) -> 
     }
 }
 
+/// The [`ClientError::NotAppliedHere`] sentence: the bundle, the update that would apply it, and
+/// why the verb still cannot act. Spelled for the scope whose `update` owns the row, because that
+/// is the command that changes anything — the machine's row is only ever applied by `-g`.
+fn not_applied_here_message(name: &str, global: bool) -> String {
+    let (where_, flag) = if global {
+        ("on this machine", " -g")
+    } else {
+        ("here", "")
+    };
+    format!(
+        "{name} is not applied {where_} yet — `topos update{flag}` applies it; revert acts on an \
+         applied copy"
+    )
+}
+
+/// The [`ClientError::NoTrackedBundle`] sentence: nothing of this name is tracked, and the one
+/// command that says what IS — in the scope the invocation selected, so the answer is about the
+/// same place the refusal is.
+fn no_tracked_bundle_message(name: &str, global: bool) -> String {
+    if global {
+        format!(
+            "no tracked bundle named '{name}' here — `topos list -g` shows what this machine tracks"
+        )
+    } else {
+        format!("no tracked bundle named '{name}' here — `topos list` shows what is tracked here")
+    }
+}
+
 /// WHICH of the two manifests an add answer is about, in the one PORTABLE spelling both the
 /// receipt and the already-added refusal name it by. The absolute path a reader's own cwd would
 /// make of it is noise: there is exactly one project file and exactly one machine file, and this
@@ -615,6 +643,17 @@ pub(crate) enum ClientError {
     /// No tracked skill matches the given name.
     #[error("no tracked skill named '{name}'")]
     NoSuchSkill { name: String },
+    /// The scope DOES carry a row for this name — `list` prints it — but no `update` has applied
+    /// it here yet, so there is no copy for a version verb to act on. Its own state, because it
+    /// has its own next step: the one command that turns the row into a copy, which the listing
+    /// already spells beside the row. `global` picks the scope the update names (`-g`).
+    #[error("{}", not_applied_here_message(.name, *.global))]
+    NotAppliedHere { name: String, global: bool },
+    /// The scope tracks nothing of this name at all — the honest miss, pointing at the listing
+    /// that says what it DOES track. The name-oriented sibling of [`ClientError::NotAppliedHere`];
+    /// both wear `NO_SUCH_SKILL` on the wire, so an agent branches exactly as it always has.
+    #[error("{}", no_tracked_bundle_message(.name, *.global))]
+    NoTrackedBundle { name: String, global: bool },
     /// `add <skill>` resolved a name against discovery and found nothing adoptable — no untracked skill of
     /// that name sits in any known harness dir. Usage guidance shown VERBATIM (the name is the user's own
     /// argv token). Distinct from [`ClientError::NoSuchSkill`] (which is about *tracked* skills).
@@ -1229,7 +1268,13 @@ impl ClientError {
             ClientError::AmbiguousName { .. } | ClientError::AmbiguousSource { .. } => {
                 "AMBIGUOUS_NAME"
             }
-            ClientError::NoSuchSkill { .. } => "NO_SUCH_SKILL",
+            // One wire code for the whole "this scope has no copy of that name" family: the plain
+            // miss, the better-worded miss, and the demanded-but-unapplied row. The MESSAGE tells
+            // them apart for a reader; an agent branches on the code it always has (and on the
+            // `next_actions` the unapplied one carries).
+            ClientError::NoSuchSkill { .. }
+            | ClientError::NoTrackedBundle { .. }
+            | ClientError::NotAppliedHere { .. } => "NO_SUCH_SKILL",
             ClientError::NoUntrackedSkill { .. } => "NO_UNTRACKED_SKILL",
             // The name-oriented twins of AlreadyTracked share its code (agents branch the same on
             // any) — including a claim over a folder another record already holds, which is that

--- a/bins/topos/src/ops/mod.rs
+++ b/bins/topos/src/ops/mod.rs
@@ -552,6 +552,52 @@ fn resolve_followed_skill_in_scope(
     Ok((ctx.layout.clone(), id, lock))
 }
 
+/// The refusal a FOLLOWED-bundle verb (`revert`) answers when a name resolved to no copy in the
+/// scope it acts in. Two very different states wore one sentence otherwise, and the sentence was
+/// wrong for the commoner of them: a machine whose `list` prints
+/// `r2-smoke  (not applied here yet — \`topos update -g\` applies it)` was told `no tracked skill
+/// named 'r2-smoke'` — the same machine contradicting itself, with no next step even though ONE
+/// command turns the row into a copy. So the demand is asked about before a miss is claimed.
+pub(crate) fn unapplied_or_unknown(ctx: &Ctx<'_>, name: &str, scope: StoreScope) -> ClientError {
+    match demanded_but_unapplied(ctx, name, scope) {
+        Some(global) => ClientError::NotAppliedHere {
+            name: name.to_owned(),
+            global,
+        },
+        None => ClientError::NoTrackedBundle {
+            name: name.to_owned(),
+            global: scope == StoreScope::Machine,
+        },
+    }
+}
+
+/// Does a manifest row in the scope this invocation acts in DEMAND `name` with no applied version
+/// behind it? Answers WHICH scope's `update` would apply it (`true` = the machine's, the `-g`
+/// spelling), so the refusal spells the command that actually changes something.
+///
+/// The same rows [`list`](super::list) prints, read through the same resolution — a row whose
+/// folder is GONE is excluded, because no `update` will ever apply that one either. Best-effort:
+/// an unreadable manifest or store answers `None` and the plain miss stands, rather than a
+/// half-fact promising a command that would not help.
+fn demanded_but_unapplied(ctx: &Ctx<'_>, name: &str, scope: StoreScope) -> Option<bool> {
+    let (all, cache) = inventory::read_sources(ctx).ok()?;
+    let resolved = inventory::resolve(ctx, &all, &cache).ok()?;
+    let unapplied = |section: &inventory::ScopeResolution| {
+        section.inventory_rows().any(|row| {
+            row.bundle && row.name == name && row.version.is_none() && !row.source_missing
+        })
+    };
+    if scope == StoreScope::Machine {
+        return unapplied(resolved.machine()).then_some(true);
+    }
+    // Bare: the order the resolution itself walks — the checkout you stand in first, the machine
+    // behind it — so the update the refusal names is the one that owns the row it found.
+    if resolved.project().is_some_and(unapplied) {
+        return Some(false);
+    }
+    unapplied(resolved.machine()).then_some(true)
+}
+
 /// A store's DRAFT of one bundle: the folder holding the unshipped bytes, and the digest those
 /// bytes carry — the pair a cross-scope disclosure needs, because naming a second copy is only
 /// honest while its bytes differ from the ones being shipped.

--- a/bins/topos/src/ops/revert.rs
+++ b/bins/topos/src/ops/revert.rs
@@ -96,7 +96,18 @@ pub(crate) fn revert(
     // delivers lives in that checkout's own store, and every per-skill read and write below rides
     // the OWNING store's layout. The machine-level seams — the sessions, the plane, the follow
     // state, the cwd roots — stay the outer ctx's.
-    let (layout, id, lock) = resolve_followed_skill_in_scope(ctx, skill_name, workspace, scope)?;
+    //
+    // A miss here is TWO states, and only one of them is a dead end: the scope may carry a
+    // manifest row for the name that no `update` has applied yet (`list` prints it as such), or
+    // it may track nothing of the name at all. The first has a next step and now says it.
+    let (layout, id, lock) =
+        match resolve_followed_skill_in_scope(ctx, skill_name, workspace, scope) {
+            Ok(hit) => hit,
+            Err(ClientError::NoSuchSkill { name }) => {
+                return Err(super::unapplied_or_unknown(ctx, &name, scope));
+            }
+            Err(e) => return Err(e),
+        };
     let outer_ctx = ctx;
     let store_ctx = super::pull::ctx_with_layout(ctx, &layout);
     let ctx = &store_ctx;

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -590,6 +590,14 @@ const STATIC_PROSE_COMMANDS: &[(&str, &str, &[&str])] = &[
         "UPDATE_SKILLS",
         &["topos", "update", "--json"],
     ),
+    // The MACHINE sweep, spelled whole: a refusal about a machine-scope row (a demanded bundle no
+    // update has applied there yet) must hand back the `-g` form, not the here-scope one that
+    // would leave the row exactly as it found it.
+    (
+        "topos update -g",
+        "UPDATE_SKILLS",
+        &["topos", "update", "-g", "--json"],
+    ),
     ("topos self-update", "UPDATE_CLI", &["topos", "self-update"]),
 ];
 

--- a/bins/topos/src/tests/manifest_reconcile/scope_verbs.rs
+++ b/bins/topos/src/tests/manifest_reconcile/scope_verbs.rs
@@ -1494,3 +1494,81 @@ fn two_same_named_mcp_bundles_in_one_scope_each_keep_their_own_states() {
         "{text}"
     );
 }
+
+/// A machine whose `list -g` prints `r2-smoke  (not applied here yet — `topos update -g` applies
+/// it)` answered `revert` with `no tracked skill named 'r2-smoke'` — the same machine
+/// contradicting its own listing, and no next step for a state that is ONE command from being
+/// real. The row is asked about before a miss is claimed, and each of the two states says what it
+/// is: the demanded row names the update that would apply it (as prose AND as a runnable
+/// `next_actions` argv), the genuine miss names the listing that says what this scope tracks.
+#[test]
+fn revert_tells_a_demanded_unapplied_row_apart_from_a_name_it_never_heard_of() {
+    let rig = Rig::new("zq-revert-unapplied");
+    rig.seed_session();
+    // The machine-wide recipe DEMANDS the bundle; nothing has ever applied it here (no store
+    // record, no lock) — exactly the row the inventory prints as "not applied here yet".
+    rig.write_global(&format!(
+        "[skills]\n\"{HOST}/{WS_NAME}/deploy\" = \"latest\"\n"
+    ));
+    let ctx = rig.ctx_at(None);
+    let no_contribute = |_: &str, _: Option<&str>| -> Box<dyn crate::plane::ContributeSource> {
+        unreachable!("the copy is resolved before any write lane is built")
+    };
+    let no_session = |_: &Session| -> ops::SessionTransports {
+        unreachable!("the copy is resolved before any workspace read")
+    };
+    let good = "a".repeat(64);
+    let revert = |name: &str| {
+        ops::revert(
+            &ctx,
+            &ops::RevertConnectors {
+                contribute: &no_contribute,
+                session: &no_session,
+            },
+            name,
+            &good,
+            false,
+            None,
+            ops::StoreScope::Machine,
+        )
+        .expect_err("no applied copy to revert")
+    };
+
+    let demanded = revert("deploy");
+    assert_eq!(
+        demanded.to_string(),
+        "deploy is not applied on this machine yet — `topos update -g` applies it; revert acts on \
+         an applied copy",
+        "{demanded:?}"
+    );
+    assert_eq!(
+        scope_ways_out(
+            "revert",
+            &["revert", "deploy", "--to", &good, "-g"],
+            &demanded
+        ),
+        vec![(
+            "UPDATE_SKILLS".to_owned(),
+            vec![
+                "topos".to_owned(),
+                "update".to_owned(),
+                "-g".to_owned(),
+                "--json".to_owned(),
+            ],
+        )],
+        "the fix rides as a runnable argv, spelled for the scope the row lives in",
+    );
+
+    // A name nothing demands and nothing tracks: still a refusal — in the BUNDLE vocabulary, and
+    // pointing at the listing rather than ending on a dead word.
+    let unknown = revert("never-heard-of-it");
+    assert_eq!(
+        unknown.to_string(),
+        "no tracked bundle named 'never-heard-of-it' here — `topos list -g` shows what this \
+         machine tracks",
+        "{unknown:?}"
+    );
+    // Both still branch as the one refusal an agent already knows.
+    assert_eq!(demanded.code(), "NO_SUCH_SKILL");
+    assert_eq!(unknown.code(), "NO_SUCH_SKILL");
+}

--- a/crates/topos-gitstore/src/diff.rs
+++ b/crates/topos-gitstore/src/diff.rs
@@ -9,7 +9,8 @@
 //! Lines are compared **byte-exactly** (a line is split inclusive of its `\n`, so a trailing-newline
 //! change is a real difference). A **mode** change (e.g. `chmod +x`) is surfaced even with identical
 //! content — it changes the `bundle_digest`, so the diff must not hide it. A non-UTF-8 file renders as
-//! `Binary files … differ`; a missing trailing newline renders the standard `\ No newline at end of file`.
+//! `Binary file b/… added` / `Binary file a/… removed` / `Binary files … differ`, matching the side it
+//! is on; a missing trailing newline renders the standard `\ No newline at end of file`.
 
 use std::ops::Range;
 
@@ -138,7 +139,15 @@ fn file_diff(path: &str, old: Option<DiffFile<'_>>, new: Option<DiffFile<'_>>) -
     let old_lines = old_bytes.map(split_lines);
     let new_lines = new_bytes.map(split_lines);
     if matches!(old_lines, Some(None)) || matches!(new_lines, Some(None)) {
-        out.push_str(&format!("Binary files a/{path} and b/{path} differ\n"));
+        // A binary note says the SAME thing about the file the text headers do: whether it was
+        // added, removed, or changed. `Binary files a/… and b/… differ` over a file that exists
+        // on ONE side names a side that has nothing on it — the reader goes looking for an `a/`
+        // copy that never existed. One line, one truth per side.
+        out.push_str(&match (old.is_some(), new.is_some()) {
+            (true, true) => format!("Binary files a/{path} and b/{path} differ\n"),
+            (false, _) => format!("Binary file b/{path} added\n"),
+            (_, false) => format!("Binary file a/{path} removed\n"),
+        });
         return out;
     }
     let old_lines = old_lines.flatten().unwrap_or_default();
@@ -457,6 +466,34 @@ mod tests {
         );
         // The same answer whichever side is unsorted — and the same as with both sorted.
         assert_eq!(unified_diff(&draft, &base).matches("--- a/").count(), 2);
+    }
+
+    #[test]
+    fn an_added_binary_names_only_the_side_it_is_on() {
+        // A file that exists only on the draft side is an ADDITION — the note must not name an
+        // `a/` copy for the reader to go looking for (the text renderer says `--- /dev/null` for
+        // the same shape).
+        let draft = [f("assets/big.bin", FileMode::Regular, &[0x00, 0xff])];
+        let out = unified_diff(&[], &draft);
+        assert_eq!(out, "Binary file b/assets/big.bin added\n", "{out}");
+    }
+
+    #[test]
+    fn a_removed_binary_names_only_the_side_it_is_on() {
+        let base = [f("assets/big.bin", FileMode::Regular, &[0x00, 0xff])];
+        let out = unified_diff(&base, &[]);
+        assert_eq!(out, "Binary file a/assets/big.bin removed\n", "{out}");
+    }
+
+    #[test]
+    fn a_changed_binary_still_names_both_sides() {
+        let base = [f("assets/big.bin", FileMode::Regular, &[0x00, 0xff])];
+        let draft = [f("assets/big.bin", FileMode::Regular, &[0x01, 0xfe])];
+        let out = unified_diff(&base, &draft);
+        assert_eq!(
+            out, "Binary files a/assets/big.bin and b/assets/big.bin differ\n",
+            "{out}"
+        );
     }
 
     #[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   plane:
     # Pinned to one release (see the header). Override with TOPOS_VERSION, or build from source with
     # the docker-compose.build.yml override.
-    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.51}
+    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.52}
     restart: unless-stopped
     mem_limit: 1g
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
@@ -186,7 +186,7 @@ services:
   gateway:
     # The same release as the other two — one TOPOS_VERSION moves all three, and they are only ever
     # tested together.
-    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.51}
+    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.52}
     restart: unless-stopped
     mem_limit: 1g
     # WHAT THIS BOUNDS IS CONCURRENT MCP STREAMS, NOT MEMORY (mem_limit above is the memory
@@ -253,7 +253,7 @@ services:
   web:
     # The same release as the plane and the gateway — one TOPOS_VERSION moves all three, and they are
     # only ever tested together.
-    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.51}
+    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.52}
     restart: unless-stopped
     mem_limit: 1g
     depends_on:

--- a/tests/tests/current_truth_e2e.rs
+++ b/tests/tests/current_truth_e2e.rs
@@ -354,6 +354,12 @@ fn diff_entries(body: &str) -> Vec<(String, &'static str)> {
         if let Some(rest) = line.strip_prefix("Binary files a/") {
             let path = rest.split(" and b/").next().unwrap_or_default();
             out.push((path.to_owned(), "modified"));
+        } else if let Some(rest) = line.strip_prefix("Binary file b/") {
+            let path = rest.strip_suffix(" added").unwrap_or(rest);
+            out.push((path.to_owned(), "added"));
+        } else if let Some(rest) = line.strip_prefix("Binary file a/") {
+            let path = rest.strip_suffix(" removed").unwrap_or(rest);
+            out.push((path.to_owned(), "deleted"));
         } else if let Some(old) = line.strip_prefix("--- ") {
             let new = lines
                 .next()

--- a/web/app/lib/db/queries.custody.server.ts
+++ b/web/app/lib/db/queries.custody.server.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, like, sql } from "drizzle-orm";
 import { composition } from "@/composition.server";
 import type { MemberActor, ReadActor, SessionActor } from "@/lib/auth/guards.server";
 import { auditInTx, mintProposalId } from "@/lib/db/identity.server";
@@ -329,6 +329,62 @@ export async function versionCreatedAtMap(
       ),
     );
   return new Map(rows.map((r) => [r.versionId, r.createdAt]));
+}
+
+// ── Addressing a version by what a person can copy ───────────────────────────────────────────
+
+/** The shortest prefix a version id may be addressed by — git's own object-prefix floor. */
+export const VERSION_PREFIX_MIN = 8;
+
+const VERSION_REF = new RegExp(`^[0-9a-f]{${VERSION_PREFIX_MIN},64}$`);
+
+/** Is `typed` shaped like a version address at all — a full id or a long-enough prefix? The cheap
+ * gate a page runs before it asks the database anything. */
+export function isVersionRef(typed: string): boolean {
+  return VERSION_REF.test(typed);
+}
+
+/**
+ * Resolve a version id AS TYPED IN A URL against ONE bundle's versions, by git's object-prefix
+ * rule: a full 64-hex id addresses itself, and a prefix of at least eight hex characters
+ * addresses the one version that starts with it.
+ *
+ * Every id this product shows a person is the 12-hex SHORT form — the link text on a version, the
+ * History rows, `topos log`, and every CLI receipt — so a URL assembled from what the app itself
+ * printed has to open. Only the full 64-hex form did, which made a hand-built version URL a 404
+ * over an id the same page had just rendered.
+ *
+ * An ambiguous prefix, a prefix nothing matches, and a token of the wrong shape all answer `null`;
+ * the caller turns that into the uniform 404, so a probe learns nothing a member could not list
+ * anyway. A FULL id comes back WITHOUT asking the mirror: whether the vault still holds those
+ * bytes is the vault's answer to give (the page's own "no readable version" card), not this
+ * lookup's.
+ */
+export async function resolveVersionRef(
+  actor: PublishActor,
+  bundleId: string,
+  typed: string,
+): Promise<string | null> {
+  if (!isVersionRef(typed)) {
+    return null;
+  }
+  if (typed.length === 64) {
+    return typed;
+  }
+  // `typed` is hex-only by the gate above, so it carries no LIKE metacharacter. Two rows is all
+  // the question needs: one is the answer, two is an ambiguity, and neither reads further.
+  const rows = await getDb()
+    .select({ versionId: planeVersion.versionId })
+    .from(planeVersion)
+    .where(
+      and(
+        eq(planeVersion.workspaceId, actor.workspaceId),
+        eq(planeVersion.bundleId, bundleId),
+        like(planeVersion.versionId, `${typed}%`),
+      ),
+    )
+    .limit(2);
+  return rows.length === 1 ? (rows[0]?.versionId ?? null) : null;
 }
 
 // ── Who authored a version (the display-time key) ───────────────────────────────────────────

--- a/web/app/lib/plane/contract/version.ts
+++ b/web/app/lib/plane/contract/version.ts
@@ -4,7 +4,7 @@
  */
 
 /** The release version of the build serving this app — what the protocol card declares. */
-export const SERVER_RELEASE_VERSION = "0.1.51";
+export const SERVER_RELEASE_VERSION = "0.1.52";
 
 /** The wire contract's version — stamped on every document this tier emits. */
 export const WIRE_SCHEMA_VERSION = 2;

--- a/web/app/routes/file-view.tsx
+++ b/web/app/routes/file-view.tsx
@@ -8,6 +8,7 @@ import { Card, Chip } from "@/components/ui";
 import { notFound, requireMemberInScope } from "@/lib/auth/guards.server";
 import { baseOf, bundleNameOf, bundleNoun, bundlePath, useBundleBase } from "@/lib/bundle-base";
 import { requireCanonicalBase } from "@/lib/bundle-base.server";
+import { isVersionRef, resolveVersionRef } from "@/lib/db/queries.custody.server";
 import { skillIndexRow } from "@/lib/db/queries.server";
 import { classifyBytes, decodeTextVerbatim } from "@/lib/diff/classify";
 import { MAX_BLOB_BYTES, MAX_HIGHLIGHT_BYTES } from "@/lib/diff/model";
@@ -16,8 +17,6 @@ import { renderCodeHTML } from "@/lib/view/highlight.server";
 import { languageForPath } from "@/lib/view/language";
 import { renderMarkdownHTML } from "@/lib/view/markdown.server";
 import { wsPathServer } from "@/lib/ws-url.server";
-
-const HEX64 = /^[0-9a-f]{64}$/;
 
 /**
  * The splat's segments percent-decoded, or undefined when they don't decode (a literal `%` outside
@@ -58,7 +57,9 @@ type FileContent =
  * One file of a version, rendered inline: markdown as sanitized HTML, code as sanitized highlighted
  * HTML (both under a Rendered | Raw toggle), everything else as an escaped <pre>. The async render
  * runs HERE in the loader (a route component fetches and renders nothing itself). Guard order
- * mirrors the review page (requireMember → id shape → catalog probe). The path is rebuilt from the
+ * mirrors the review page (requireMember → id shape → catalog probe), and the version id is
+ * addressed exactly as the listing above it is: the full 64-hex form or a unique prefix of at
+ * least eight hex characters. The path is rebuilt from the
  * splat and used ONLY as a manifest lookup key — never as a filesystem path — so there is no
  * traversal surface: a "../x" simply fails to match a manifest entry and 404s. The blob rides the
  * internal custody lane under the per-file byte cap, and each failure mode degrades to an honest
@@ -69,11 +70,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const ws = workspace.id;
   const base = baseOf(params);
   const skill = bundleNameOf(params);
-  const versionId = params.versionId as string;
+  const typed = params.versionId as string;
   const splat = params["*"] ?? "";
   const raw = new URL(request.url).searchParams.get("view") === "raw";
 
-  if (!HEX64.test(versionId)) {
+  if (!isVersionRef(typed)) {
     notFound();
   }
   const row = await skillIndexRow(actor, skill);
@@ -85,9 +86,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     base,
     kind: row.kind,
     name: skill,
-    tail: `/versions/${versionId}/files/${splat}`,
+    tail: `/versions/${typed}/files/${splat}`,
     search: raw ? "?view=raw" : "",
   });
+  const versionId = await resolveVersionRef(actor, row.skillId, typed);
+  if (versionId === null) {
+    notFound();
+  }
 
   const meta = await custodyVersionMeta(ws, row.skillId, versionId);
   if (!meta.ok) {

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -140,13 +140,31 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
 }
 
-/** The lookup belt's own in-page line. A refusal a PERSON meets has to be a sentence on the form
- * they are standing at, with the wait in it — the house fault screen says nothing they can act
- * on, and mistyping a code is the commonest way to arrive here. */
+/** The guessing belt's own in-page line, on whichever arm ran the person out of tokens. A refusal
+ * a PERSON meets has to be a sentence on the form they are standing at, with the wait in it — the
+ * house fault screen says nothing they can act on, and mistyping a code is the commonest way to
+ * arrive here. */
 const TOO_MANY_LOOKUPS = "Too many attempts — wait a few seconds and try again";
 
 const REQUEST_GONE =
   "That request expired or was already handled — nothing was approved. Ask the device to start again.";
+
+/**
+ * The answer a DECISION arm gives when the typed code resolved nothing — expired, already
+ * handled, or never a code at all. It is the only shape a guess can take on `approve` and
+ * `deny`, so it is where those two arms pay the belt.
+ *
+ * A decision on a code that RESOLVES costs nothing: the card was already in front of the person,
+ * and the act of deciding it is not a guess — which is why ten mistyped lookups must never lock
+ * out the approve of the request on screen. A loop of guesses pays for every miss instead, and
+ * meets the same wall the lookup does, in the same words: the two doors share one bucket, so
+ * spreading a scan across both buys nothing.
+ */
+function decisionMissed(actor: UserActor) {
+  return allowVerifyLookup(actor.userId)
+    ? data({ kind: "refused" as const, error: REQUEST_GONE }, { status: 400 })
+    : data({ kind: "refused" as const, error: TOO_MANY_LOOKUPS }, { status: 429 });
+}
 
 /** Parse the chooser's posted pick into the ceremony's choice. Null = the invite-token
  * pre-bound arm (valid only while the flow's token binds — the fence decides). */
@@ -265,7 +283,7 @@ export async function action({ request }: ActionFunctionArgs) {
       choice,
     );
     if (approved === null) {
-      return data({ kind: "refused" as const, error: REQUEST_GONE }, { status: 400 });
+      return decisionMissed(actor);
     }
     if (approved.outcome === "taken") {
       // The whole transaction rolled back — the flow is still pending, so re-resolve the card
@@ -309,7 +327,7 @@ export async function action({ request }: ActionFunctionArgs) {
     display: actor.display,
   });
   if (denied === null) {
-    return data({ kind: "refused" as const, error: REQUEST_GONE }, { status: 400 });
+    return decisionMissed(actor);
   }
   if (loopback !== null && device !== null && denied.flowChallenge === device) {
     throw redirect(loopbackReturn(loopback, "denied"));

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -192,7 +192,19 @@ export async function action({ request }: ActionFunctionArgs) {
     throw data(null, { status: 429 });
   }
 
-  if (intent === "lookup") {
+  // THE LOOKUP IS THE DEFAULT ARM. `approve` and `deny` are the two acts that DECIDE a request,
+  // and each names itself; every other submission of this page is the code lookup — including one
+  // that arrives with no `intent` field at all.
+  //
+  // Pressing Enter in the code field IS clicking "Look up", and it has to answer like it. A
+  // submission can reach here without the form's hidden field for reasons the person who typed
+  // the code cannot see (a form re-submitted by something else on the page carries no submitter;
+  // a script or extension between the two can drop a hidden input), and keying the lookup on that
+  // field being present turned every one of those into a bare 400 — a page with no card, no
+  // message, and nothing to do next. Reading the lookup as the default costs nothing: it resolves
+  // only a flow THIS actor may approve, under the same rate belt as the other two arms, so a
+  // submission that loses a hidden field loses no protection with it.
+  if (intent !== "approve" && intent !== "deny") {
     // The two-state page's first state: resolve the typed code into the request card. A POST,
     // deliberately — the code never rides a URL (history, logs, referers all stay clean).
     const userCode = String(form.get("code") ?? "")
@@ -209,7 +221,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const userCode = String(form.get("code") ?? "").trim();
-  if (userCode === "" || (intent !== "approve" && intent !== "deny")) {
+  if (userCode === "") {
     throw data(null, { status: 400 });
   }
 

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -140,6 +140,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
 }
 
+/** The lookup belt's own in-page line. A refusal a PERSON meets has to be a sentence on the form
+ * they are standing at, with the wait in it — the house fault screen says nothing they can act
+ * on, and mistyping a code is the commonest way to arrive here. */
+const TOO_MANY_LOOKUPS = "Too many attempts — wait a few seconds and try again";
+
 const REQUEST_GONE =
   "That request expired or was already handled — nothing was approved. Ask the device to start again.";
 
@@ -185,13 +190,6 @@ export async function action({ request }: ActionFunctionArgs) {
   // card approved from a loopback-armed URL must not spend the listener's one wake.
   const { device, loopback } = loopbackFrom(form);
 
-  // ONE belt over all three arms: `approve` and `deny` resolve a flow by the same typed code
-  // `lookup` does, so leaving them unbelted would just move an enumeration loop one intent to
-  // the left. Page actions never reach the /api/v1 door belt, so the action wears it.
-  if (!allowVerifyLookup(actor.userId)) {
-    throw data(null, { status: 429 });
-  }
-
   // THE LOOKUP IS THE DEFAULT ARM. `approve` and `deny` are the two acts that DECIDE a request,
   // and each names itself; every other submission of this page is the code lookup — including one
   // that arrives with no `intent` field at all.
@@ -202,7 +200,7 @@ export async function action({ request }: ActionFunctionArgs) {
   // a script or extension between the two can drop a hidden input), and keying the lookup on that
   // field being present turned every one of those into a bare 400 — a page with no card, no
   // message, and nothing to do next. Reading the lookup as the default costs nothing: it resolves
-  // only a flow THIS actor may approve, under the same rate belt as the other two arms, so a
+  // only a flow THIS actor may approve, and it is the arm the guessing belt sits on, so a
   // submission that loses a hidden field loses no protection with it.
   if (intent !== "approve" && intent !== "deny") {
     // The two-state page's first state: resolve the typed code into the request card. A POST,
@@ -212,6 +210,15 @@ export async function action({ request }: ActionFunctionArgs) {
       .toUpperCase();
     if (userCode === "") {
       throw data(null, { status: 400 });
+    }
+    // THE GUESSING BELT, keyed per acting person and spent HERE — on the one arm that turns a
+    // typed code into a request. A code space of ~2^40 has to meet a wall long before it matters,
+    // and this is the only door that answers "is this a code at all". Deciding a request you have
+    // already looked up is not a guess, so `approve` and `deny` spend nothing: the person with a
+    // card in front of them can always act on it, however many codes they mistyped getting there.
+    // Page actions never reach the /api/v1 door belt, so the action wears its own.
+    if (!allowVerifyLookup(actor.userId)) {
+      return data({ kind: "refused" as const, error: TOO_MANY_LOOKUPS }, { status: 429 });
     }
     const pending = await pendingLoginFlow(userCode, actor.userId);
     if (pending === null) {

--- a/web/app/routes/version-files.tsx
+++ b/web/app/routes/version-files.tsx
@@ -8,11 +8,10 @@ import { notFound, requireMemberInScope } from "@/lib/auth/guards.server";
 import { loadVersionFilesData } from "@/lib/browse/version-files.server";
 import { baseOf, bundleNameOf, bundlePath, useBundleBase } from "@/lib/bundle-base";
 import { requireCanonicalBase } from "@/lib/bundle-base.server";
+import { isVersionRef, resolveVersionRef } from "@/lib/db/queries.custody.server";
 import { skillIndexRow } from "@/lib/db/queries.server";
 import { custodyCurrent } from "@/lib/plane/reads.server";
 import { useWsPath } from "@/lib/ws-path";
-
-const HEX64 = /^[0-9a-f]{64}$/;
 
 export function meta({
   params,
@@ -35,14 +34,19 @@ export function meta({
  * on the version id, then the DB catalog probe (an unknown NAME is the uniform 404). Every vault
  * read rides the internal custody lane and keys on the immutable `skillId` — authorization
  * already happened in the guard.
+ *
+ * The URL addresses a version the way git addresses an object: the full 64-hex id, or a unique
+ * prefix of at least eight hex characters (`resolveVersionRef`). The 12-hex SHORT form is the one
+ * every surface shows — this page's own header, History, `topos log`, every CLI receipt — so it
+ * is the form a person copies, and it opens. An ambiguous or unmatched prefix is the uniform 404.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { workspace, actor } = await requireMemberInScope(request, params);
   const ws = workspace.id;
   const base = baseOf(params);
   const skill = bundleNameOf(params);
-  const versionId = params.versionId as string;
-  if (!HEX64.test(versionId)) {
+  const typed = params.versionId as string;
+  if (!isVersionRef(typed)) {
     notFound();
   }
   const row = await skillIndexRow(actor, skill);
@@ -54,8 +58,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     base,
     kind: row.kind,
     name: skill,
-    tail: `/versions/${versionId}`,
+    tail: `/versions/${typed}`,
   });
+  // From here the FULL id is the one truth: the vault reads, the current comparison, and every
+  // link this page renders are built from it, never from the prefix the URL happened to carry.
+  const versionId = await resolveVersionRef(actor, row.skillId, typed);
+  if (versionId === null) {
+    notFound();
+  }
 
   const [versionFiles, current] = await Promise.all([
     loadVersionFilesData(actor, row.skillId, versionId),

--- a/web/tests/e2e/verify.spec.ts
+++ b/web/tests/e2e/verify.spec.ts
@@ -85,6 +85,18 @@ test.describe("signed out", () => {
   });
 });
 
+test("ENTER in the code field looks the request up — exactly as the button does", async ({
+  page,
+}) => {
+  // The keyboard is how a code gets typed: hands are already on it. Enter must be the Look up
+  // click, not a second, emptier page.
+  const flow = await startLoginFlow(page, "e2e-keyboard");
+  await page.goto("/verify");
+  await page.getByLabel("Code").fill(flow.user_code);
+  await page.getByLabel("Code").press("Enter");
+  await expect(page.getByText("\u201ce2e-keyboard\u201d", { exact: true })).toBeVisible();
+});
+
 test("an unknown code is an honest in-page state, never a 404", async ({ page }) => {
   await lookUp(page, "ZZZZ-9999");
   await expect(page.getByRole("heading", { name: "Approve a login" })).toBeVisible();

--- a/web/tests/unit/verify-lookup-arm.test.ts
+++ b/web/tests/unit/verify-lookup-arm.test.ts
@@ -22,8 +22,13 @@ import {
  * to be thrown out to the house fault screen ("Something went wrong"), which names neither the
  * cause nor the wait.
  *
+ * The two DECISION arms share that bucket, but only when they MISS: deciding a request already
+ * resolved on screen is not a guess and costs nothing, while a loop of guessed codes pays for
+ * every miss and meets the same wall.
+ *
  * Driven through the REAL action against a scratch Postgres, with its own module graph so the
- * page's per-user lookup belt is this file's alone.
+ * page's per-user belt is this file's alone; each belt case runs as its own seeded person, which
+ * is what the bucket is keyed on, so one case never spends another's tokens.
  */
 
 let session: { user: { id: string; name: string; email: string } } | null = null;
@@ -144,6 +149,43 @@ describe("the guessing belt is spent by lookups alone, and says so on the form",
     expect(
       await postVerify({ intent: "approve", code: flow.userCode, pick: "seat:" }),
     ).toMatchObject({ kind: "approved", name: "belted-box" });
+    expect((await identity.pollLoginFlow(flow.flowCode)).status).toBe("granted");
+  });
+});
+
+describe("a guessed DECISION pays per miss; a decision on a resolved code never does", () => {
+  it("the eleventh missed approve renders the refusal, and a real approve after it still lands", async () => {
+    await seedUser(db, "u_guess", "Guesser", "guesser@example.com");
+    await seatUser(db, wsId, "u_guess", "member");
+    session = { user: { id: "u_guess", name: "Guesser", email: "guesser@example.com" } };
+
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startLoginFlow("guessed-box", null);
+
+    // Ten approves of codes that resolve NOTHING. Each is the honest gone line — and each pays a
+    // token, because a decision that resolves nothing is a guess whatever it calls itself.
+    for (let i = 0; i < 10; i++) {
+      const missed = await postVerify({
+        intent: "approve",
+        code: `ZZZZ-00${String(i).padStart(2, "0")}`,
+        pick: "seat:",
+      });
+      expect(statusOf(missed)).toBe(400);
+      expect(bodyOf(missed)).toMatchObject({ kind: "refused" });
+    }
+
+    // The eleventh meets the wall the lookup meets, in the same words and on the same page.
+    const walled = await postVerify({ intent: "approve", code: "ZZZZ-0099", pick: "seat:" });
+    expect(statusOf(walled)).toBe(429);
+    expect(bodyOf(walled)).toEqual({
+      kind: "refused",
+      error: "Too many attempts — wait a few seconds and try again",
+    });
+
+    // A REAL approve still lands with the bucket empty: a code that resolves never asks the belt.
+    expect(
+      await postVerify({ intent: "approve", code: flow.userCode, pick: "seat:" }),
+    ).toMatchObject({ kind: "approved", name: "guessed-box" });
     expect((await identity.pollLoginFlow(flow.flowCode)).status).toBe("granted");
   });
 });

--- a/web/tests/unit/verify-lookup-arm.test.ts
+++ b/web/tests/unit/verify-lookup-arm.test.ts
@@ -17,9 +17,13 @@ import {
  * drop a hidden input) fell through to a bare 400: no card, no message, nothing to do next.
  *
  * The lookup is the DEFAULT arm now — `approve` and `deny` are the two acts that decide a
- * request and each names itself; everything else is the lookup. Driven through the REAL action
- * against a scratch Postgres, with its own module graph so the page's per-user lookup belt is
- * this file's alone.
+ * request and each names itself; everything else is the lookup. It is also where the guessing
+ * belt sits, and where the belt's refusal is SAID: a person who mistypes a code a few times used
+ * to be thrown out to the house fault screen ("Something went wrong"), which names neither the
+ * cause nor the wait.
+ *
+ * Driven through the REAL action against a scratch Postgres, with its own module graph so the
+ * page's per-user lookup belt is this file's alone.
  */
 
 let session: { user: { id: string; name: string; email: string } } | null = null;
@@ -29,6 +33,7 @@ vi.mock("@/lib/auth/server", () => ({
 }));
 
 let db: ScratchDb;
+let wsId = "";
 
 const ORIGIN = "http://x";
 
@@ -54,6 +59,13 @@ async function postVerify(form: Record<string, string>): Promise<unknown> {
   }
 }
 
+/** The payload of a `data(...)` answer — the actionData the page would render. */
+function bodyOf(result: unknown): unknown {
+  return typeof result === "object" && result !== null && "data" in result
+    ? (result as { data: unknown }).data
+    : result;
+}
+
 /** The HTTP status a thrown `data(...)`/Response answer carries, wherever it rides. */
 function statusOf(result: unknown): number | undefined {
   if (result instanceof Response) {
@@ -64,7 +76,7 @@ function statusOf(result: unknown): number | undefined {
 
 beforeAll(async () => {
   db = await createScratchDb("web_verifylookup", { TOPOS_WEB_RATELIMIT: "off" });
-  const wsId = await bootWorkspace();
+  wsId = await bootWorkspace();
   await seedUser(db, "u_own", "Owner", "owner@example.com");
   await seatUser(db, wsId, "u_own", "owner");
   session = { user: { id: "u_own", name: "Owner", email: "owner@example.com" } };
@@ -100,5 +112,38 @@ describe("the code lookup is the DEFAULT arm, not a named one", () => {
   it("still refuses a submission carrying no code at all", async () => {
     expect(statusOf(await postVerify({}))).toBe(400);
     expect(statusOf(await postVerify({ intent: "approve", pick: "seat:" }))).toBe(400);
+  });
+});
+
+describe("the guessing belt is spent by lookups alone, and says so on the form", () => {
+  it("the eleventh lookup answers on the page; an approval after ten still lands", async () => {
+    // The belt keys on the acting PERSON, so this case runs as its own — a fresh burst of ten.
+    await seedUser(db, "u_belt", "Belted", "belted@example.com");
+    await seatUser(db, wsId, "u_belt", "member");
+    session = { user: { id: "u_belt", name: "Belted", email: "belted@example.com" } };
+
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startLoginFlow("belted-box", null);
+
+    // Ten lookups: the burst, all answered.
+    for (let i = 0; i < 10; i++) {
+      expect(await postVerify({ code: flow.userCode })).toMatchObject({ kind: "resolved" });
+    }
+
+    // The eleventh is refused IN THE PAGE — the status is still 429, but what comes back is the
+    // form's own line, with the wait in it, instead of the house fault screen.
+    const refused = await postVerify({ code: flow.userCode });
+    expect(statusOf(refused)).toBe(429);
+    expect(bodyOf(refused)).toEqual({
+      kind: "refused",
+      error: "Too many attempts — wait a few seconds and try again",
+    });
+
+    // …and the card the person already has in front of them still decides: an approve of a code
+    // already looked up is not a guess, so it never had to queue behind the belt.
+    expect(
+      await postVerify({ intent: "approve", code: flow.userCode, pick: "seat:" }),
+    ).toMatchObject({ kind: "approved", name: "belted-box" });
+    expect((await identity.pollLoginFlow(flow.flowCode)).status).toBe("granted");
   });
 });

--- a/web/tests/unit/verify-lookup-arm.test.ts
+++ b/web/tests/unit/verify-lookup-arm.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * /verify's CODE LOOKUP, reached the way a keyboard reaches it.
+ *
+ * Pressing Enter in the code field IS clicking "Look up" — the same act, and the page has to
+ * answer it the same way. The action used to run the lookup only for a submission carrying the
+ * form's hidden `intent=lookup` field, so anything that arrived without it (a form re-submitted
+ * by something else on the page carries no submitter; a script or extension between the two can
+ * drop a hidden input) fell through to a bare 400: no card, no message, nothing to do next.
+ *
+ * The lookup is the DEFAULT arm now — `approve` and `deny` are the two acts that decide a
+ * request and each names itself; everything else is the lookup. Driven through the REAL action
+ * against a scratch Postgres, with its own module graph so the page's per-user lookup belt is
+ * this file's alone.
+ */
+
+let session: { user: { id: string; name: string; email: string } } | null = null;
+
+vi.mock("@/lib/auth/server", () => ({
+  getAuth: () => ({ api: { getSession: async () => session } }),
+}));
+
+let db: ScratchDb;
+
+const ORIGIN = "http://x";
+
+type RouteHandler = (a: {
+  request: Request;
+  params: Record<string, string | undefined>;
+}) => Promise<unknown>;
+
+/** POST the given fields to the real action; a thrown answer comes back as the value. */
+async function postVerify(form: Record<string, string>): Promise<unknown> {
+  const { action } = await import("@/routes/verify");
+  try {
+    return await (action as RouteHandler)({
+      request: new Request(`${ORIGIN}/verify`, {
+        method: "POST",
+        headers: { origin: ORIGIN, "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams(form).toString(),
+      }),
+      params: {},
+    });
+  } catch (thrown) {
+    return thrown;
+  }
+}
+
+/** The HTTP status a thrown `data(...)`/Response answer carries, wherever it rides. */
+function statusOf(result: unknown): number | undefined {
+  if (result instanceof Response) {
+    return result.status;
+  }
+  return (result as { init?: { status?: number } }).init?.status;
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_verifylookup", { TOPOS_WEB_RATELIMIT: "off" });
+  const wsId = await bootWorkspace();
+  await seedUser(db, "u_own", "Owner", "owner@example.com");
+  await seatUser(db, wsId, "u_own", "owner");
+  session = { user: { id: "u_own", name: "Owner", email: "owner@example.com" } };
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("the code lookup is the DEFAULT arm, not a named one", () => {
+  it("a submission with no intent field resolves the card, exactly as the button does", async () => {
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startLoginFlow("keyboard-box", null);
+
+    expect(await postVerify({ code: flow.userCode })).toMatchObject({
+      kind: "resolved",
+      pending: { requestedName: "keyboard-box" },
+    });
+    // The named intent is the same answer — one arm, two spellings.
+    expect(await postVerify({ intent: "lookup", code: flow.userCode })).toMatchObject({
+      kind: "resolved",
+      pending: { requestedName: "keyboard-box" },
+    });
+    // Resolving decides nothing: the request is still waiting for its approve or deny.
+    expect((await identity.pollLoginFlow(flow.flowCode)).status).toBe("pending");
+  });
+
+  it("a code nothing pends is the honest in-page miss either way, never a fault", async () => {
+    expect(await postVerify({ code: "ZZZZ-9999" })).toEqual({ kind: "miss" });
+    expect(await postVerify({ intent: "lookup", code: "ZZZZ-9999" })).toEqual({ kind: "miss" });
+  });
+
+  it("still refuses a submission carrying no code at all", async () => {
+    expect(statusOf(await postVerify({}))).toBe(400);
+    expect(statusOf(await postVerify({ intent: "approve", pick: "seat:" }))).toBe(400);
+  });
+});

--- a/web/tests/unit/version-prefix.test.ts
+++ b/web/tests/unit/version-prefix.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedBundle,
+  seedUser,
+} from "./helpers/scratch-db";
+import { type StubVault, startStubVault } from "./helpers/stub-vault";
+
+/**
+ * ADDRESSING A VERSION BY WHAT THE PRODUCT ITSELF PRINTS.
+ *
+ * Every id a person can copy is the 12-hex SHORT form — the link text on a version page, the
+ * History rows, `topos log`, every CLI receipt — but the version routes matched only the full
+ * 64-hex id, so `/…/versions/da9fa16db64b` 404'd while the same page under the long id opened.
+ * The rule is git's: a full id, or a unique prefix of at least eight hex characters; an ambiguous
+ * prefix is the uniform 404 rather than a coin flip between two releases.
+ *
+ * Driven through the REAL loaders against a scratch Postgres (the `plane.version` mirror is what
+ * a prefix resolves against) with the app's custody transport re-pointed at an in-process stub
+ * vault, so a resolved prefix is proven by the version the page actually renders.
+ */
+
+let session: { user: { id: string; name: string; email: string } } | null = null;
+vi.mock("@/lib/auth/server", () => ({
+  getAuth: () => ({ api: { getSession: async () => session } }),
+}));
+
+let db: ScratchDb;
+let vault: StubVault;
+let wsId = "";
+
+const ORIGIN = "http://x";
+const BUNDLE = "s_versioned";
+const NAME = "r2-smoke";
+
+/** Two versions sharing the first eight characters, and one that shares nothing. */
+const TWIN_A = `da9fa16d${"1".repeat(56)}`;
+const TWIN_B = `da9fa16d${"2".repeat(56)}`;
+const LONE = `beef0042${"c".repeat(56)}`;
+
+type Loader = (args: {
+  request: Request;
+  params: Record<string, string | undefined>;
+  context: unknown;
+}) => Promise<unknown>;
+
+/** Run a loader, handing back either its data or the Response a guard threw. */
+async function load(
+  loader: Loader,
+  params: Record<string, string | undefined>,
+  path: string,
+): Promise<{ data?: Record<string, unknown>; status?: number }> {
+  try {
+    const data = (await loader({
+      request: new Request(`${ORIGIN}${path}`),
+      params,
+      context: {},
+    })) as Record<string, unknown>;
+    return { data };
+  } catch (thrown) {
+    // A guard throws either a Response or the framework's `data(null, { status })` wrapper —
+    // both are the uniform miss, read here through one shape.
+    if (thrown instanceof Response) {
+      return { status: thrown.status };
+    }
+    if (typeof thrown === "object" && thrown !== null && "init" in thrown) {
+      const status = (thrown as { init?: ResponseInit }).init?.status;
+      if (typeof status === "number") {
+        return { status };
+      }
+    }
+    throw thrown;
+  }
+}
+
+async function versionPage(
+  typed: string,
+): Promise<{ data?: Record<string, unknown>; status?: number }> {
+  const { loader } = await import("@/routes/version-files");
+  return await load(
+    loader as unknown as Loader,
+    { skill: NAME, versionId: typed },
+    `/skills/${NAME}/versions/${typed}`,
+  );
+}
+
+beforeAll(async () => {
+  vault = await startStubVault();
+  db = await createScratchDb("web_versionprefix", {
+    TOPOS_WEB_RATELIMIT: "off",
+    PLANE_INTERNAL_URL: vault.url,
+  });
+  wsId = await bootWorkspace();
+  await seedUser(db, "u_mem", "Member", "member@example.com");
+  await seatUser(db, wsId, "u_mem", "member");
+  session = { user: { id: "u_mem", name: "Member", email: "member@example.com" } };
+
+  await seedBundle(db, wsId, BUNDLE, NAME, { versionId: LONE });
+  for (const versionId of [TWIN_A, TWIN_B]) {
+    await db.q(
+      `INSERT INTO plane.version (workspace_id, bundle_id, version_id, commit_id, author_display)
+       VALUES ($1, $2, $3, $3, 'seed')`,
+      [wsId, BUNDLE, versionId],
+    );
+  }
+  for (const versionId of [LONE, TWIN_A, TWIN_B]) {
+    vault.seed(wsId, BUNDLE, versionId, [{ path: "SKILL.md", content: `# ${versionId}\n` }]);
+  }
+  vault.point(wsId, BUNDLE, LONE, 1);
+}, 60000);
+
+afterAll(async () => {
+  await vault.close();
+  await db.drop();
+});
+
+describe("the version page addresses a version the way git addresses an object", () => {
+  it("opens on the 12-hex SHORT id the page itself prints", async () => {
+    const { data, status } = await versionPage(LONE.slice(0, 12));
+    expect(status).toBeUndefined();
+    expect(data?.versionId).toBe(LONE);
+    // The page really read THAT version's bytes, not merely echoed the prefix back.
+    const files = data?.versionFiles as { version: { version_id: string } | null };
+    expect(files.version?.version_id).toBe(LONE);
+  });
+
+  it("still opens on the full 64-hex id", async () => {
+    const { data, status } = await versionPage(LONE);
+    expect(status).toBeUndefined();
+    expect(data?.versionId).toBe(LONE);
+  });
+
+  it("answers the uniform 404 for a prefix two versions share", async () => {
+    // `da9fa16d` names TWIN_A and TWIN_B equally — picking one would send a reader to a release
+    // they did not ask for.
+    expect(await versionPage("da9fa16d")).toEqual({ status: 404 });
+    // One character further still lands on both.
+    expect(await versionPage(TWIN_A.slice(0, 8))).toEqual({ status: 404 });
+    // …and the character that tells them apart resolves.
+    const { data } = await versionPage(TWIN_A.slice(0, 9));
+    expect(data?.versionId).toBe(TWIN_A);
+  });
+
+  it("answers the uniform 404 for a prefix nothing matches and for one too short to be an id", async () => {
+    expect(await versionPage(`0123abcd${"f".repeat(4)}`)).toEqual({ status: 404 });
+    expect(await versionPage("da9fa16")).toEqual({ status: 404 });
+    expect(await versionPage("not-hex-at-all")).toEqual({ status: 404 });
+  });
+
+  it("carries the same rule into the file view under it", async () => {
+    const { loader } = await import("@/routes/file-view");
+    const short = LONE.slice(0, 12);
+    const { data, status } = await load(
+      loader as unknown as Loader,
+      { skill: NAME, versionId: short, "*": "SKILL.md" },
+      `/skills/${NAME}/versions/${short}/files/SKILL.md`,
+    );
+    expect(status).toBeUndefined();
+    expect(data?.versionId).toBe(LONE);
+
+    expect(
+      await load(
+        loader as unknown as Loader,
+        { skill: NAME, versionId: "da9fa16d", "*": "SKILL.md" },
+        `/skills/${NAME}/versions/da9fa16d/files/SKILL.md`,
+      ),
+    ).toEqual({ status: 404 });
+  });
+});


### PR DESCRIPTION
Round 3 from the production journey on v0.1.51, plus the v0.1.52 bump:

- `diff`: a one-sided binary names only the side it is on (`Binary file b/<path> added` / `a/<path> removed`); a changed one still says both differ.
- `revert -g` on a bundle the machine demands but never applied says so and names `topos update -g`; an unknown name refuses with `bundle`, not `skill`, and points at `list`.
- Web version and file-view URLs open on a unique prefix of 8+ hex — the short id every CLI surface prints.
- `/verify`: the code lookup is the form's default arm (Enter behaves like the button); the lookup rate limit refuses on the page instead of the fault screen and no longer counts approvals; a guessed approve/deny spends the belt, a resolved one does not.

Gates: `cargo test -p topos` (1383), `cargo xtask ci` 8/8, web check + unit (1277) + build + bundle scan + Playwright (162; verify spec re-run after the last two commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
