### PR TITLE
Uniform signed-out 404 at the shell, Usage per machine, verify form (v0.1.53 web)

### DIFF
--- a/web/app/components/browse/file-listing.tsx
+++ b/web/app/components/browse/file-listing.tsx
@@ -11,14 +11,20 @@ import { useWsPath } from "@/lib/ws-path";
  * Tailwind can't express a per-row dynamic step, and the value is a trusted small integer off
  * the manifest, never user bytes. `skill` is the catalog NAME (the URL key; the workspace prefix
  * comes from `useWsPath`).
+ *
+ * `versionRef` is the id AS THE VISITOR SPELLED IT — the 12-hex short form when that is the URL
+ * they opened, the full 64-hex when it is not. A page reached by the short id that linked on with
+ * the long one swapped the address under the reader mid-visit: the id in the bar stopped matching
+ * the id they had copied, and a shared link changed shape on the first click.
  */
 export function FileListing({
   skill,
-  versionId,
+  versionRef,
   entries,
 }: {
   skill: string;
-  versionId: string;
+  /** The version as the URL spells it — never re-spelled on the way into a link. */
+  versionRef: string;
   entries: readonly ListingEntry[];
 }) {
   if (entries.length === 0) {
@@ -32,7 +38,7 @@ export function FileListing({
     <Card>
       <ul>
         {entries.map((entry) => (
-          <ListingRow key={entry.path} skill={skill} versionId={versionId} entry={entry} />
+          <ListingRow key={entry.path} skill={skill} versionRef={versionRef} entry={entry} />
         ))}
       </ul>
     </Card>
@@ -41,11 +47,11 @@ export function FileListing({
 
 function ListingRow({
   skill,
-  versionId,
+  versionRef,
   entry,
 }: {
   skill: string;
-  versionId: string;
+  versionRef: string;
   entry: ListingEntry;
 }) {
   const wsPath = useWsPath();
@@ -67,7 +73,7 @@ function ListingRow({
   // Re-encode each segment so a name with a URL-unsafe character round-trips through the
   // catch-all route unharmed.
   const encoded = entry.path.split("/").map(encodeURIComponent).join("/");
-  const href = wsPath(bundlePath(base, skill, `/versions/${versionId}/files/${encoded}`));
+  const href = wsPath(bundlePath(base, skill, `/versions/${versionRef}/files/${encoded}`));
   return (
     <li className="border-line-soft border-b last:border-b-0">
       <Link

--- a/web/app/components/browse/path-breadcrumb.tsx
+++ b/web/app/components/browse/path-breadcrumb.tsx
@@ -12,20 +12,27 @@ const CRUMB_LINK =
  * list) → the path, its parent segments faint and the file name in ink. Segments are display
  * text nodes only — the path itself is never a link target here, only a label. `skill` is the
  * catalog NAME (the URL key; the workspace prefix comes from `useWsPath`).
+ *
+ * The version LINK is built from `versionRef` — the id as the visitor's own URL spells it — while
+ * the label stays the canonical 12-hex short form. Going back up must not silently re-address the
+ * page a reader arrived at.
  */
 export function PathBreadcrumb({
   skill,
   versionId,
+  versionRef,
   segments,
 }: {
   skill: string;
   versionId: string;
+  /** The version as the URL spells it — what the back-link carries. */
+  versionRef: string;
   segments: readonly string[];
 }) {
   const wsPath = useWsPath();
   const base = useBundleBase();
   const skillHref = wsPath(bundlePath(base, skill));
-  const listingHref = wsPath(bundlePath(base, skill, `/versions/${versionId}`));
+  const listingHref = wsPath(bundlePath(base, skill, `/versions/${versionRef}`));
   return (
     <nav
       aria-label="Breadcrumb"

--- a/web/app/components/browse/version-files.tsx
+++ b/web/app/components/browse/version-files.tsx
@@ -20,10 +20,15 @@ import type { ListingEntry } from "@/lib/view/tree";
  * its own live current comparison. Placing the chip HERE (beside the device line) keeps the body a
  * single shape — both callers frame the content identically and only the boolean differs. `skill`
  * is the catalog NAME (the URL key; the workspace prefix comes from `useWsPath` in FileListing).
+ *
+ * `versionRef` is what the file links are built from — the id AS THE URL SPELLS IT. The Current
+ * tab has no version in its address and passes none, so its links carry the full id; the versions
+ * page passes the ref its visitor arrived with, and the address keeps the shape they copied.
  */
 export function VersionFiles({
   skill,
   versionId,
+  versionRef,
   version,
   authorDisplay,
   entries,
@@ -34,6 +39,8 @@ export function VersionFiles({
 }: {
   skill: string;
   versionId: string;
+  /** The version as the URL spells it. Absent (the Current tab) = link with the full id. */
+  versionRef?: string;
   /** The version's immutable metadata; null when the server had no readable version for this id. */
   version: CustodyVersionMeta | null;
   /** Who to show as the author — the person behind the signing machine, else its id verbatim. */
@@ -86,7 +93,7 @@ export function VersionFiles({
         </div>
       </div>
 
-      <FileListing skill={skill} versionId={versionId} entries={entries} />
+      <FileListing skill={skill} versionRef={versionRef ?? versionId} entries={entries} />
 
       {docHtml !== undefined && docName !== undefined && (
         <section className="space-y-2">

--- a/web/app/components/skill/mcp-gateway.tsx
+++ b/web/app/components/skill/mcp-gateway.tsx
@@ -1,4 +1,4 @@
-import { Form, useActionData } from "react-router";
+import { Form, Link, useActionData } from "react-router";
 import { ConfirmButton } from "@/components/confirm";
 import { relativeTime } from "@/components/format";
 import { BusyFields, buttonClasses, Card, Chip, SectionHeading } from "@/components/ui";
@@ -26,14 +26,34 @@ export interface McpGatewayToolRow {
   selected: boolean;
 }
 
-export interface McpGatewayUsageRow {
-  id: number;
+/**
+ * ONE MACHINE'S WHOLE HISTORY with this server — one row per session, never one per call. A
+ * working agent makes hundreds of calls, and a hundred identical lines is not a record anybody can
+ * read; a session is the unit a person can act on (find that machine, end that session).
+ */
+export interface McpGatewayUsageSession {
+  sessionId: string;
   person: string;
   machine: string;
-  toolName: string | null;
-  method: string;
-  outcome: string;
-  createdAtMs: number;
+  calls: number;
+  /** How the calls ended. The two add up to `calls`. */
+  ok: number;
+  failed: number;
+  /** The distinct tools this session called, alphabetical — empty where the ledger holds only
+   *  non-tool methods (initialize, a listing), which the row says once instead of a dash column. */
+  tools: string[];
+  firstCallMs: number;
+  lastCallMs: number;
+}
+
+export interface McpGatewayUsage {
+  sessions: McpGatewayUsageSession[];
+  /** 1-based, already clamped into range by the read. */
+  page: number;
+  /** At least 1, so a reader is never on "page 1 of 0". */
+  pageCount: number;
+  /** Every session that has called this server, not just the ones on this page. */
+  total: number;
 }
 
 export interface McpGatewayView {
@@ -49,8 +69,8 @@ export interface McpGatewayView {
   canConnectWorkspace: boolean;
   mode: "all" | "selected";
   tools: McpGatewayToolRow[];
-  /** The most recent calls, newest first — a bounded window, not the whole ledger. */
-  usage: McpGatewayUsageRow[];
+  /** The whole ledger, aggregated per session and paged — newest activity first. */
+  usage: McpGatewayUsage;
 }
 
 /**
@@ -318,48 +338,115 @@ function ToolsSection({ view }: { view: McpGatewayView }) {
   );
 }
 
-/** USAGE. Who called, from which machine, which tool, how it ended, when. Never an argument and
- *  never a result — the ledger records that a call happened, not what was in it. */
+/**
+ * THE ONE LINE ABOVE THE TABLE — how much there is, and where in it you are standing. The count is
+ * the WHOLE ledger, not this page: a reader who sees five rows must not read that as five machines.
+ */
+function usageSummary(usage: McpGatewayUsage): string {
+  const sessions = usage.total === 1 ? "1 session" : `${usage.total} sessions`;
+  if (usage.pageCount > 1) {
+    return `${sessions}, newest activity first — page ${usage.page} of ${usage.pageCount}.`;
+  }
+  return `${sessions}, newest activity first.`;
+}
+
+/** Prev/next, and nothing else — the position is on the summary line, said once. Rendered only
+ *  where there is a second page to go to. */
+function UsagePager({ usage }: { usage: McpGatewayUsage }) {
+  if (usage.pageCount <= 1) {
+    return null;
+  }
+  return (
+    <nav
+      aria-label="Usage pages"
+      data-testid="mcp-usage-pager"
+      className="flex flex-wrap items-center gap-2 border-line-soft border-t pt-3"
+    >
+      {usage.page > 1 && (
+        <Link to={`?page=${usage.page - 1}`} className={buttonClasses("quiet")}>
+          Previous
+        </Link>
+      )}
+      {usage.page < usage.pageCount && (
+        <Link to={`?page=${usage.page + 1}`} className={buttonClasses("quiet")}>
+          Next
+        </Link>
+      )}
+    </nav>
+  );
+}
+
+/**
+ * USAGE. Who called, from which machine, how many times, how it ended, which tools, over what
+ * stretch. Never an argument and never a result — the ledger records that a call happened, not
+ * what was in it.
+ *
+ * ONE ROW PER SESSION. Per-call rows were the honest shape of the table and the wrong one to read:
+ * a single agent session filled the page with visually identical lines, all naming the same person
+ * and the same machine, and a `—` under Tool on every one of them because most calls are not tool
+ * calls. Aggregated, the row answers what a person came here to ask — which machines are using
+ * this, how hard, and is anything failing — and the page control makes the older ones reachable
+ * rather than silently dropped.
+ */
 function UsageSection({ view }: { view: McpGatewayView }) {
+  const usage = view.usage;
   return (
     <section aria-labelledby="mcp-usage-heading" className="space-y-3">
       <SectionHeading>
         <span id="mcp-usage-heading">Usage</span>
       </SectionHeading>
-      <Card className="px-4 py-3">
-        {view.usage.length === 0 ? (
+      <Card className="space-y-3 px-4 py-3">
+        {usage.sessions.length === 0 ? (
           <p className="text-faint text-sm" data-testid="mcp-usage-empty">
             No calls yet.
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm" data-testid="mcp-usage-table">
-              <thead>
-                <tr className="text-dim text-xs">
-                  <th className="py-1 pr-3 text-left font-medium">Person</th>
-                  <th className="py-1 pr-3 text-left font-medium">Machine</th>
-                  <th className="py-1 pr-3 text-left font-medium">Tool</th>
-                  <th className="py-1 pr-3 text-left font-medium">Outcome</th>
-                  <th className="py-1 text-left font-medium">When</th>
-                </tr>
-              </thead>
-              <tbody>
-                {view.usage.map((row) => (
-                  <tr key={row.id} className="border-line-soft border-t">
-                    <td className="py-1.5 pr-3 text-ink">{row.person}</td>
-                    <td className="py-1.5 pr-3 text-dim">{row.machine}</td>
-                    <td className="py-1.5 pr-3 font-mono text-[13px] text-dim">
-                      {row.toolName ?? "—"}
-                    </td>
-                    <td className="py-1.5 pr-3 font-mono text-[13px] text-dim">{row.outcome}</td>
-                    <td className="py-1.5 text-faint text-xs">
-                      {relativeTime(new Date(row.createdAtMs))}
-                    </td>
+          <>
+            <p className="text-faint text-xs" data-testid="mcp-usage-summary">
+              {usageSummary(usage)}
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-testid="mcp-usage-table">
+                <thead>
+                  <tr className="text-dim text-xs">
+                    <th className="py-1 pr-3 text-left font-medium">Person</th>
+                    <th className="py-1 pr-3 text-left font-medium">Machine</th>
+                    <th className="py-1 pr-3 text-left font-medium">Calls</th>
+                    <th className="py-1 pr-3 text-left font-medium">Outcome</th>
+                    <th className="py-1 pr-3 text-left font-medium">Tools</th>
+                    <th className="py-1 pr-3 text-left font-medium">First call</th>
+                    <th className="py-1 text-left font-medium">Last call</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {usage.sessions.map((row) => (
+                    <tr
+                      key={row.sessionId}
+                      data-testid={`mcp-usage-${row.sessionId}`}
+                      className="border-line-soft border-t"
+                    >
+                      <td className="py-1.5 pr-3 text-ink">{row.person}</td>
+                      <td className="py-1.5 pr-3 text-dim">{row.machine}</td>
+                      <td className="py-1.5 pr-3 text-dim tabular-nums">{row.calls}</td>
+                      <td className="py-1.5 pr-3 text-dim">
+                        {row.ok} ok · {row.failed} failed
+                      </td>
+                      <td className="py-1.5 pr-3 font-mono text-[13px] text-dim">
+                        {row.tools.length === 0 ? "—" : row.tools.join(", ")}
+                      </td>
+                      <td className="py-1.5 pr-3 text-faint text-xs">
+                        {relativeTime(new Date(row.firstCallMs))}
+                      </td>
+                      <td className="py-1.5 text-faint text-xs">
+                        {relativeTime(new Date(row.lastCallMs))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <UsagePager usage={usage} />
+          </>
         )}
       </Card>
     </section>

--- a/web/app/components/skill/mcp-gateway.tsx
+++ b/web/app/components/skill/mcp-gateway.tsx
@@ -1,4 +1,4 @@
-import { Form, Link, useActionData } from "react-router";
+import { Form, Link, useActionData, useSearchParams } from "react-router";
 import { ConfirmButton } from "@/components/confirm";
 import { relativeTime } from "@/components/format";
 import { BusyFields, buttonClasses, Card, Chip, SectionHeading } from "@/components/ui";
@@ -386,12 +386,25 @@ function usageSummary(usage: McpGatewayUsage): string {
   return `${sessions}, newest activity first.`;
 }
 
-/** Prev/next, and nothing else — the position is on the summary line, said once. Rendered only
- *  where there is a second page to go to. */
+/**
+ * Prev/next, and nothing else — the position is on the summary line, said once. Rendered only
+ * where there is a second page to go to.
+ *
+ * A page link REWRITES `page` and carries everything else on the address through. A bare
+ * `?page=2` would have replaced the whole query, so paging the Usage table would silently drop
+ * whatever else the URL was saying — the post-publish placement note this page reads, and any
+ * parameter added later. Turning a page is a move within the page, not a fresh arrival at it.
+ */
 function UsagePager({ usage }: { usage: McpGatewayUsage }) {
+  const [params] = useSearchParams();
   if (usage.pageCount <= 1) {
     return null;
   }
+  const pageHref = (page: number): string => {
+    const next = new URLSearchParams(params);
+    next.set("page", String(page));
+    return `?${next.toString()}`;
+  };
   return (
     <nav
       aria-label="Usage pages"
@@ -399,12 +412,12 @@ function UsagePager({ usage }: { usage: McpGatewayUsage }) {
       className="flex flex-wrap items-center gap-2 border-line-soft border-t pt-3"
     >
       {usage.page > 1 && (
-        <Link to={`?page=${usage.page - 1}`} className={buttonClasses("quiet")}>
+        <Link to={pageHref(usage.page - 1)} className={buttonClasses("quiet")}>
           Previous
         </Link>
       )}
       {usage.page < usage.pageCount && (
-        <Link to={`?page=${usage.page + 1}`} className={buttonClasses("quiet")}>
+        <Link to={pageHref(usage.page + 1)} className={buttonClasses("quiet")}>
           Next
         </Link>
       )}

--- a/web/app/components/skill/mcp-gateway.tsx
+++ b/web/app/components/skill/mcp-gateway.tsx
@@ -39,6 +39,9 @@ export interface McpGatewayUsageSession {
   /** How the calls ended. The two add up to `calls`. */
   ok: number;
   failed: number;
+  /** WHY the failed ones failed — the ledger's own outcome names with their counts, biggest
+   *  first, summing to `failed`. Empty when nothing failed. */
+  failures: { kind: string; count: number }[];
   /** The distinct tools this session called, alphabetical — empty where the ledger holds only
    *  non-tool methods (initialize, a listing), which the row says once instead of a dash column. */
   tools: string[];
@@ -339,6 +342,39 @@ function ToolsSection({ view }: { view: McpGatewayView }) {
 }
 
 /**
+ * THE LEDGER'S OUTCOME NAMES, said the way a person would say them. The gateway owns the set (its
+ * own CHECK constraint), so an unknown one is shown as itself with its underscores opened out
+ * rather than dropped — a failure kind this tier has not learned about yet is still a fact.
+ */
+const FAILURE_WORDS: Record<string, string> = {
+  denied_tool: "tool not allowed",
+  no_credential: "no sign-in",
+  unauthorized: "sign-in refused",
+  upstream_error: "server error",
+};
+
+function failureWord(kind: string): string {
+  return FAILURE_WORDS[kind] ?? kind.replaceAll("_", " ");
+}
+
+/**
+ * ONE ROW'S OUTCOME CELL: `12 ok · 3 failed (2 no sign-in, 1 server error)`.
+ *
+ * The parenthetical is the whole reason this column is worth reading. "3 failed" is a number
+ * nobody can act on — a tool the workspace switched off, a sign-in nobody connected and a server
+ * that is down are three different problems with three different fixes, and the ledger already
+ * knows which is which.
+ */
+function outcomeLine(row: McpGatewayUsageSession): string {
+  const counts = `${row.ok} ok · ${row.failed} failed`;
+  if (row.failures.length === 0) {
+    return counts;
+  }
+  const why = row.failures.map((f) => `${f.count} ${failureWord(f.kind)}`).join(", ");
+  return `${counts} (${why})`;
+}
+
+/**
  * THE ONE LINE ABOVE THE TABLE — how much there is, and where in it you are standing. The count is
  * the WHOLE ledger, not this page: a reader who sees five rows must not read that as five machines.
  */
@@ -428,9 +464,7 @@ function UsageSection({ view }: { view: McpGatewayView }) {
                       <td className="py-1.5 pr-3 text-ink">{row.person}</td>
                       <td className="py-1.5 pr-3 text-dim">{row.machine}</td>
                       <td className="py-1.5 pr-3 text-dim tabular-nums">{row.calls}</td>
-                      <td className="py-1.5 pr-3 text-dim">
-                        {row.ok} ok · {row.failed} failed
-                      </td>
+                      <td className="py-1.5 pr-3 text-dim">{outcomeLine(row)}</td>
                       <td className="py-1.5 pr-3 font-mono text-[13px] text-dim">
                         {row.tools.length === 0 ? "—" : row.tools.join(", ")}
                       </td>

--- a/web/app/lib/auth/guards.server.ts
+++ b/web/app/lib/auth/guards.server.ts
@@ -166,6 +166,32 @@ export async function requireMemberInScope(
   return memberInScope(actor, params);
 }
 
+/**
+ * THE MEMBER-ONLY PAGE guard — requireMemberInScope's twin for the HTML face, differing in one
+ * thing: a SIGNED-OUT visitor gets the uniform 404, not a bounce to /login.
+ *
+ * A workspace address is members-only in every face, and the bundle face already answered a
+ * stranger with the house 404 — the same answer a mistyped path gets. A sibling page under the
+ * same bundle that bounced to /login instead handed a signed-out visitor a second, different
+ * answer for the same address family, and read as an invitation to sign in to a workspace they
+ * have no seat in. Nothing is read before the refusal, so it stays existence-blind by
+ * construction: real slug and invented slug get the same body.
+ *
+ * Actions keep requireMemberInScope. A person who is signed out mid-form has somewhere to go, and
+ * a POST is not an address anybody probes.
+ */
+export async function memberPageInScope(
+  request: Request,
+  params: { ws?: string },
+): Promise<ScopedMember> {
+  assertSameOrigin(request);
+  const actor = actorFromSession(await getAuth().api.getSession({ headers: request.headers }));
+  if (actor === null) {
+    notFound();
+  }
+  return memberInScope(actor, params);
+}
+
 /** requireMemberInScope, then the owner gate — for pages owner-gated from the top. 404 below owner. */
 export async function requireOwnerInScope(
   request: Request,

--- a/web/app/lib/auth/guards.server.ts
+++ b/web/app/lib/auth/guards.server.ts
@@ -9,6 +9,7 @@ import {
   workspaceByName,
 } from "@/lib/db/identity.server";
 import { MACHINE_TOKEN_PREFIX, tokenActor } from "@/lib/db/queries.tokens.server";
+import { destinationPathname } from "@/lib/destination-path";
 import { personDisplay } from "@/lib/person-display";
 import { publicOrigin } from "@/lib/plane/public-base.server";
 import { getAuth } from "./server";
@@ -149,10 +150,14 @@ export async function memberInScope(
 }
 
 /**
- * The workspace-scoped guard for member-only loaders/actions: session FIRST (an anonymous or
+ * The workspace-scoped guard for member-only ACTIONS: session FIRST (an anonymous or
  * invalid-session request bounces to the constant /login BEFORE any workspace read, so a real
  * slug and an invented one answer byte-identically), then the one memberInScope resolution
  * (unknown slug and non-member land the same uniform 404).
+ *
+ * PAGES use memberPageInScope instead — a signed-out visitor at a `/<ws>…` address gets the house
+ * 404, not an invitation to sign in. An action is not an address anybody probes, and somebody
+ * whose session lapsed mid-form has somewhere to go, so the bounce is right here.
  */
 export async function requireMemberInScope(
   request: Request,
@@ -170,12 +175,13 @@ export async function requireMemberInScope(
  * THE MEMBER-ONLY PAGE guard — requireMemberInScope's twin for the HTML face, differing in one
  * thing: a SIGNED-OUT visitor gets the uniform 404, not a bounce to /login.
  *
- * A workspace address is members-only in every face, and the bundle face already answered a
- * stranger with the house 404 — the same answer a mistyped path gets. A sibling page under the
- * same bundle that bounced to /login instead handed a signed-out visitor a second, different
- * answer for the same address family, and read as an invitation to sign in to a workspace they
- * have no seat in. Nothing is read before the refusal, so it stays existence-blind by
- * construction: real slug and invented slug get the same body.
+ * EVERY `/<ws>…` page runs this. A workspace address is members-only in every face, so a stranger
+ * gets the answer a mistyped path gets, and gets it identically whether or not the workspace, the
+ * channel, the bundle or the version behind it exists. Pages that bounced to /login instead were
+ * each blind on their own (the bounce is constant), but they gave one address family two answers,
+ * and the one a person actually met read as an invitation to sign in to a workspace they hold no
+ * seat in. Nothing is read before the refusal, so the blind holds by construction: real slug and
+ * invented slug get the same body.
  *
  * Actions keep requireMemberInScope. A person who is signed out mid-form has somewhere to go, and
  * a POST is not an address anybody probes.
@@ -190,6 +196,58 @@ export async function memberPageInScope(
     notFound();
   }
   return memberInScope(actor, params);
+}
+
+/**
+ * WHAT A SIGNED-OUT VISITOR GETS under the signed-in shell — and it is not one answer.
+ *
+ * A workspace page is a members-only ADDRESS: the house 404, byte-identical for a workspace that
+ * exists and a slug nobody ever registered, so nothing about it confirms what exists. Sending that
+ * visitor to /login instead was a second answer for one address family, and it read as an
+ * invitation to sign in to a workspace they hold no seat in.
+ *
+ * `personalPaths` are the destination paths under the calling layout that belong to a PERSON
+ * rather than a workspace (their own session list; creating a workspace). Those have nothing to
+ * hide and somewhere to send you, so they keep the bounce. The layout owns that list — it is the
+ * one module that knows its own children — and the DESTINATION path is what decides, because a
+ * client-side arrival asks for `<path>.data` and it is the same page either way.
+ */
+export function refuseShellSignedOut(request: Request, personalPaths: ReadonlySet<string>): never {
+  if (personalPaths.has(destinationPathname(request).replace(/\/+$/, ""))) {
+    throw redirect("/login");
+  }
+  notFound();
+}
+
+/**
+ * THE SIGNED-IN SHELL'S OWN GUARD: the acting person, or the refusal above. The shell is chrome
+ * and never authorizes anything — every child re-derives admission from the seat table — but it
+ * cannot render without knowing WHO, and whatever it answers a signed-out visitor is the answer
+ * that visitor meets, so it has to be the same one its children give.
+ */
+export async function requireShellActor(
+  request: Request,
+  personalPaths: ReadonlySet<string>,
+): Promise<UserActor> {
+  assertSameOrigin(request);
+  const actor = actorFromSession(await getAuth().api.getSession({ headers: request.headers }));
+  if (actor === null) {
+    refuseShellSignedOut(request, personalPaths);
+  }
+  return actor;
+}
+
+/** memberPageInScope, then the owner gate — for a PAGE owner-gated from the top. Signed-out and
+ *  below-owner land the same house 404, which is the whole of what this address ever says. */
+export async function ownerPageInScope(
+  request: Request,
+  params: { ws?: string },
+): Promise<{ workspace: ScopedWorkspace; actor: OwnerActor }> {
+  const { workspace, actor } = await memberPageInScope(request, params);
+  if (actor.role !== "owner") {
+    notFound();
+  }
+  return { workspace, actor: actor as OwnerActor };
 }
 
 /** requireMemberInScope, then the owner gate — for pages owner-gated from the top. 404 below owner. */

--- a/web/app/lib/db/queries.gateway.server.ts
+++ b/web/app/lib/db/queries.gateway.server.ts
@@ -368,6 +368,11 @@ export interface McpUsageSessionRow {
   /** How many ended `ok`, and how many ended any other way. The two add up to `calls`. */
   ok: number;
   failed: number;
+  /** WHY the failed ones failed — the ledger's own outcome names with their counts, biggest
+   *  first. Empty when nothing failed, and it always sums to `failed`. "3 failed" alone is a
+   *  number nobody can act on: a tool the workspace switched off and a server that is down are
+   *  different problems with different fixes. */
+  failures: { kind: string; count: number }[];
   /** The distinct tools this session called, alphabetical. EMPTY where the ledger holds only
    *  non-tool methods (initialize, a listing) — the table says so once per row rather than
    *  carrying a column of dashes. */
@@ -388,6 +393,17 @@ export interface McpUsagePage {
 
 /** One page of the Usage table. A number, not a "recent window" — the ledger is reachable whole. */
 export const MCP_USAGE_PAGE_SIZE = 25;
+
+/** The per-kind failure counts, biggest first and ties broken by name so a row never reorders
+ *  itself between two reads of the same data. */
+function failureKindsOf(stored: unknown): { kind: string; count: number }[] {
+  if (stored === null || typeof stored !== "object") {
+    return [];
+  }
+  return Object.entries(stored as Record<string, number>)
+    .map(([kind, count]) => ({ kind, count: Number(count) }))
+    .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind));
+}
 
 /**
  * THE USAGE TABLE'S ONE READ — every session that has called this server, one row each, newest
@@ -435,8 +451,22 @@ export async function mcpUsageSessions(
       FROM gateway.usage_event e
       WHERE e.workspace_id = ${actor.workspaceId} AND e.server_id = ${serverId}
       GROUP BY e.session_id, e.user_id
+    ),
+    -- WHY the failures failed, counted per kind. The gateway owns the set of outcome names (its
+    -- own CHECK constraint), so this reads whatever is there rather than naming them here: a kind
+    -- added upstream shows up as itself instead of vanishing into a total.
+    per_failure AS (
+      SELECT session_id, user_id, jsonb_object_agg(outcome, n) AS kinds
+      FROM (
+        SELECT e.session_id, e.user_id, e.outcome, count(*)::int AS n
+        FROM gateway.usage_event e
+        WHERE e.workspace_id = ${actor.workspaceId} AND e.server_id = ${serverId}
+          AND e.outcome <> 'ok'
+        GROUP BY e.session_id, e.user_id, e.outcome
+      ) counted
+      GROUP BY session_id, user_id
     )
-    SELECT g.session_id, g.calls, g.ok, g.failed, g.tools,
+    SELECT g.session_id, g.calls, g.ok, g.failed, g.tools, f.kinds AS failure_kinds,
            (extract(epoch from g.first_at) * 1000)::bigint AS first_call_ms,
            (extract(epoch from g.last_at) * 1000)::bigint AS last_call_ms,
            -- The display rule, spelled the way every other raw-SQL reader here spells it: the
@@ -444,6 +474,7 @@ export async function mcpUsageSessions(
            COALESCE(NULLIF(btrim(u.name), ''), u.email, 'former member') AS person,
            COALESCE(s.display_name, 'a removed machine') AS machine
     FROM per_session g
+    LEFT JOIN per_failure f ON f.session_id = g.session_id AND f.user_id = g.user_id
     LEFT JOIN web."user" u ON u.id = g.user_id
     LEFT JOIN web.cli_session s ON s.id = g.session_id
     ORDER BY g.last_at DESC, g.session_id DESC
@@ -456,6 +487,7 @@ export async function mcpUsageSessions(
     calls: Number(row.calls),
     ok: Number(row.ok),
     failed: Number(row.failed),
+    failures: failureKindsOf(row.failure_kinds),
     tools: (row.tools as string[] | null) ?? [],
     firstCallMs: Number(row.first_call_ms),
     lastCallMs: Number(row.last_call_ms),

--- a/web/app/lib/db/queries.gateway.server.ts
+++ b/web/app/lib/db/queries.gateway.server.ts
@@ -348,62 +348,117 @@ export async function setMcpGatewayRoute(
 
 // ── Usage ────────────────────────────────────────────────────────────────────────────────────
 
-/** One call through the gateway, as the Usage table renders it. */
-export interface McpUsageRow {
-  id: number;
+/**
+ * ONE MACHINE'S WHOLE HISTORY with one server, as the Usage table renders it.
+ *
+ * The ledger is per-CALL, and a working agent makes hundreds of them — the raw list rendered a
+ * hundred visually identical lines and told a reader nothing they could act on. A row here is one
+ * SESSION (a machine's login), which is the unit a person can actually do something about: they
+ * can find that machine, or end that session.
+ */
+export interface McpUsageSessionRow {
+  /** The session — the row's identity, and what the Sessions page calls the same machine. */
+  sessionId: string;
   /** Who called — the display of the person whose session it was, or a stand-in for a gone account. */
   person: string;
   /** Which machine — the session's own display label. */
   machine: string;
-  toolName: string | null;
-  method: string;
-  outcome: string;
-  createdAtMs: number;
+  /** Every call this session made through the gateway to this server. */
+  calls: number;
+  /** How many ended `ok`, and how many ended any other way. The two add up to `calls`. */
+  ok: number;
+  failed: number;
+  /** The distinct tools this session called, alphabetical. EMPTY where the ledger holds only
+   *  non-tool methods (initialize, a listing) — the table says so once per row rather than
+   *  carrying a column of dashes. */
+  tools: string[];
+  firstCallMs: number;
+  lastCallMs: number;
 }
 
-export interface McpUsageWindow {
-  events: McpUsageRow[];
-  /** True when older calls exist beyond the window — recorded, just not shown. */
-  hasMore: boolean;
+export interface McpUsagePage {
+  sessions: McpUsageSessionRow[];
+  /** 1-based, and already CLAMPED into range: a page number past the end reads the last page. */
+  page: number;
+  /** At least 1, even with nothing to show — a reader is never on "page 1 of 0". */
+  pageCount: number;
+  /** Every session that has ever called this server, not just the ones on this page. */
+  total: number;
 }
 
-/** The usage window's ceiling — the audit reader's number, for the same reason. */
-export const MCP_USAGE_MAX_LIMIT = 100;
+/** One page of the Usage table. A number, not a "recent window" — the ledger is reachable whole. */
+export const MCP_USAGE_PAGE_SIZE = 25;
 
 /**
- * THE LAST CALLS through the gateway for one server, newest first, bounded with the same +1 probe
- * the audit windows use so a full window can honestly say there are older ones. The person and the
- * machine are joined from THIS tier's rows — the gateway records ids, and displays are ours.
+ * THE USAGE TABLE'S ONE READ — every session that has called this server, one row each, newest
+ * activity first, a page at a time.
+ *
+ * Grouping is by (session, person) rather than session alone: a session is minted for exactly one
+ * person, so this is one row per session, and it can never blend two people's calls into a row
+ * that names one of them. The person and the machine are joined from THIS tier's rows — the
+ * gateway records ids, and displays are ours.
+ *
+ * The count is taken first so the page number can be clamped before the offset is spent: asking
+ * for page 9 of a 3-page ledger reads page 3, never an empty table that looks like "no calls".
  */
-export async function mcpUsageWindow(
+export async function mcpUsageSessions(
   actor: MemberActor,
   serverId: string,
-  opts: { limit?: number } = {},
-): Promise<McpUsageWindow> {
-  const limit = Math.min(Math.max(opts.limit ?? MCP_USAGE_MAX_LIMIT, 1), MCP_USAGE_MAX_LIMIT);
+  opts: { page?: number } = {},
+): Promise<McpUsagePage> {
+  const requested =
+    opts.page !== undefined && Number.isFinite(opts.page) ? Math.max(1, Math.floor(opts.page)) : 1;
+  const counted = await getDb().execute(sql`
+    SELECT count(*)::int AS total
+    FROM (
+      SELECT 1 FROM gateway.usage_event
+      WHERE workspace_id = ${actor.workspaceId} AND server_id = ${serverId}
+      GROUP BY session_id, user_id
+    ) grouped
+  `);
+  const total = Number((counted.rows[0] as { total: number } | undefined)?.total ?? 0);
+  const pageCount = Math.max(1, Math.ceil(total / MCP_USAGE_PAGE_SIZE));
+  const page = Math.min(requested, pageCount);
+  if (total === 0) {
+    return { sessions: [], page, pageCount, total };
+  }
   const rows = await getDb().execute(sql`
-    SELECT e.id, e.tool_name, e.method, e.outcome,
-           (extract(epoch from e.created_at) * 1000)::bigint AS created_at_ms,
+    WITH per_session AS (
+      SELECT e.session_id, e.user_id,
+             count(*)::int AS calls,
+             count(*) FILTER (WHERE e.outcome = 'ok')::int AS ok,
+             count(*) FILTER (WHERE e.outcome <> 'ok')::int AS failed,
+             array_agg(DISTINCT e.tool_name ORDER BY e.tool_name)
+               FILTER (WHERE e.tool_name IS NOT NULL) AS tools,
+             min(e.created_at) AS first_at,
+             max(e.created_at) AS last_at
+      FROM gateway.usage_event e
+      WHERE e.workspace_id = ${actor.workspaceId} AND e.server_id = ${serverId}
+      GROUP BY e.session_id, e.user_id
+    )
+    SELECT g.session_id, g.calls, g.ok, g.failed, g.tools,
+           (extract(epoch from g.first_at) * 1000)::bigint AS first_call_ms,
+           (extract(epoch from g.last_at) * 1000)::bigint AS last_call_ms,
            -- The display rule, spelled the way every other raw-SQL reader here spells it: the
            -- profile name, else the email, else a stand-in for an account that is gone.
            COALESCE(NULLIF(btrim(u.name), ''), u.email, 'former member') AS person,
            COALESCE(s.display_name, 'a removed machine') AS machine
-    FROM gateway.usage_event e
-    LEFT JOIN web."user" u ON u.id = e.user_id
-    LEFT JOIN web.cli_session s ON s.id = e.session_id
-    WHERE e.workspace_id = ${actor.workspaceId} AND e.server_id = ${serverId}
-    ORDER BY e.id DESC
-    LIMIT ${limit + 1}
+    FROM per_session g
+    LEFT JOIN web."user" u ON u.id = g.user_id
+    LEFT JOIN web.cli_session s ON s.id = g.session_id
+    ORDER BY g.last_at DESC, g.session_id DESC
+    LIMIT ${MCP_USAGE_PAGE_SIZE} OFFSET ${(page - 1) * MCP_USAGE_PAGE_SIZE}
   `);
-  const all = (rows.rows as Record<string, unknown>[]).map((row) => ({
-    id: Number(row.id),
+  const sessions = (rows.rows as Record<string, unknown>[]).map((row) => ({
+    sessionId: row.session_id as string,
     person: row.person as string,
     machine: row.machine as string,
-    toolName: (row.tool_name as string | null) ?? null,
-    method: row.method as string,
-    outcome: row.outcome as string,
-    createdAtMs: Number(row.created_at_ms),
+    calls: Number(row.calls),
+    ok: Number(row.ok),
+    failed: Number(row.failed),
+    tools: (row.tools as string[] | null) ?? [],
+    firstCallMs: Number(row.first_call_ms),
+    lastCallMs: Number(row.last_call_ms),
   }));
-  const hasMore = all.length > limit;
-  return { events: hasMore ? all.slice(0, limit) : all, hasMore };
+  return { sessions, page, pageCount, total };
 }

--- a/web/app/lib/gateway/panel.server.ts
+++ b/web/app/lib/gateway/panel.server.ts
@@ -1,6 +1,6 @@
 import type { McpGatewayView } from "@/components/skill/mcp-gateway";
 import type { MemberActor } from "@/lib/auth/guards.server";
-import { mcpSignInState, mcpToolsView, mcpUsageWindow } from "@/lib/db/queries.gateway.server";
+import { mcpSignInState, mcpToolsView, mcpUsageSessions } from "@/lib/db/queries.gateway.server";
 import { gatewayLane } from "@/lib/gateway/client.server";
 
 /**
@@ -19,6 +19,9 @@ export async function mcpGatewayView(
     displayName: string;
     authMode: string | null;
   },
+  /** Which page of the Usage table to read — the `?page=` the person is standing on. Out-of-range
+   *  numbers are clamped by the read, so a hand-typed one never renders an empty table. */
+  opts: { usagePage?: number } = {},
 ): Promise<McpGatewayView | null> {
   if (gatewayLane() === null) {
     return null;
@@ -26,7 +29,7 @@ export async function mcpGatewayView(
   const [signIn, tools, usage] = await Promise.all([
     mcpSignInState(actor, server.serverId),
     mcpToolsView(actor, server.serverId),
-    mcpUsageWindow(actor, server.serverId),
+    mcpUsageSessions(actor, server.serverId, { page: opts.usagePage }),
   ]);
   // Resolution mirrors the gateway's own: a person's own sign-in answers first, the workspace
   // service account second. The state line names the one a call would actually carry.
@@ -39,6 +42,6 @@ export async function mcpGatewayView(
     canConnectWorkspace: actor.role === "owner" && signIn.workspace === null,
     mode: tools.mode,
     tools: tools.tools,
-    usage: usage.events,
+    usage,
   };
 }

--- a/web/app/routes/channel-history.tsx
+++ b/web/app/routes/channel-history.tsx
@@ -4,7 +4,7 @@ import { ChannelHeader } from "@/components/channel/channel-header";
 import { ChannelTabs } from "@/components/channel/channel-tabs";
 import { relativeTime } from "@/components/format";
 import { Card, Chip } from "@/components/ui";
-import { notFound, requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope, notFound } from "@/lib/auth/guards.server";
 import { type AuditEventRow, auditEventsForSubject } from "@/lib/db/audit.server";
 import { channelDetail } from "@/lib/db/queries.channels.server";
 import { useWsPath } from "@/lib/ws-path";
@@ -24,7 +24,7 @@ export function meta({ params }: { params: { channel?: string } }) {
  * re-surfaced here after the row disappears.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { actor } = await requireMemberInScope(request, params);
+  const { actor } = await memberPageInScope(request, params);
   const channel = params.channel;
   if (!channel) {
     notFound();

--- a/web/app/routes/channel-new.tsx
+++ b/web/app/routes/channel-new.tsx
@@ -1,7 +1,7 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Form, Link, redirect, useActionData } from "react-router";
 import { BusyFields, buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
-import { requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope, requireMemberInScope } from "@/lib/auth/guards.server";
 import { recordAdminEvent } from "@/lib/db/audit.server";
 import { type ChannelCreateOutcome, createChannel } from "@/lib/db/queries.channels.server";
 import { useSubmittingIntent } from "@/lib/pending";
@@ -19,7 +19,7 @@ export function meta({ params }: { params: { ws?: string } }) {
  * mint a group. The loader just guards; the form lives below.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  await requireMemberInScope(request, params);
+  await memberPageInScope(request, params);
   return null;
 }
 

--- a/web/app/routes/channel-settings.tsx
+++ b/web/app/routes/channel-settings.tsx
@@ -5,7 +5,12 @@ import { ChannelTabs } from "@/components/channel/channel-tabs";
 import { ConfirmButton, ConfirmNameField } from "@/components/confirm";
 import { buttonClasses, Card, SectionHeading } from "@/components/ui";
 import { requireTypedName } from "@/lib/auth/ceremony.server";
-import { notFound, requireMemberInScope, requireWorkspaceOwner } from "@/lib/auth/guards.server";
+import {
+  memberPageInScope,
+  notFound,
+  requireMemberInScope,
+  requireWorkspaceOwner,
+} from "@/lib/auth/guards.server";
 import { recordAdminEvent } from "@/lib/db/audit.server";
 import {
   type ChannelDeleteOutcome,
@@ -31,7 +36,7 @@ export function meta({ params }: { params: { channel?: string } }) {
  * so a member finds the tab without an existence oracle.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { actor } = await requireMemberInScope(request, params);
+  const { actor } = await memberPageInScope(request, params);
   const channel = params.channel;
   if (!channel) {
     notFound();

--- a/web/app/routes/channels-index.tsx
+++ b/web/app/routes/channels-index.tsx
@@ -1,7 +1,7 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 import { buttonClasses, Card, Chip, PageHeader, SectionHeading } from "@/components/ui";
-import { requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope } from "@/lib/auth/guards.server";
 import { type ChannelSummary, channelsOf } from "@/lib/db/queries.channels.server";
 import { useWsPath } from "@/lib/ws-path";
 
@@ -16,7 +16,7 @@ export function meta({ params }: { params: { ws?: string } }) {
  * its own Rails-style `channels/new` route (channel-new.tsx).
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { actor } = await requireMemberInScope(request, params);
+  const { actor } = await memberPageInScope(request, params);
   return { channels: await channelsOf(actor) };
 }
 

--- a/web/app/routes/file-view.tsx
+++ b/web/app/routes/file-view.tsx
@@ -5,7 +5,7 @@ import { BrowseEmpty, BrowseShell } from "@/components/browse/shell";
 import { ViewToggle } from "@/components/browse/view-toggle";
 import { Breadcrumbs } from "@/components/shell/breadcrumbs";
 import { Card, Chip } from "@/components/ui";
-import { notFound, requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope, notFound } from "@/lib/auth/guards.server";
 import { baseOf, bundleNameOf, bundleNoun, bundlePath, useBundleBase } from "@/lib/bundle-base";
 import { requireCanonicalBase } from "@/lib/bundle-base.server";
 import { isVersionRef, resolveVersionRef } from "@/lib/db/queries.custody.server";
@@ -57,7 +57,8 @@ type FileContent =
  * One file of a version, rendered inline: markdown as sanitized HTML, code as sanitized highlighted
  * HTML (both under a Rendered | Raw toggle), everything else as an escaped <pre>. The async render
  * runs HERE in the loader (a route component fetches and renders nothing itself). Guard order
- * mirrors the review page (requireMember → id shape → catalog probe), and the version id is
+ * mirrors the bundle face (membership → id shape → catalog probe), with the same house 404 for a
+ * signed-out visitor that the bundle page gives, and the version id is
  * addressed exactly as the listing above it is: the full 64-hex form or a unique prefix of at
  * least eight hex characters. The path is rebuilt from the
  * splat and used ONLY as a manifest lookup key — never as a filesystem path — so there is no
@@ -66,7 +67,7 @@ type FileContent =
  * card.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const ws = workspace.id;
   const base = baseOf(params);
   const skill = bundleNameOf(params);

--- a/web/app/routes/file-view.tsx
+++ b/web/app/routes/file-view.tsx
@@ -97,7 +97,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const meta = await custodyVersionMeta(ws, row.skillId, versionId);
   if (!meta.ok) {
-    return { kind: "meta_missing" as const, skill, versionId };
+    return { kind: "meta_missing" as const, skill, versionId, versionRef: typed };
   }
 
   // The path is a pure lookup key into the version manifest (never a filesystem path). Both delivery
@@ -118,9 +118,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const filePath = file.path;
   const displaySegments = filePath.split("/");
   const encodedPath = displaySegments.map(encodeURIComponent).join("/");
+  // Built from the TYPED spelling, not the resolved id: this path is the page's own address (the
+  // Rendered|Raw toggle re-enters it), and a toggle must not re-address the page a reader is on.
   const fileBasePath = wsPathServer(
     workspace.name,
-    bundlePath(base, skill, `/versions/${versionId}/files/${encodedPath}`),
+    bundlePath(base, skill, `/versions/${typed}/files/${encodedPath}`),
   );
   const executable = file.mode === "100755";
 
@@ -167,6 +169,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     kind: "file" as const,
     skill,
     versionId,
+    /** The version as the URL spells it — what the breadcrumb links back with. */
+    versionRef: typed,
     displaySegments,
     fileBasePath,
     executable,
@@ -193,6 +197,7 @@ export default function FileViewPage() {
   const {
     skill,
     versionId,
+    versionRef,
     displaySegments,
     fileBasePath,
     executable,
@@ -208,7 +213,12 @@ export default function FileViewPage() {
           spot), a page section apart from PathBreadcrumb, which stays the in-version file locator. */}
       <Breadcrumbs />
       <header className="space-y-2">
-        <PathBreadcrumb skill={skill} versionId={versionId} segments={displaySegments} />
+        <PathBreadcrumb
+          skill={skill}
+          versionId={versionId}
+          versionRef={versionRef}
+          segments={displaySegments}
+        />
         {(sizeBytes !== undefined || executable) && (
           <p className="flex items-center gap-2 text-faint text-xs">
             {sizeBytes !== undefined && <span>{sizeBytes} bytes</span>}

--- a/web/app/routes/mcp-connect.tsx
+++ b/web/app/routes/mcp-connect.tsx
@@ -2,7 +2,12 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Link, redirect, useActionData, useLoaderData } from "react-router";
 import { McpConnectForm } from "@/components/skill/mcp-gateway";
 import { buttonClasses, PageHeader } from "@/components/ui";
-import { notFound, requireMemberInScope, requireWorkspaceOwner } from "@/lib/auth/guards.server";
+import {
+  memberPageInScope,
+  notFound,
+  requireMemberInScope,
+  requireWorkspaceOwner,
+} from "@/lib/auth/guards.server";
 import { baseForKind, bundleNameOf, bundlePath } from "@/lib/bundle-base";
 import { recordAdminEvent } from "@/lib/db/audit.server";
 import { mcpServerFace } from "@/lib/db/queries.mcp-catalog.server";
@@ -28,7 +33,7 @@ export function meta({ params }: { params: { server?: string } }) {
  * action, never trusted from the query. The default is the person's own sign-in.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   if (gatewayLane() === null) {
     notFound();
   }

--- a/web/app/routes/mcp-new.tsx
+++ b/web/app/routes/mcp-new.tsx
@@ -11,7 +11,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { webNewDestination } from "@/lib/api/genesis.server";
-import { requireMemberInScope, requireWorkspaceOwner } from "@/lib/auth/guards.server";
+import {
+  memberPageInScope,
+  requireMemberInScope,
+  requireWorkspaceOwner,
+} from "@/lib/auth/guards.server";
 import { bundlePath } from "@/lib/bundle-base";
 import { channelsOf } from "@/lib/db/queries.channels.server";
 import {
@@ -59,7 +63,7 @@ export function meta() {
  * anything is written.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const [channels, servers] = await Promise.all([channelsOf(actor), connectableMcpServers(actor)]);
   return {
     wsName: workspace.name,

--- a/web/app/routes/profile.tsx
+++ b/web/app/routes/profile.tsx
@@ -2,7 +2,7 @@ import { Package, Plus } from "lucide-react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Link, useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { buttonClasses, Card, Chip, PageHeader, SectionHeading, ShortId } from "@/components/ui";
-import { requireMember, requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope, requireMember, requireMemberInScope } from "@/lib/auth/guards.server";
 import { baseForKind, bundlePath } from "@/lib/bundle-base";
 import {
   type AssignedBundle,
@@ -41,7 +41,7 @@ export function meta() {
  * ceremony, nobody else's rows touched.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { actor } = await requireMemberInScope(request, params);
+  const { actor } = await memberPageInScope(request, params);
   const [view, catalog] = await Promise.all([
     assignedView(actor),
     skillIndexOf(actor, actor.workspaceId),

--- a/web/app/routes/proposal-review.tsx
+++ b/web/app/routes/proposal-review.tsx
@@ -20,6 +20,7 @@ import { TrustPanel } from "@/components/review/TrustPanel";
 import { Card } from "@/components/ui";
 import { noFilesRefusal } from "@/lib/api/genesis.server";
 import {
+  memberPageInScope,
   notFound,
   requireMember,
   requireMemberInScope,
@@ -106,7 +107,7 @@ interface RenderedDiffFile {
  * stays a plain synchronous component.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const ws = workspace.id;
   const base = baseOf(params);
   const skill = bundleNameOf(params);

--- a/web/app/routes/sessions.tsx
+++ b/web/app/routes/sessions.tsx
@@ -5,7 +5,11 @@ import { relativeTime, shortDevice } from "@/components/format";
 import { SettingsTabs } from "@/components/settings-tabs";
 import { buttonClasses, Card, Chip, PageHeader, SectionHeading, ShortId } from "@/components/ui";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { requireMemberInScope, requireWorkspaceOwner } from "@/lib/auth/guards.server";
+import {
+  memberPageInScope,
+  requireMemberInScope,
+  requireWorkspaceOwner,
+} from "@/lib/auth/guards.server";
 import { recordAdminEvent } from "@/lib/db/audit.server";
 import { approveSession, ownerRemoveSession, rejectSession } from "@/lib/db/identity.server";
 import {
@@ -34,7 +38,7 @@ export function meta({ params }: { params: { ws?: string } }) {
  * sessions stay self-service on the account page too.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { actor } = await requireMemberInScope(request, params);
+  const { actor } = await memberPageInScope(request, params);
   const view = await workspaceSessions(actor);
   // Service machines (CI runners on a machine token) are workspace facts, not a person's — they
   // ride only the whole-workspace view the reviewer+ roles see.

--- a/web/app/routes/sessions.tsx
+++ b/web/app/routes/sessions.tsx
@@ -398,8 +398,12 @@ function ActiveSessions({
   return (
     <section aria-labelledby="sessions-heading" className="space-y-6">
       <div className="space-y-2">
+        {/* "Sessions", not "Active sessions": the list holds every session that is not waiting for
+            approval, and a session the workspace has not heard from in a while is in it, chip and
+            all. The counts line under the page title is the qualifier — it says how many of these
+            are active, stale, never-reported or expired, and it must add up to what is below. */}
         <SectionHeading>
-          <span id="sessions-heading">Active sessions</span>
+          <span id="sessions-heading">Sessions</span>
         </SectionHeading>
         {isOwner && (
           <p className="text-faint text-sm leading-relaxed">

--- a/web/app/routes/shell.tsx
+++ b/web/app/routes/shell.tsx
@@ -1,37 +1,44 @@
 import { getSessionCookie } from "better-auth/cookies";
 import type { LoaderFunctionArgs, MiddlewareFunction } from "react-router";
-import { Outlet, redirect, useLoaderData } from "react-router";
+import { Outlet, useLoaderData } from "react-router";
 import { ShellChrome } from "@/components/shell/shell-chrome";
-import { actorFromSession, requireSession } from "@/lib/auth/guards.server";
+import { refuseShellSignedOut, requireShellActor } from "@/lib/auth/guards.server";
 import { loadChrome } from "@/lib/shell/chrome.server";
 
 /**
  * The signed-in shell — the sidebar rail + the content pane. It is CHROME, never a gate:
  * authorization lives in each child route's own guard (guards.server.ts), which this layout
- * never stands in for. Two independent layers keep it honest — the optimistic cookie bounce
- * below, and the real per-request seat check every child loader runs.
+ * never stands in for. Two independent layers keep it honest — the optimistic cookie check
+ * below, and the real per-request seat check every child loader runs. They must AGREE about what
+ * a signed-out visitor gets, because the optimistic one runs first and is therefore the one a
+ * person actually meets.
  */
 
 /**
- * Optimistic sign-in bounce: if no session cookie is even PRESENT, send an obviously
- * signed-out visitor to /login before rendering the shell. This is UX only — the cookie is
- * never verified here and this check is NEVER authorization. Every child loader re-establishes
- * the session (requireSession) and re-derives admission from the seat table; a forged or stale
- * cookie sails past this bounce and dies at the guard, as it must.
+ * THE TWO PAGES UNDER THIS LAYOUT THAT BELONG TO A PERSON, not to a workspace: their own session
+ * list, and (in multi tenancy) creating a workspace. Everything else here is a workspace address.
+ */
+const PERSONAL_PAGES = new Set(["/account/sessions", "/new"]);
+
+/**
+ * Optimistic sign-in refusal: if no session cookie is even PRESENT, refuse an obviously
+ * signed-out visitor before rendering the shell. This is UX only — the cookie is never verified
+ * here and this check is NEVER authorization. Every child loader re-establishes the session and
+ * re-derives admission from the seat table; a forged or stale cookie sails past this and dies at
+ * the guard, as it must. What it must NOT do is answer differently from the guard behind it: this
+ * runs before every loader, so if the two disagreed, this one would be the one a person met.
  */
 export const middleware: MiddlewareFunction[] = [
   ({ request }) => {
     if (!getSessionCookie(request)) {
-      throw redirect("/login");
+      refuseShellSignedOut(request, PERSONAL_PAGES);
     }
   },
 ];
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const actor = actorFromSession(await requireSession(request));
-  if (!actor) {
-    throw redirect("/login");
-  }
+  // A cookie that carried no live session meets the same fork, one layer down.
+  const actor = await requireShellActor(request, PERSONAL_PAGES);
   // The nav slots resolve here per the ACTIVE workspace (derived from the URL under the tenancy
   // grammar — a layout loader has no child `:ws` param). Shared with face-shell so the two chromes
   // cannot drift.

--- a/web/app/routes/skill-current.tsx
+++ b/web/app/routes/skill-current.tsx
@@ -125,14 +125,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   // THE GATEWAY'S HALF of a connected server's page — the sign-in, the tool policy and the call
   // ledger. `null` on a deployment that runs no gateway (and on every skill), and the page renders
   // nothing rather than a panel promising a capability this install does not have.
+  // `?page=` is the Usage table's page, and the only query this page reads. Out-of-range and
+  // unparseable numbers are the read's problem, not the route's — it clamps rather than 404s, so a
+  // hand-edited URL lands on a real page instead of an empty table that reads as "no calls".
+  const usagePage = Number.parseInt(new URL(request.url).searchParams.get("page") ?? "", 10);
   const gateway =
     server === null
       ? null
-      : await mcpGatewayView(memberActor, {
-          serverId: server.serverId,
-          displayName: server.displayName,
-          authMode: server.authMode,
-        });
+      : await mcpGatewayView(
+          memberActor,
+          {
+            serverId: server.serverId,
+            displayName: server.displayName,
+            authMode: server.authMode,
+          },
+          { usagePage: Number.isNaN(usagePage) ? 1 : usagePage },
+        );
 
   // THE VIEWER'S OWN ROUTE for this server — rendered only where the choice (or the mandate that
   // took it) can matter: an addressable server, a deployment whose delivery hands out gateway

--- a/web/app/routes/skill-history.tsx
+++ b/web/app/routes/skill-history.tsx
@@ -7,6 +7,7 @@ import { SkillTabs } from "@/components/skill/skill-tabs";
 import { noFilesRefusal } from "@/lib/api/genesis.server";
 import { requireTypedName } from "@/lib/auth/ceremony.server";
 import {
+  memberPageInScope,
   notFound,
   requireMemberInScope,
   requireReviewer,
@@ -73,9 +74,11 @@ interface RevertActionData {
 /**
  * The bundle's History tab — the first-parent version walk as its own shareable route (a sibling
  * of Current and Proposals), carrying the `?from=` cursor for Show-older / second-parent paging.
- * Same guard-then-probe order as every bundle page: requireMember before any data, then the DB
+ * Same guard-then-probe order as every bundle page: membership before any data — a signed-out
+ * visitor gets the house 404 the bundle page gives, never a bounce to /login — then the DB
  * catalog probe as the uniform 404 (an unknown NAME) and the kind fence, with an honest empty body
- * when the name exists but nothing is published yet.
+ * when the name exists but nothing is published yet. The ACTION keeps the login bounce: somebody
+ * whose session lapsed mid-form has somewhere to go.
  *
  * The walk runs HERE in the loader (the pure walk from history.server.ts, its metadata fetcher
  * on the internal custody lane over the immutable skillId) so HistorySection renders as a plain
@@ -84,7 +87,7 @@ interface RevertActionData {
  * HEX64-gated here.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const ws = workspace.id;
   const base = baseOf(params);
   const skill = bundleNameOf(params);

--- a/web/app/routes/skill-import.tsx
+++ b/web/app/routes/skill-import.tsx
@@ -2,7 +2,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Form, Link, redirect, useActionData, useLoaderData } from "react-router";
 import { BusyFields, buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
 import { publishGenesisBundle, webNewDestination } from "@/lib/api/genesis.server";
-import { requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope, requireMemberInScope } from "@/lib/auth/guards.server";
 import { fetchUpstreamTree, governedCopiesOf, resolveTreeSource } from "@/lib/db/upstream.server";
 import { useSubmittingIntent } from "@/lib/pending";
 import { allowUpstreamFetch } from "@/lib/rate-limit.server";
@@ -25,7 +25,7 @@ export function meta() {
  * what lands) and runs the ordinary genesis publish + provenance rows.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace } = await requireMemberInScope(request, params);
+  const { workspace } = await memberPageInScope(request, params);
   // The canonical reference's HOST half — the same origin resolution as the login address, so
   // the dedup notice's `topos add <host>/<ws>/<name>` line is unambiguous however many servers
   // the reader's installation is logged into.

--- a/web/app/routes/skill-proposals.tsx
+++ b/web/app/routes/skill-proposals.tsx
@@ -3,7 +3,7 @@ import { redirect, useLoaderData } from "react-router";
 import { type ProposalListItem, ProposalsSection } from "@/components/skill/proposals-section";
 import { SkillHeader } from "@/components/skill/skill-header";
 import { SkillTabs } from "@/components/skill/skill-tabs";
-import { notFound, requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope, notFound } from "@/lib/auth/guards.server";
 import { baseOf, bundleNameOf, bundlePath, useBundleBase } from "@/lib/bundle-base";
 import { requireCanonicalBase } from "@/lib/bundle-base.server";
 import { proposalsOf, skillIndexRow } from "@/lib/db/queries.server";
@@ -26,7 +26,7 @@ export function meta({ params }: { params: { skill?: string; server?: string } }
  * count) and the open list agree by construction — they read the same table.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const base = baseOf(params);
   const skill = bundleNameOf(params);
   const row = await skillIndexRow(actor, skill);

--- a/web/app/routes/skill-settings.tsx
+++ b/web/app/routes/skill-settings.tsx
@@ -8,9 +8,9 @@ import { SkillTabs } from "@/components/skill/skill-tabs";
 import { buttonClasses, Card, SectionHeading } from "@/components/ui";
 import {
   notFound,
+  ownerPageInScope,
   requireMember,
   requireMemberInScope,
-  requireOwnerInScope,
   requireWorkspaceOwner,
 } from "@/lib/auth/guards.server";
 import {
@@ -60,7 +60,7 @@ type ProtectionChoice = "inherit" | "open" | "reviewed";
  * house 404.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor: owner } = await requireOwnerInScope(request, params);
+  const { workspace, actor: owner } = await ownerPageInScope(request, params);
   const base = baseOf(params);
   const skill = params.server ?? params.skill;
   if (!skill) {

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -146,6 +146,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
  * arrive here. */
 const TOO_MANY_LOOKUPS = "Too many attempts — wait a few seconds and try again";
 
+/**
+ * THE CODE'S OWN SHAPE — `XXXX-XXXX`: eight characters from the unambiguous alphabet plus the
+ * hyphen that groups them for reading aloud. It is the field's maxlength AND the server's cap:
+ * the input used to take any amount of text, so a stray paste (a whole command line, a URL) went
+ * to the lookup as if it might be a code.
+ */
+const USER_CODE_LENGTH = 9;
+
+/** The empty submit's answer. A form that does nothing and says nothing on a click is the one
+ *  outcome a person cannot learn anything from — this is the same sentence the page opens with,
+ *  said again where the click happened. */
+const CODE_REQUIRED = "Enter the code your terminal shows";
+
 const REQUEST_GONE =
   "That request expired or was already handled — nothing was approved. Ask the device to start again.";
 
@@ -227,7 +240,15 @@ export async function action({ request }: ActionFunctionArgs) {
       .trim()
       .toUpperCase();
     if (userCode === "") {
-      throw data(null, { status: 400 });
+      // In the page, not the house fault screen: an empty submit is the commonest thing a person
+      // does by accident, and it has an answer they can act on.
+      return data({ kind: "refused" as const, error: CODE_REQUIRED }, { status: 400 });
+    }
+    // Longer than a code can be: answered like any other code that names nothing, and for free —
+    // a string that cannot be a code is not a guess of the code space, so it never spends the belt
+    // and never reaches the database.
+    if (userCode.length > USER_CODE_LENGTH) {
+      return { kind: "miss" as const };
     }
     // THE GUESSING BELT, keyed per acting person and spent HERE — on the one arm that turns a
     // typed code into a request. A code space of ~2^40 has to meet a wall long before it matters,
@@ -490,10 +511,13 @@ function CodeLookup() {
       <BusyFields busy={busy} className="flex items-end gap-2">
         <label className="block flex-1">
           <span className="mb-1 block font-medium text-dim text-sm">Code</span>
+          {/* No `required`: the browser's own bubble is not this form's voice, and an empty
+              submit has one answer — the action's line, in the app's words, in the same place
+              every other refusal on this page appears. */}
           <input
             type="text"
             name="code"
-            required
+            maxLength={USER_CODE_LENGTH}
             autoComplete="off"
             spellCheck={false}
             className={`${INPUT} font-mono uppercase`}

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -148,11 +148,37 @@ const TOO_MANY_LOOKUPS = "Too many attempts — wait a few seconds and try again
 
 /**
  * THE CODE'S OWN SHAPE — `XXXX-XXXX`: eight characters from the unambiguous alphabet plus the
- * hyphen that groups them for reading aloud. It is the field's maxlength AND the server's cap:
- * the input used to take any amount of text, so a stray paste (a whole command line, a URL) went
- * to the lookup as if it might be a code.
+ * hyphen that groups them for reading aloud. The full spelling is the field's maxlength AND the
+ * server's cap: the input used to take any amount of text, so a stray paste (a whole command
+ * line, a URL) went to the lookup as if it might be a code.
  */
 const USER_CODE_LENGTH = 9;
+const USER_CODE_BARE_LENGTH = 8;
+
+/**
+ * THE CODE AS THE PERSON MEANT IT.
+ *
+ * The hyphen is there so a code can be read aloud; it is not part of what a code IS. Someone
+ * reading `AB29-CD34` off their terminal and typing `AB29CD34`, or saying it to a colleague who
+ * writes `AB29 CD34`, has typed the same code — and both used to miss, sending a person back to
+ * re-read a code they had already read correctly. Case is normalised for the same reason.
+ *
+ * Only the eight-character spelling is re-hyphenated: anything else is handed back trimmed and
+ * upper-cased, so the length cap still sees what was actually typed rather than something this
+ * function invented. A submission carrying nothing a code is MADE of — spaces, a stray hyphen —
+ * is empty, and gets the empty submit's line rather than being spent as a guess.
+ */
+function normalizeUserCode(typed: string): string {
+  const said = typed.trim().toUpperCase();
+  const bare = said.replaceAll(/[\s-]/g, "");
+  if (bare.length === 0) {
+    return "";
+  }
+  if (bare.length !== USER_CODE_BARE_LENGTH) {
+    return said;
+  }
+  return `${bare.slice(0, 4)}-${bare.slice(4)}`;
+}
 
 /** The empty submit's answer. A form that does nothing and says nothing on a click is the one
  *  outcome a person cannot learn anything from — this is the same sentence the page opens with,
@@ -236,17 +262,15 @@ export async function action({ request }: ActionFunctionArgs) {
   if (intent !== "approve" && intent !== "deny") {
     // The two-state page's first state: resolve the typed code into the request card. A POST,
     // deliberately — the code never rides a URL (history, logs, referers all stay clean).
-    const userCode = String(form.get("code") ?? "")
-      .trim()
-      .toUpperCase();
+    const userCode = normalizeUserCode(String(form.get("code") ?? ""));
     if (userCode === "") {
       // In the page, not the house fault screen: an empty submit is the commonest thing a person
       // does by accident, and it has an answer they can act on.
       return data({ kind: "refused" as const, error: CODE_REQUIRED }, { status: 400 });
     }
-    // Longer than a code can be: answered like any other code that names nothing, and for free —
-    // a string that cannot be a code is not a guess of the code space, so it never spends the belt
-    // and never reaches the database.
+    // Longer than a code can be, once it has been spelled the way a code is spelled: answered
+    // like any other code that names nothing, and for free — a string that cannot be a code is not
+    // a guess of the code space, so it never spends the belt and never reaches the database.
     if (userCode.length > USER_CODE_LENGTH) {
       return { kind: "miss" as const };
     }
@@ -513,7 +537,9 @@ function CodeLookup() {
           <span className="mb-1 block font-medium text-dim text-sm">Code</span>
           {/* No `required`: the browser's own bubble is not this form's voice, and an empty
               submit has one answer — the action's line, in the app's words, in the same place
-              every other refusal on this page appears. */}
+              every other refusal on this page appears. The maxlength is the FULL spelling, so
+              typing the code without its hyphen (or with a space) still fits; the action puts the
+              hyphen back. */}
           <input
             type="text"
             name="code"

--- a/web/app/routes/version-files.tsx
+++ b/web/app/routes/version-files.tsx
@@ -75,11 +75,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   ]);
   const isCurrent = current.ok && current.data.version_id === versionId;
 
-  return { skill, versionId, isCurrent, versionFiles };
+  // `versionId` is the truth every read used; `versionRef` is the spelling the visitor arrived
+  // with, and it is what every link on this page is built from. A page opened on the 12-hex short
+  // id that linked on with the full 64-hex one swapped the address under the reader: the id in
+  // their bar stopped matching the one they had copied, and a shared link changed shape on the
+  // first click.
+  return { skill, versionId, versionRef: typed, isCurrent, versionFiles };
 }
 
 export default function VersionFilesPage() {
-  const { skill, versionId, isCurrent, versionFiles } = useLoaderData<typeof loader>();
+  const { skill, versionId, versionRef, isCurrent, versionFiles } = useLoaderData<typeof loader>();
   const wsPath = useWsPath();
   const base = useBundleBase();
   return (
@@ -96,7 +101,13 @@ export default function VersionFilesPage() {
         </header>
         <Breadcrumbs className="mt-1" />
       </div>
-      <VersionFiles skill={skill} versionId={versionId} currentChip={isCurrent} {...versionFiles} />
+      <VersionFiles
+        skill={skill}
+        versionId={versionId}
+        versionRef={versionRef}
+        currentChip={isCurrent}
+        {...versionFiles}
+      />
     </BrowseShell>
   );
 }

--- a/web/app/routes/version-files.tsx
+++ b/web/app/routes/version-files.tsx
@@ -4,7 +4,7 @@ import { BrowseShell } from "@/components/browse/shell";
 import { VersionFiles } from "@/components/browse/version-files";
 import { Breadcrumbs } from "@/components/shell/breadcrumbs";
 import { ShortId } from "@/components/ui";
-import { notFound, requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope, notFound } from "@/lib/auth/guards.server";
 import { loadVersionFilesData } from "@/lib/browse/version-files.server";
 import { baseOf, bundleNameOf, bundlePath, useBundleBase } from "@/lib/bundle-base";
 import { requireCanonicalBase } from "@/lib/bundle-base.server";
@@ -30,8 +30,10 @@ export function meta({
  *
  * Because this page can address any historical version, "current" is NOT the DB catalog row — it
  * is a LIVE comparison against the vault's pointer (`custodyCurrent`), which VersionFiles renders
- * as `currentChip`. Guard order mirrors the review page: requireMember first, a cheap shape check
- * on the version id, then the DB catalog probe (an unknown NAME is the uniform 404). Every vault
+ * as `currentChip`. Guard order mirrors the bundle face: membership first — and a signed-out
+ * visitor gets the house 404 there, not a bounce to /login, because this address is members-only
+ * in every face — then a cheap shape check on the version id, then the DB catalog probe (an
+ * unknown NAME is the uniform 404). Every vault
  * read rides the internal custody lane and keys on the immutable `skillId` — authorization
  * already happened in the guard.
  *
@@ -41,7 +43,7 @@ export function meta({
  * is the form a person copies, and it opens. An ambiguous or unmatched prefix is the uniform 404.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const ws = workspace.id;
   const base = baseOf(params);
   const skill = bundleNameOf(params);

--- a/web/app/routes/visibility.tsx
+++ b/web/app/routes/visibility.tsx
@@ -2,7 +2,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 import { relativeTime } from "@/components/format";
 import { buttonClasses, Card, PageHeader, SectionHeading, ShortId } from "@/components/ui";
-import { requireMemberInScope } from "@/lib/auth/guards.server";
+import { memberPageInScope } from "@/lib/auth/guards.server";
 import { type VisibleSession, visibleSessionsOf } from "@/lib/db/queries.sessions.server";
 import { useWsPath } from "@/lib/ws-path";
 
@@ -22,7 +22,7 @@ export function meta() {
  * rather than illustration.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { actor } = await requireMemberInScope(request, params);
+  const { actor } = await memberPageInScope(request, params);
   return { sessions: await visibleSessionsOf(actor) };
 }
 

--- a/web/app/routes/workspace-archive.tsx
+++ b/web/app/routes/workspace-archive.tsx
@@ -4,7 +4,11 @@ import { ConfirmButton, ConfirmNameField } from "@/components/confirm";
 import { SettingsTabs } from "@/components/settings-tabs";
 import { buttonClasses, Card, PageHeader } from "@/components/ui";
 import { requireTypedName } from "@/lib/auth/ceremony.server";
-import { requireMemberInScope, requireWorkspaceOwner } from "@/lib/auth/guards.server";
+import {
+  memberPageInScope,
+  requireMemberInScope,
+  requireWorkspaceOwner,
+} from "@/lib/auth/guards.server";
 import { recordAdminEvent } from "@/lib/db/audit.server";
 import {
   archivedSkillById,
@@ -26,7 +30,7 @@ export function meta({ params }: { params: { ws?: string } }) {
  * hands the page the owner flag so a plain member sees the list without the action controls.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const archived = await archivedSkillsOf(actor);
   return {
     wsName: workspace.name,

--- a/web/app/routes/workspace-members.tsx
+++ b/web/app/routes/workspace-members.tsx
@@ -11,6 +11,7 @@ import { RemoveMemberForm } from "@/components/members/remove-member-form";
 import { RoleForm } from "@/components/members/role-form";
 import { buttonClasses, Card, Chip, PageHeader, SectionHeading } from "@/components/ui";
 import {
+  memberPageInScope,
   requireMember,
   requireMemberInScope,
   requireWorkspaceOwner,
@@ -53,7 +54,7 @@ function lapseLabel(expiresAt: Date | null, now: number): string {
 }
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   const isOwner = actor.role === "owner";
   const [roster, pending] = await Promise.all([rosterOf(actor), pendingInvitationsOf(actor)]);
   const displayByUserId = new Map(roster.map((seat) => [seat.userId, seat.display]));

--- a/web/app/routes/workspace-settings.tsx
+++ b/web/app/routes/workspace-settings.tsx
@@ -15,7 +15,11 @@ import { StalenessWindowPanel } from "@/components/policy/staleness-window-panel
 import { SettingsTabs } from "@/components/settings-tabs";
 import { buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
 import { composition } from "@/composition.server";
-import { requireMemberInScope, requireWorkspaceOwner } from "@/lib/auth/guards.server";
+import {
+  memberPageInScope,
+  requireMemberInScope,
+  requireWorkspaceOwner,
+} from "@/lib/auth/guards.server";
 import { type AuditEventRow, lastAuditEventOfKind, recordAdminEvent } from "@/lib/db/audit.server";
 import {
   setMcpGateway,
@@ -47,7 +51,7 @@ function lastSetOf(row: AuditEventRow | undefined): LastSetLine | null {
 }
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { workspace, actor } = await requireMemberInScope(request, params);
+  const { workspace, actor } = await memberPageInScope(request, params);
   // Management is a confirmed OWNER seat — the actor's role IS the seat table's.
   const isOwner = actor.role === "owner";
   // The registration knob governs sign-up only where the install IS the workspace (single

--- a/web/scripts/check-boundary.mjs
+++ b/web/scripts/check-boundary.mjs
@@ -373,11 +373,13 @@ const SESSIONLESS_ROUTES = new Set([
   // The lane's catch-all answers the constant uniform 404 — it reads nothing.
   "api.v1.$",
 ]);
-// The guard family: the request-level require* mints plus memberInScope — the one
-// membership-or-404 resolution the face modules call on their signed-in arm (their anonymous
-// arm resolves the session itself, teaser-or-404, so the require* wrappers cannot front them).
+// The guard family: the request-level require* mints, memberPageInScope (the member-only PAGE
+// guard, which answers a signed-out visitor with the house 404 instead of the /login bounce), and
+// memberInScope — the one membership-or-404 resolution the face modules call on their signed-in
+// arm (their anonymous arm resolves the session itself, teaser-or-404, so the require* wrappers
+// cannot front them).
 const GUARD_CALL =
-  /\b(?:require(?:SessionActorPreBody|SessionActor|ReadActor|Session|MemberInScope|Member|OwnerInScope|WorkspaceOwner|Reviewer)|memberInScope)\s*\(/;
+  /\b(?:require(?:SessionActorPreBody|SessionActor|ReadActor|Session|MemberInScope|Member|OwnerInScope|WorkspaceOwner|Reviewer)|memberPageInScope|memberInScope)\s*\(/;
 const READS_DATA = /export\s+(?:async\s+)?(?:function|const)\s+(?:loader|action)\b/;
 for (const { rel, text, base } of files) {
   if (!rel.startsWith(ROUTES_DIR)) {

--- a/web/scripts/check-boundary.mjs
+++ b/web/scripts/check-boundary.mjs
@@ -373,13 +373,13 @@ const SESSIONLESS_ROUTES = new Set([
   // The lane's catch-all answers the constant uniform 404 — it reads nothing.
   "api.v1.$",
 ]);
-// The guard family: the request-level require* mints, memberPageInScope (the member-only PAGE
-// guard, which answers a signed-out visitor with the house 404 instead of the /login bounce), and
-// memberInScope — the one membership-or-404 resolution the face modules call on their signed-in
-// arm (their anonymous arm resolves the session itself, teaser-or-404, so the require* wrappers
-// cannot front them).
+// The guard family: the request-level require* mints, the PAGE guards (memberPageInScope /
+// ownerPageInScope, which answer a signed-out visitor with the house 404 instead of the /login
+// bounce), and memberInScope — the one membership-or-404 resolution the face modules call on their
+// signed-in arm (their anonymous arm resolves the session itself, teaser-or-404, so the require*
+// wrappers cannot front them).
 const GUARD_CALL =
-  /\b(?:require(?:SessionActorPreBody|SessionActor|ReadActor|Session|MemberInScope|Member|OwnerInScope|WorkspaceOwner|Reviewer)|memberPageInScope|memberInScope)\s*\(/;
+  /\b(?:require(?:SessionActorPreBody|SessionActor|ReadActor|Session|MemberInScope|Member|OwnerInScope|ShellActor|WorkspaceOwner|Reviewer)|memberPageInScope|ownerPageInScope|memberInScope)\s*\(/;
 const READS_DATA = /export\s+(?:async\s+)?(?:function|const)\s+(?:loader|action)\b/;
 for (const { rel, text, base } of files) {
   if (!rel.startsWith(ROUTES_DIR)) {

--- a/web/tests/e2e/landing.spec.ts
+++ b/web/tests/e2e/landing.spec.ts
@@ -39,11 +39,22 @@ test.describe("the public landing page", () => {
     await expect(page.locator('a[href="/app"]').first()).toBeVisible();
   });
 
-  test("signed-out visits to the app bounce to login", async ({ page }) => {
-    // A member page under the shell: the cookie middleware bounces a signed-out visitor to /login.
+  test("a signed-out visitor gets the house 404 at a workspace page, and /login only where there is something to sign in for", async ({
+    page,
+  }) => {
+    // A WORKSPACE address is members-only in every face: the same uniform miss a mistyped path
+    // gets, so nothing about it confirms what exists. The shell's optimistic cookie check runs
+    // before any loader, so it is this answer a signed-out person actually meets.
     await page.goto("/members");
-    await page.waitForURL((u) => u.pathname === "/login");
+    await expect(page.getByRole("heading", { name: "Not found" })).toBeVisible();
+    await page.goto("/skills/browse-runbook/history");
+    await expect(page.getByRole("heading", { name: "Not found" })).toBeVisible();
+
+    // The door into the product, and a page that is a PERSON'S rather than a workspace's, both
+    // still send a signed-out visitor somewhere they can act.
     await page.goto("/app");
+    await page.waitForURL((u) => u.pathname === "/login");
+    await page.goto("/account/sessions");
     await page.waitForURL((u) => u.pathname === "/login");
   });
 

--- a/web/tests/e2e/verify.spec.ts
+++ b/web/tests/e2e/verify.spec.ts
@@ -103,6 +103,22 @@ test("an unknown code is an honest in-page state, never a 404", async ({ page })
   await expect(page.getByText("No pending request for that code")).toBeVisible();
 });
 
+test("an empty submit says what to do, and the field takes no more than a code", async ({
+  page,
+}) => {
+  await page.goto("/verify");
+  // Clicking Look up with nothing typed used to do nothing a person could see.
+  await page.getByRole("button", { name: "Look up" }).click();
+  await expect(page.getByRole("alert")).toHaveText("Enter the code your terminal shows");
+
+  // The field stops at the code's own shape, so a stray paste cannot ride into the lookup.
+  const field = page.getByLabel("Code");
+  await expect(field).toHaveAttribute("maxlength", "9");
+  // Typed, not set: maxlength is a browser rule about typing, and typing is what a paste is.
+  await field.pressSequentially("AB29-CD34EXTRA");
+  expect(await field.inputValue()).toBe("AB29-CD34");
+});
+
 test("the ONE-SEAT one-click: approve records the choice and THE POLL mints the credential", async ({
   page,
 }) => {

--- a/web/tests/e2e/verify.spec.ts
+++ b/web/tests/e2e/verify.spec.ts
@@ -103,6 +103,13 @@ test("an unknown code is an honest in-page state, never a 404", async ({ page })
   await expect(page.getByText("No pending request for that code")).toBeVisible();
 });
 
+test("a code typed without its hyphen is the same code", async ({ page }) => {
+  // The grouping is there so a code can be read aloud; it is not part of what a code is.
+  const flow = await startLoginFlow(page, "e2e-hyphenless");
+  await lookUp(page, flow.user_code.replace("-", ""));
+  await expect(page.getByText("\u201ce2e-hyphenless\u201d", { exact: true })).toBeVisible();
+});
+
 test("an empty submit says what to do, and the field takes no more than a code", async ({
   page,
 }) => {

--- a/web/tests/unit/gateway-panel.test.ts
+++ b/web/tests/unit/gateway-panel.test.ts
@@ -8,7 +8,6 @@ import {
   type ScratchDb,
   seatUser,
   seedBundle,
-  seedSession,
   seedUser,
 } from "./helpers/scratch-db";
 
@@ -22,8 +21,9 @@ import {
  *  - the policy hangs off the CONNECTION: disconnecting takes it and its selections with it, which
  *    is a database cascade rather than cleanup code somebody has to remember to write;
  *  - sign-in resolution is the gateway's own — the person's credential first, the workspace
- *    service account second — and the page never sees more than metadata;
- *  - the usage window is newest-first and bounded with the +1 probe the audit windows use.
+ *    service account second — and the page never sees more than metadata.
+ *
+ * The Usage table has its own suite (gateway-usage.test.ts) — it is a read of its own shape.
  */
 
 let db: ScratchDb;
@@ -87,29 +87,6 @@ async function seedTool(serverId: string, name: string, offered = true) {
   );
 }
 
-async function seedUsage(
-  serverId: string,
-  userId: string,
-  sessionId: string,
-  toolName: string | null,
-  outcome: string,
-) {
-  await db.q(
-    `INSERT INTO gateway.usage_event
-       (workspace_id, server_id, session_id, user_id, tool_name, method, outcome, duration_ms)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, 12)`,
-    [
-      ws,
-      serverId,
-      sessionId,
-      userId,
-      toolName,
-      toolName === null ? "initialize" : "tools/call",
-      outcome,
-    ],
-  );
-}
-
 beforeAll(async () => {
   db = await createScratchDb("web_gateway_panel");
   await applyGatewayDdl(db.url);
@@ -118,7 +95,6 @@ beforeAll(async () => {
   await seatUser(db, ws, MEMBER, "member");
   await seedUser(db, OTHER, "Ola Other", "ola@example.com");
   await seatUser(db, ws, OTHER, "member");
-  await seedSession(db, "cs_laptop", ws, MEMBER, "active", "Mo's laptop");
 
   await seedServer(SERVER, "com.example/gated");
   await connect("b_gated", "gated-server", SERVER);
@@ -280,39 +256,5 @@ describe("the sign-in state", () => {
     );
     const state = await (await dal()).mcpSignInState(member(), SERVER);
     expect(state.mine?.credentialId).toBe(CRED_MINE);
-  });
-});
-
-describe("the usage window", () => {
-  it("is empty before anything has been called", async () => {
-    const window = await (await dal()).mcpUsageWindow(member(), OTHER_SERVER);
-    expect(window).toEqual({ events: [], hasMore: false });
-  });
-
-  it("names the person and the machine, newest first", async () => {
-    await seedUsage(SERVER, MEMBER, "cs_laptop", null, "ok");
-    await seedUsage(SERVER, MEMBER, "cs_laptop", "search", "ok");
-    await seedUsage(SERVER, MEMBER, "cs_laptop", "create_issue", "denied_tool");
-
-    const window = await (await dal()).mcpUsageWindow(member(), SERVER);
-    expect(window.hasMore).toBe(false);
-    expect(window.events.map((row) => row.toolName)).toEqual(["create_issue", "search", null]);
-    expect(window.events[0]?.person).toBe("Mo Member");
-    expect(window.events[0]?.machine).toBe("Mo's laptop");
-    expect(window.events[0]?.outcome).toBe("denied_tool");
-    expect(window.events[0]?.createdAtMs).toBeGreaterThan(0);
-  });
-
-  it("bounds the window and says so with the +1 probe", async () => {
-    const window = await (await dal()).mcpUsageWindow(member(), SERVER, { limit: 2 });
-    expect(window.events).toHaveLength(2);
-    expect(window.hasMore).toBe(true);
-  });
-
-  it("stands in for a gone account and a removed machine rather than dropping the row", async () => {
-    await seedUsage(SERVER, "u_ghost", "cs_ghost", "search", "upstream_error");
-    const window = await (await dal()).mcpUsageWindow(member(), SERVER, { limit: 1 });
-    expect(window.events[0]?.person).toBe("former member");
-    expect(window.events[0]?.machine).toBe("a removed machine");
   });
 });

--- a/web/tests/unit/gateway-usage.test.ts
+++ b/web/tests/unit/gateway-usage.test.ts
@@ -1,0 +1,369 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  createStaticHandler,
+  createStaticRouter,
+  type RouteObject,
+  StaticRouterProvider,
+} from "react-router";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { applyGatewayDdl } from "../helpers/gateway-ddl";
+import { mcpRevisionId } from "../helpers/mcp-ids";
+import {
+  asMember,
+  bootWorkspace,
+  createScratchDb,
+  type ScratchDb,
+  seatUser,
+  seedBundle,
+  seedSession,
+  seedUser,
+} from "./helpers/scratch-db";
+
+/**
+ * THE USAGE TABLE on a connected server's page, against a REAL scratch Postgres.
+ *
+ * The ledger is per-CALL and a working agent makes hundreds of them, so the table that rendered
+ * one row per call rendered a hundred visually identical lines — same person, same machine, the
+ * same "ok just now", and a `—` under Tool on nearly every one, because most calls through a
+ * gateway are not tool calls. Nothing in it could be acted on, and everything past the hundredth
+ * was silently gone.
+ *
+ * A row is now one SESSION — the unit a person can do something about — and the ledger is paged
+ * rather than windowed. What this suite holds still:
+ *
+ *  - the counts are per session and the outcomes are split ok / not-ok, so one failing machine is
+ *    visible next to a healthy one instead of averaged into a wall of lines;
+ *  - a session that only ever spoke non-tool methods carries NO tools rather than a dash column;
+ *  - rows come back by most recent activity, so the machine that just called is the first read;
+ *  - the page number is CLAMPED, never trusted: a hand-typed `?page=99` reads the last page, and
+ *    an unparseable one reads the first — an empty table would read as "no calls";
+ *  - `?page=2` on the real route hands the page's own component the second page and says so.
+ */
+
+let session: { user: { id: string; name: string; email: string } } | null = null;
+vi.mock("@/lib/auth/server", () => ({
+  getAuth: () => ({ api: { getSession: async () => session } }),
+}));
+
+let db: ScratchDb;
+let ws = "";
+
+const ORIGIN = "http://x";
+const MEMBER = { id: "u_mem", name: "Mo Member", email: "mo@example.com" };
+const SERVER = "mcps_usage";
+const QUIET_SERVER = "mcps_quiet";
+const BUNDLE_NAME = "deepwiki";
+
+const LAPTOP = "cs_laptop";
+const RUNNER = "cs_runner";
+
+const member = () => asMember(ws, MEMBER.id, "member", MEMBER.name);
+
+async function dal() {
+  return await import("@/lib/db/queries.gateway.server");
+}
+
+async function seedServer(id: string, name: string): Promise<void> {
+  await db.q(
+    `INSERT INTO web.mcp_server (id, workspace_id, name, display_name, auth_mode, status)
+     VALUES ($1, NULL, $2, $2, 'oauth', 'active')`,
+    [id, name],
+  );
+  const revision = mcpRevisionId(id);
+  await db.q(
+    `INSERT INTO web.mcp_server_revision
+       (id, server_id, seq, upstream_version, document, transport, url, published_at, published_by)
+     VALUES ($1, $2, 1, '1.0.0', $3::jsonb, 'streamable-http', 'https://mcp.example.com/mcp',
+             now(), 'Staff')`,
+    [revision, id, JSON.stringify({ name, version: "1.0.0" })],
+  );
+  await db.q(`UPDATE web.mcp_server SET current_revision_id = $2 WHERE id = $1`, [id, revision]);
+}
+
+async function connect(bundleId: string, bundleName: string, serverId: string): Promise<void> {
+  await seedBundle(db, ws, bundleId, bundleName, { kind: "mcp", withPointer: false });
+  await db.q(
+    `INSERT INTO web.bundle_mcp (bundle_id, workspace_id, server_id) VALUES ($1, $2, $3)`,
+    [bundleId, ws, serverId],
+  );
+}
+
+/** One call, placed on the clock by minutes-ago so the ordering under test is the real one. */
+async function call(
+  serverId: string,
+  sessionId: string,
+  userId: string,
+  toolName: string | null,
+  outcome: string,
+  minutesAgo: number,
+): Promise<void> {
+  await db.q(
+    `INSERT INTO gateway.usage_event
+       (workspace_id, server_id, session_id, user_id, tool_name, method, outcome, duration_ms,
+        created_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 12, now() - ($8 || ' minutes')::interval)`,
+    [
+      ws,
+      serverId,
+      sessionId,
+      userId,
+      toolName,
+      toolName === null ? "initialize" : "tools/call",
+      outcome,
+      String(minutesAgo),
+    ],
+  );
+}
+
+beforeAll(async () => {
+  db = await createScratchDb("web_gateway_usage", {
+    // The panel is read only where a gateway is deployed; with no lane there is no table at all.
+    GATEWAY_INTERNAL_URL: "http://gateway.internal:8789",
+    GATEWAY_INTERNAL_TOKEN: "internal-token-unit",
+  });
+  await applyGatewayDdl(db.url);
+  ws = await bootWorkspace();
+  await seedUser(db, MEMBER.id, MEMBER.name, MEMBER.email);
+  await seatUser(db, ws, MEMBER.id, "member");
+  await seedSession(db, LAPTOP, ws, MEMBER.id, "active", "Mo's laptop");
+  await seedSession(db, RUNNER, ws, MEMBER.id, "active", "release runner");
+  await seedServer(SERVER, "com.example/deepwiki");
+  await connect("b_deepwiki", BUNDLE_NAME, SERVER);
+  await seedServer(QUIET_SERVER, "com.example/quiet");
+  await connect("b_quiet", "quiet-server", QUIET_SERVER);
+  session = { user: MEMBER };
+}, 60000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+describe("aggregating the ledger per session", () => {
+  it("is empty before anything has been called", async () => {
+    const page = await (await dal()).mcpUsageSessions(member(), QUIET_SERVER);
+    expect(page).toEqual({ sessions: [], page: 1, pageCount: 1, total: 0 });
+  });
+
+  it("gives one row per session, counted and split ok / failed, newest activity first", async () => {
+    // The laptop: five calls over an hour, two of which did not end ok.
+    await call(SERVER, LAPTOP, MEMBER.id, null, "ok", 60);
+    await call(SERVER, LAPTOP, MEMBER.id, "search", "ok", 40);
+    await call(SERVER, LAPTOP, MEMBER.id, "search", "ok", 30);
+    await call(SERVER, LAPTOP, MEMBER.id, "create_issue", "denied_tool", 20);
+    await call(SERVER, LAPTOP, MEMBER.id, "create_issue", "upstream_error", 10);
+    // The runner: two clean calls, and the most recent activity on the server.
+    await call(SERVER, RUNNER, MEMBER.id, "search", "ok", 9);
+    await call(SERVER, RUNNER, MEMBER.id, "search", "ok", 2);
+
+    const page = await (await dal()).mcpUsageSessions(member(), SERVER);
+
+    expect(page.total).toBe(2);
+    expect(page.pageCount).toBe(1);
+    expect(page.page).toBe(1);
+    // Seven calls, two rows — the whole point of the change.
+    expect(page.sessions).toHaveLength(2);
+    expect(page.sessions.map((row) => row.sessionId)).toEqual([RUNNER, LAPTOP]);
+
+    const [runner, laptop] = page.sessions;
+    expect(runner).toMatchObject({
+      person: "Mo Member",
+      machine: "release runner",
+      calls: 2,
+      ok: 2,
+      failed: 0,
+      tools: ["search"],
+    });
+    expect(laptop).toMatchObject({
+      machine: "Mo's laptop",
+      calls: 5,
+      ok: 3,
+      failed: 2,
+      // Distinct and alphabetical — five calls, two tools named once each.
+      tools: ["create_issue", "search"],
+    });
+    // The stretch the row covers, not the moment one call landed.
+    expect(laptop?.firstCallMs).toBeLessThan(laptop?.lastCallMs ?? 0);
+    expect(runner?.lastCallMs).toBeGreaterThan(laptop?.lastCallMs ?? 0);
+  });
+
+  it("carries no tools for a session that only ever spoke non-tool methods", async () => {
+    await call(QUIET_SERVER, LAPTOP, MEMBER.id, null, "ok", 5);
+    await call(QUIET_SERVER, LAPTOP, MEMBER.id, null, "no_credential", 4);
+
+    const page = await (await dal()).mcpUsageSessions(member(), QUIET_SERVER);
+    expect(page.sessions).toHaveLength(1);
+    expect(page.sessions[0]?.tools).toEqual([]);
+    expect(page.sessions[0]).toMatchObject({ calls: 2, ok: 1, failed: 1 });
+  });
+
+  it("stands in for a gone account and a removed machine rather than dropping the row", async () => {
+    await call(SERVER, "cs_ghost", "u_ghost", "search", "unauthorized", 1);
+    const page = await (await dal()).mcpUsageSessions(member(), SERVER);
+    expect(page.sessions[0]).toMatchObject({
+      person: "former member",
+      machine: "a removed machine",
+      calls: 1,
+      ok: 0,
+      failed: 1,
+    });
+  });
+
+  it("clamps a page number past the end, and an unparseable one, onto a real page", async () => {
+    const far = await (await dal()).mcpUsageSessions(member(), SERVER, { page: 99 });
+    expect(far.page).toBe(1);
+    expect(far.pageCount).toBe(1);
+    expect(far.sessions.length).toBeGreaterThan(0);
+
+    const nonsense = await (await dal()).mcpUsageSessions(member(), SERVER, { page: Number.NaN });
+    expect(nonsense.page).toBe(1);
+  });
+
+  it("sees nothing of another workspace's calls against the same server", async () => {
+    await call(SERVER, "cs_elsewhere", MEMBER.id, "search", "ok", 1);
+    await db.q(
+      `UPDATE gateway.usage_event SET workspace_id = 'ws_elsewhere' WHERE session_id = $1`,
+      ["cs_elsewhere"],
+    );
+    const page = await (await dal()).mcpUsageSessions(member(), SERVER);
+    expect(page.sessions.map((row) => row.sessionId)).not.toContain("cs_elsewhere");
+  });
+});
+
+describe("the server page's Usage pages", () => {
+  const PAGED_SERVER = "mcps_paged";
+  const PAGED_BUNDLE = "linear";
+  /** One over a page, so page 2 holds exactly the spill. */
+  const MACHINES = 26;
+
+  beforeAll(async () => {
+    await seedServer(PAGED_SERVER, "com.example/linear");
+    await connect("b_linear", PAGED_BUNDLE, PAGED_SERVER);
+    for (let i = 0; i < MACHINES; i += 1) {
+      const id = `cs_fleet_${String(i).padStart(2, "0")}`;
+      await seedSession(db, id, ws, MEMBER.id, "active", `fleet ${i}`);
+      // Machine 0 called most recently, machine 25 longest ago — so the oldest is the page-2 row.
+      await call(PAGED_SERVER, id, MEMBER.id, "search", "ok", i + 1);
+    }
+  }, 60000);
+
+  it("fills page 1 and spills the oldest machine onto page 2", async () => {
+    const first = await (await dal()).mcpUsageSessions(member(), PAGED_SERVER);
+    expect(first).toMatchObject({ page: 1, pageCount: 2, total: MACHINES });
+    expect(first.sessions).toHaveLength(25);
+    expect(first.sessions[0]?.machine).toBe("fleet 0");
+
+    const second = await (await dal()).mcpUsageSessions(member(), PAGED_SERVER, { page: 2 });
+    expect(second).toMatchObject({ page: 2, pageCount: 2, total: MACHINES });
+    expect(second.sessions).toHaveLength(1);
+    expect(second.sessions[0]?.machine).toBe("fleet 25");
+  });
+
+  it("hands the route's `?page=2` to the page, and page 1 without it", async () => {
+    const { loader } = await import("@/routes/skill-current");
+    const load = async (query: string) =>
+      (await loader({
+        request: new Request(`${ORIGIN}/mcp/${PAGED_BUNDLE}${query}`),
+        params: { server: PAGED_BUNDLE },
+        context: {},
+      } as unknown as Parameters<typeof loader>[0])) as {
+        gateway: { usage: { page: number; pageCount: number; total: number; sessions: unknown[] } };
+      };
+
+    const bare = await load("");
+    expect(bare.gateway.usage).toMatchObject({ page: 1, pageCount: 2, total: MACHINES });
+    expect(bare.gateway.usage.sessions).toHaveLength(25);
+
+    const page2 = await load("?page=2");
+    expect(page2.gateway.usage).toMatchObject({ page: 2, pageCount: 2, total: MACHINES });
+    expect(page2.gateway.usage.sessions).toHaveLength(1);
+  });
+});
+
+/** Render the panel the way the server face does, inside a router so its links resolve. */
+async function renderPanel(usage: unknown): Promise<string> {
+  const { McpGatewayPanel } = await import("@/components/skill/mcp-gateway");
+  const view = {
+    displayName: "Linear",
+    authMode: "none",
+    signedIn: null,
+    canConnectPersonal: false,
+    canConnectWorkspace: false,
+    mode: "all",
+    tools: [],
+    usage,
+  };
+  const routes: RouteObject[] = [
+    {
+      // The real address, so the pager's search-only links resolve the way they do in the app.
+      path: "/mcp/:server",
+      Component: () =>
+        createElement(McpGatewayPanel, {
+          view: view as Parameters<typeof McpGatewayPanel>[0]["view"],
+        }),
+    },
+  ];
+  const handler = createStaticHandler(routes);
+  const context = await handler.query(new Request(`${ORIGIN}/mcp/${BUNDLE_NAME}`));
+  if (context instanceof Response) {
+    throw new Error("expected a rendered context, got a Response");
+  }
+  const router = createStaticRouter(handler.dataRoutes, context);
+  return renderToStaticMarkup(createElement(StaticRouterProvider, { router, context }));
+}
+
+function usageRow(overrides: Record<string, unknown>) {
+  return {
+    sessionId: "cs_laptop",
+    person: "Mo Member",
+    machine: "Mo's laptop",
+    calls: 5,
+    ok: 3,
+    failed: 2,
+    tools: ["create_issue", "search"],
+    firstCallMs: Date.now() - 3_600_000,
+    lastCallMs: Date.now() - 60_000,
+    ...overrides,
+  };
+}
+
+describe("what the Usage table renders", () => {
+  it("says how many sessions there are in total, and where in them the reader stands", async () => {
+    const html = await renderPanel({
+      sessions: [usageRow({}), usageRow({ sessionId: "cs_runner", machine: "release runner" })],
+      page: 2,
+      pageCount: 4,
+      total: 84,
+    });
+    expect(html).toContain("84 sessions, newest activity first — page 2 of 4.");
+    // Two rows for two sessions, whatever the call count on them.
+    expect(html.match(/data-testid="mcp-usage-cs_/g)).toHaveLength(2);
+    expect(html).toContain("3 ok · 2 failed");
+    expect(html).toContain("create_issue, search");
+  });
+
+  it("offers both directions in the middle of the ledger", async () => {
+    const html = await renderPanel({ sessions: [usageRow({})], page: 2, pageCount: 4, total: 84 });
+    expect(html).toContain('href="/mcp/deepwiki?page=1"');
+    expect(html).toContain('href="/mcp/deepwiki?page=3"');
+  });
+
+  it("offers no page control at all when the whole ledger fits on one page", async () => {
+    const html = await renderPanel({ sessions: [usageRow({})], page: 1, pageCount: 1, total: 1 });
+    expect(html).toContain("1 session, newest activity first.");
+    expect(html).not.toContain('data-testid="mcp-usage-pager"');
+  });
+
+  it("says `—` once for a session that called no tools, not a column of them", async () => {
+    const html = await renderPanel({
+      sessions: [usageRow({ tools: [], calls: 2, ok: 2, failed: 0 })],
+      page: 1,
+      pageCount: 1,
+      total: 1,
+    });
+    const row = html.slice(html.indexOf('data-testid="mcp-usage-cs_laptop"'));
+    const cells = row.slice(0, row.indexOf("</tr>"));
+    // One dash in the whole row: the Tools cell. Every other cell carries a real number.
+    expect(cells.match(/—/g)).toHaveLength(1);
+  });
+});

--- a/web/tests/unit/gateway-usage.test.ts
+++ b/web/tests/unit/gateway-usage.test.ts
@@ -182,6 +182,13 @@ describe("aggregating the ledger per session", () => {
       // Distinct and alphabetical — five calls, two tools named once each.
       tools: ["create_issue", "search"],
     });
+    // WHY they failed, not just how many: one call the tool policy refused and one the server
+    // broke on are different problems, and the counts sum to `failed`.
+    expect(laptop?.failures).toEqual([
+      { kind: "denied_tool", count: 1 },
+      { kind: "upstream_error", count: 1 },
+    ]);
+    expect(runner?.failures).toEqual([]);
     // The stretch the row covers, not the moment one call landed.
     expect(laptop?.firstCallMs).toBeLessThan(laptop?.lastCallMs ?? 0);
     expect(runner?.lastCallMs).toBeGreaterThan(laptop?.lastCallMs ?? 0);
@@ -195,6 +202,26 @@ describe("aggregating the ledger per session", () => {
     expect(page.sessions).toHaveLength(1);
     expect(page.sessions[0]?.tools).toEqual([]);
     expect(page.sessions[0]).toMatchObject({ calls: 2, ok: 1, failed: 1 });
+    expect(page.sessions[0]?.failures).toEqual([{ kind: "no_credential", count: 1 }]);
+  });
+
+  it("orders the failure kinds by how many, so the biggest problem reads first", async () => {
+    await seedSession(db, "cs_flaky", ws, MEMBER.id, "active", "flaky box");
+    for (let i = 0; i < 3; i += 1) {
+      await call(SERVER, "cs_flaky", MEMBER.id, "search", "upstream_error", 40 + i);
+    }
+    await call(SERVER, "cs_flaky", MEMBER.id, "create_issue", "denied_tool", 39);
+    await call(SERVER, "cs_flaky", MEMBER.id, null, "unauthorized", 38);
+
+    const page = await (await dal()).mcpUsageSessions(member(), SERVER);
+    const flaky = page.sessions.find((row) => row.sessionId === "cs_flaky");
+    expect(flaky?.failed).toBe(5);
+    // Biggest first; the two ones tie and break by name, so the row never reorders itself.
+    expect(flaky?.failures).toEqual([
+      { kind: "upstream_error", count: 3 },
+      { kind: "denied_tool", count: 1 },
+      { kind: "unauthorized", count: 1 },
+    ]);
   });
 
   it("stands in for a gone account and a removed machine rather than dropping the row", async () => {
@@ -320,6 +347,10 @@ function usageRow(overrides: Record<string, unknown>) {
     calls: 5,
     ok: 3,
     failed: 2,
+    failures: [
+      { kind: "no_credential", count: 2 },
+      { kind: "upstream_error", count: 1 },
+    ],
     tools: ["create_issue", "search"],
     firstCallMs: Date.now() - 3_600_000,
     lastCallMs: Date.now() - 60_000,
@@ -338,7 +369,8 @@ describe("what the Usage table renders", () => {
     expect(html).toContain("84 sessions, newest activity first — page 2 of 4.");
     // Two rows for two sessions, whatever the call count on them.
     expect(html.match(/data-testid="mcp-usage-cs_/g)).toHaveLength(2);
-    expect(html).toContain("3 ok · 2 failed");
+    // The cell names the kinds: "3 failed" alone is a number nobody can act on.
+    expect(html).toContain("3 ok · 2 failed (2 no sign-in, 1 server error)");
     expect(html).toContain("create_issue, search");
   });
 
@@ -354,9 +386,20 @@ describe("what the Usage table renders", () => {
     expect(html).not.toContain('data-testid="mcp-usage-pager"');
   });
 
+  it("says only the counts for a session where nothing failed", async () => {
+    const html = await renderPanel({
+      sessions: [usageRow({ calls: 4, ok: 4, failed: 0, failures: [] })],
+      page: 1,
+      pageCount: 1,
+      total: 1,
+    });
+    expect(html).toContain("4 ok · 0 failed");
+    expect(html).not.toContain("4 ok · 0 failed (");
+  });
+
   it("says `—` once for a session that called no tools, not a column of them", async () => {
     const html = await renderPanel({
-      sessions: [usageRow({ tools: [], calls: 2, ok: 2, failed: 0 })],
+      sessions: [usageRow({ tools: [], calls: 2, ok: 2, failed: 0, failures: [] })],
       page: 1,
       pageCount: 1,
       total: 1,

--- a/web/tests/unit/gateway-usage.test.ts
+++ b/web/tests/unit/gateway-usage.test.ts
@@ -307,8 +307,9 @@ describe("the server page's Usage pages", () => {
   });
 });
 
-/** Render the panel the way the server face does, inside a router so its links resolve. */
-async function renderPanel(usage: unknown): Promise<string> {
+/** Render the panel the way the server face does, inside a router so its links resolve. The
+ *  search string is the page's real address — a pager link is built against it. */
+async function renderPanel(usage: unknown, search = ""): Promise<string> {
   const { McpGatewayPanel } = await import("@/components/skill/mcp-gateway");
   const view = {
     displayName: "Linear",
@@ -331,7 +332,7 @@ async function renderPanel(usage: unknown): Promise<string> {
     },
   ];
   const handler = createStaticHandler(routes);
-  const context = await handler.query(new Request(`${ORIGIN}/mcp/${BUNDLE_NAME}`));
+  const context = await handler.query(new Request(`${ORIGIN}/mcp/${BUNDLE_NAME}${search}`));
   if (context instanceof Response) {
     throw new Error("expected a rendered context, got a Response");
   }
@@ -375,9 +376,37 @@ describe("what the Usage table renders", () => {
   });
 
   it("offers both directions in the middle of the ledger", async () => {
-    const html = await renderPanel({ sessions: [usageRow({})], page: 2, pageCount: 4, total: 84 });
+    const html = await renderPanel(
+      { sessions: [usageRow({})], page: 2, pageCount: 4, total: 84 },
+      "?page=2",
+    );
     expect(html).toContain('href="/mcp/deepwiki?page=1"');
     expect(html).toContain('href="/mcp/deepwiki?page=3"');
+  });
+
+  it("carries the rest of the address through a page turn", async () => {
+    // The post-publish placement note lives in the query. Turning a page is a move WITHIN this
+    // page, not a fresh arrival at it, so a page link rewrites `page` and nothing else.
+    const html = await renderPanel(
+      { sessions: [usageRow({})], page: 2, pageCount: 4, total: 84 },
+      "?placement=curated_role_required&channel=eng&page=2",
+    );
+    expect(html).toContain(
+      'href="/mcp/deepwiki?placement=curated_role_required&amp;channel=eng&amp;page=1"',
+    );
+    expect(html).toContain(
+      'href="/mcp/deepwiki?placement=curated_role_required&amp;channel=eng&amp;page=3"',
+    );
+  });
+
+  it("adds `page` to an address that never carried one", async () => {
+    const html = await renderPanel(
+      { sessions: [usageRow({})], page: 1, pageCount: 3, total: 60 },
+      "?placement=channel_not_found&channel=eng",
+    );
+    expect(html).toContain(
+      'href="/mcp/deepwiki?placement=channel_not_found&amp;channel=eng&amp;page=2"',
+    );
   });
 
   it("offers no page control at all when the whole ledger fits on one page", async () => {

--- a/web/tests/unit/sessions-page.test.ts
+++ b/web/tests/unit/sessions-page.test.ts
@@ -1,0 +1,91 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  createStaticHandler,
+  createStaticRouter,
+  type RouteObject,
+  StaticRouterProvider,
+} from "react-router";
+import { describe, expect, it } from "vitest";
+
+/**
+ * THE SESSIONS LIST'S OWN HEADING, rendered — the one thing about this page a cold reader can
+ * read as a lie.
+ *
+ * The list holds every session that is not waiting for approval, and staleness is a property OF a
+ * session in it, not a reason to leave it out: a machine nobody has heard from in a week sits in
+ * the list carrying a `stale` chip. A heading that called the list "Active sessions" therefore
+ * contradicted the counts line directly above it ("1 active session · 1 stale") over a list of
+ * two. The heading names the list; the counts line qualifies it.
+ */
+
+const STALE = 1_000;
+const WINDOW_MS = 60_000;
+const NOW = Date.now();
+
+function session(overrides: Record<string, unknown>) {
+  return {
+    sessionId: "sn_one",
+    displayName: "topos CLI (mac)",
+    ownerDisplay: "Olive Owner",
+    ownerEmail: "olive@example.com",
+    ownerUserId: "u_owner",
+    status: "active",
+    createdAtMs: NOW - WINDOW_MS,
+    lastSeenAtMs: NOW,
+    expired: false,
+    freshness: "fresh",
+    skills: [],
+    declinedButApplied: [],
+    ...overrides,
+  };
+}
+
+/** One fresh machine and one the workspace has not heard from — the counts line's "1 · 1" case. */
+function pageData() {
+  return {
+    view: {
+      sessions: [
+        session({}),
+        session({
+          sessionId: "sn_two",
+          displayName: "topos CLI (linux)",
+          lastSeenAtMs: NOW - WINDOW_MS - STALE,
+          freshness: "stale",
+        }),
+      ],
+      stalenessWindowMs: WINDOW_MS,
+      sessionApproval: "off",
+      sessionMaxAgeMs: null,
+      wholeWorkspace: true,
+    },
+    serviceSessions: [],
+    isOwner: true,
+  };
+}
+
+async function renderPage(): Promise<string> {
+  const { default: Component } = await import("@/routes/sessions");
+  const routes: RouteObject[] = [{ path: "/", loader: () => pageData(), Component }];
+  const handler = createStaticHandler(routes);
+  const context = await handler.query(new Request("http://localhost/"));
+  if (context instanceof Response) {
+    throw new Error("expected a rendered context, got a Response");
+  }
+  const router = createStaticRouter(handler.dataRoutes, context);
+  return renderToStaticMarkup(createElement(StaticRouterProvider, { router, context }));
+}
+
+describe("the workspace Sessions page", () => {
+  it("heads the list `Sessions`, never `Active sessions`", async () => {
+    const html = await renderPage();
+    expect(html).toContain('<span id="sessions-heading">Sessions</span>');
+    expect(html).not.toContain("Active sessions");
+  });
+
+  it("leaves the counts line as the qualifier, adding up to the list under it", async () => {
+    const html = await renderPage();
+    expect(html).toContain("1 active session");
+    expect(html).toContain("1 stale");
+  });
+});

--- a/web/tests/unit/verify-lookup-arm.test.ts
+++ b/web/tests/unit/verify-lookup-arm.test.ts
@@ -120,6 +120,67 @@ describe("the code lookup is the DEFAULT arm, not a named one", () => {
   });
 });
 
+/**
+ * THE TWO THINGS A PERSON DOES TO THIS FIELD BY ACCIDENT.
+ *
+ * Clicking "Look up" with nothing typed threw the framework's bare 400, which the root boundary
+ * renders as the house fault screen — a page that says neither what went wrong nor what to do.
+ * From the person's side the form simply stopped working. It now answers on the form, in the
+ * sentence the page already opens with.
+ *
+ * And the field took any amount of text, so a stray paste — a whole command line, a URL, a log
+ * excerpt — went to the lookup as though it might be a code. A code is `XXXX-XXXX` and nothing
+ * longer can be one, so anything longer is the ordinary miss, told free: it is not a guess of the
+ * code space, so it must not spend the belt that guards it.
+ */
+describe("the code field refuses what cannot be a code, in the page", () => {
+  it("says what to do when the submit carried no code", async () => {
+    const empty = await postVerify({ code: "" });
+    expect(statusOf(empty)).toBe(400);
+    expect(bodyOf(empty)).toEqual({
+      kind: "refused",
+      error: "Enter the code your terminal shows",
+    });
+    // Whitespace is nothing typed, whatever the field's own validation makes of it.
+    expect(bodyOf(await postVerify({ code: "   " }))).toEqual({
+      kind: "refused",
+      error: "Enter the code your terminal shows",
+    });
+  });
+
+  it("answers a paste far longer than a code with the ordinary miss", async () => {
+    await seedUser(db, "u_paste", "Paster", "paster@example.com");
+    await seatUser(db, wsId, "u_paste", "member");
+    session = { user: { id: "u_paste", name: "Paster", email: "paster@example.com" } };
+
+    const pasted = "topos login --workspace acme # AB29-CD34";
+    expect(pasted.length).toBeGreaterThan(9);
+    // Eleven of them — one more than the belt's whole burst. Every one is the same honest miss,
+    // because none of them ever asked the belt for a token.
+    for (let i = 0; i < 11; i++) {
+      expect(await postVerify({ code: pasted })).toEqual({ kind: "miss" });
+    }
+
+    // The belt is untouched, so a real code still resolves on the very next submission.
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startLoginFlow("pasted-box", null);
+    expect(await postVerify({ code: flow.userCode })).toMatchObject({
+      kind: "resolved",
+      pending: { requestedName: "pasted-box" },
+    });
+  });
+
+  it("still looks up a code of exactly the right length", async () => {
+    session = { user: { id: "u_own", name: "Owner", email: "owner@example.com" } };
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startLoginFlow("edge-box", null);
+    expect(flow.userCode).toHaveLength(9);
+    expect(await postVerify({ code: flow.userCode })).toMatchObject({ kind: "resolved" });
+    // One character past the shape is not a code, whatever it starts with.
+    expect(await postVerify({ code: `${flow.userCode}X` })).toEqual({ kind: "miss" });
+  });
+});
+
 describe("the guessing belt is spent by lookups alone, and says so on the form", () => {
   it("the eleventh lookup answers on the page; an approval after ten still lands", async () => {
     // The belt keys on the acting PERSON, so this case runs as its own — a fresh burst of ten.

--- a/web/tests/unit/verify-lookup-arm.test.ts
+++ b/web/tests/unit/verify-lookup-arm.test.ts
@@ -250,3 +250,59 @@ describe("a guessed DECISION pays per miss; a decision on a resolved code never 
     expect((await identity.pollLoginFlow(flow.flowCode)).status).toBe("granted");
   });
 });
+
+/**
+ * THE HYPHEN IS FOR READING ALOUD, NOT PART OF THE CODE.
+ *
+ * `AB29-CD34` is grouped so a person can read it off a terminal or say it to someone across the
+ * room. Typing it back without the group — `AB29CD34` — or writing down what was said as
+ * `AB29 CD34` is the same code, and both used to miss: the person was sent back to re-read a code
+ * they had already read correctly, and each attempt spent a token off the guessing belt.
+ *
+ * The lookup spells the code the way a code is spelled before it looks anything up. The length
+ * cap runs AFTER that, so the eight-character spelling is not mistaken for a short code and a real
+ * paste is still refused free.
+ */
+describe("the code lookup reads a code however it was written down", () => {
+  it("resolves the same request from the hyphenless and the spaced spelling", async () => {
+    session = { user: { id: "u_own", name: "Owner", email: "owner@example.com" } };
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startLoginFlow("spelled-box", null);
+    const bare = flow.userCode.replace("-", "");
+
+    for (const spelling of [flow.userCode, bare, `${bare.slice(0, 4)} ${bare.slice(4)}`]) {
+      expect(await postVerify({ code: spelling })).toMatchObject({
+        kind: "resolved",
+        pending: { requestedName: "spelled-box" },
+      });
+    }
+    // Lower case is the same code too — the alphabet is upper case, the keyboard need not be.
+    expect(await postVerify({ code: bare.toLowerCase() })).toMatchObject({ kind: "resolved" });
+    // Looking a request up decides nothing, however it was spelled.
+    expect((await identity.pollLoginFlow(flow.flowCode)).status).toBe("pending");
+  });
+
+  it("caps AFTER spelling it out, so a real paste is still the free miss", async () => {
+    await seedUser(db, "u_spell", "Speller", "speller@example.com");
+    await seatUser(db, wsId, "u_spell", "member");
+    session = { user: { id: "u_spell", name: "Speller", email: "speller@example.com" } };
+
+    // Nine bare characters is not a code however it is spaced, and it never reaches the belt.
+    for (let i = 0; i < 11; i++) {
+      expect(await postVerify({ code: "AB29 CD34 X" })).toEqual({ kind: "miss" });
+    }
+    const identity = await import("@/lib/db/identity.server");
+    const flow = await identity.startLoginFlow("speller-box", null);
+    expect(await postVerify({ code: flow.userCode.replace("-", "") })).toMatchObject({
+      kind: "resolved",
+      pending: { requestedName: "speller-box" },
+    });
+  });
+
+  it("still calls an empty submit empty, however much whitespace it carried", async () => {
+    expect(bodyOf(await postVerify({ code: " - " }))).toEqual({
+      kind: "refused",
+      error: "Enter the code your terminal shows",
+    });
+  });
+});

--- a/web/tests/unit/version-prefix.test.ts
+++ b/web/tests/unit/version-prefix.test.ts
@@ -1,3 +1,11 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  createStaticHandler,
+  createStaticRouter,
+  type RouteObject,
+  StaticRouterProvider,
+} from "react-router";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   bootWorkspace,
@@ -168,5 +176,97 @@ describe("the version page addresses a version the way git addresses an object",
         `/skills/${NAME}/versions/da9fa16d/files/SKILL.md`,
       ),
     ).toEqual({ status: 404 });
+  });
+});
+
+/**
+ * THE SPELLING A VISITOR ARRIVED WITH IS THE SPELLING THEY KEEP.
+ *
+ * Resolving a short id is a READ concern: every byte on the page comes from the full 64-hex id
+ * the prefix named. Addressing is a different thing, and the page used to conflate them — opened
+ * on `…/versions/da9fa16db64b`, every file link on it pointed at `…/versions/<64 hex>/files/…`.
+ * One click and the reader was at an address they had never typed, of a shape they could not have
+ * copied from anything the product prints. The same jump waited on the way back up: the file
+ * view's breadcrumb re-addressed the listing with the long id.
+ *
+ * Links are now built from the ref in the URL. Short in, short links; full in, full links. The
+ * LABEL stays the canonical 12-hex short form either way — that is display, not address.
+ */
+describe("the id spelling a visitor arrived with rides every link", () => {
+  const SHORT = LONE.slice(0, 12);
+
+  /** Render a route's component over the data its real loader just returned. */
+  async function render(
+    path: string,
+    params: Record<string, string | undefined>,
+    Component: () => ReturnType<typeof createElement>,
+    loaderData: unknown,
+  ): Promise<string> {
+    const pattern =
+      params["*"] === undefined
+        ? "/skills/:skill/versions/:versionId"
+        : "/skills/:skill/versions/:versionId/files/*";
+    const routes: RouteObject[] = [{ path: pattern, loader: () => loaderData, Component }];
+    const handler = createStaticHandler(routes);
+    const context = await handler.query(new Request(`${ORIGIN}${path}`));
+    if (context instanceof Response) {
+      throw new Error("expected a rendered context, got a Response");
+    }
+    const router = createStaticRouter(handler.dataRoutes, context);
+    return renderToStaticMarkup(createElement(StaticRouterProvider, { router, context }));
+  }
+
+  it("keeps the short id in every file link on the version page", async () => {
+    const { data } = await versionPage(SHORT);
+    expect(data?.versionRef).toBe(SHORT);
+    expect(data?.versionId).toBe(LONE);
+
+    const { default: Component } = await import("@/routes/version-files");
+    const html = await render(
+      `/skills/${NAME}/versions/${SHORT}`,
+      { skill: NAME, versionId: SHORT },
+      Component,
+      data,
+    );
+    expect(html).toContain(`href="/skills/${NAME}/versions/${SHORT}/files/SKILL.md"`);
+    expect(html).not.toContain(`/versions/${LONE}/files/`);
+    // The label is unchanged — the short id is what a version has always been called on screen.
+    expect(html).toContain(SHORT);
+  });
+
+  it("keeps the FULL id in those links when that is the address that was opened", async () => {
+    const { data } = await versionPage(LONE);
+    expect(data?.versionRef).toBe(LONE);
+
+    const { default: Component } = await import("@/routes/version-files");
+    const html = await render(
+      `/skills/${NAME}/versions/${LONE}`,
+      { skill: NAME, versionId: LONE },
+      Component,
+      data,
+    );
+    expect(html).toContain(`href="/skills/${NAME}/versions/${LONE}/files/SKILL.md"`);
+  });
+
+  it("keeps it on the way back up, out of the file view's breadcrumb", async () => {
+    const { loader } = await import("@/routes/file-view");
+    const { data } = await load(
+      loader as unknown as Loader,
+      { skill: NAME, versionId: SHORT, "*": "SKILL.md" },
+      `/skills/${NAME}/versions/${SHORT}/files/SKILL.md`,
+    );
+    expect(data?.versionRef).toBe(SHORT);
+    // The toggle re-enters this page's own address, so it carries the same spelling.
+    expect(data?.fileBasePath).toBe(`/skills/${NAME}/versions/${SHORT}/files/SKILL.md`);
+
+    const { default: Component } = await import("@/routes/file-view");
+    const html = await render(
+      `/skills/${NAME}/versions/${SHORT}/files/SKILL.md`,
+      { skill: NAME, versionId: SHORT, "*": "SKILL.md" },
+      Component,
+      data,
+    );
+    expect(html).toContain(`href="/skills/${NAME}/versions/${SHORT}"`);
+    expect(html).not.toContain(`href="/skills/${NAME}/versions/${LONE}"`);
   });
 });

--- a/web/tests/unit/workspace-scope-404.test.ts
+++ b/web/tests/unit/workspace-scope-404.test.ts
@@ -108,11 +108,14 @@ describe("a member PANEL page (channels index) — the existence blind, status A
     expect(real).toEqual(unknown);
   });
 
-  it("an ANONYMOUS visitor on a real slug is byte-identical to an unknown slug (the constant login bounce)", async () => {
+  it("an ANONYMOUS visitor on a real slug is byte-identical to an unknown slug (the same 404)", async () => {
+    // This page used to bounce to /login. The bounce was blind — constant for every slug — but it
+    // was a SECOND answer for an address family whose other pages 404'd, and it read as an
+    // invitation to sign in to a workspace the visitor holds no seat in.
     session = null;
     const real = await probe("acme");
     const unknown = await probe("no-such-team");
-    expect(real.status).toBe(302);
+    expect(real.status).toBe(404);
     expect(real).toEqual(unknown);
   });
 
@@ -239,5 +242,200 @@ describe("a bundle's sub-pages — the same refusal the bundle page gives", () =
     for (const answer of answers) {
       expect(answer).toEqual(answers[0]);
     }
+  });
+});
+
+/**
+ * EVERY MEMBER-ONLY PAGE, one answer.
+ *
+ * The ruling is uniform: any `/<ws>…` page answers a signed-out visitor the house 404, with the
+ * same body a slug nobody has ever registered gets. Some pages already did; the rest bounced to
+ * /login. Each bounce was existence-blind on its own — it is constant for every slug — but the
+ * app had two answers for one address family, so which page a stranger happened to try told them
+ * something, and the bounce read as an invitation to sign in to a workspace they hold no seat in.
+ *
+ * This walks the whole set through its REAL loader, twice: anonymous, and as a signed-in stranger
+ * with a live session and a seat somewhere else. Both must match an invented slug to the byte,
+ * and every page must match every other — no shape may say more than another.
+ */
+describe("every member-only page — the one refusal, byte for byte", () => {
+  /** Every member-only page under a workspace address: its module, the params its route binds,
+   *  and a path of the right shape (nothing reads it before the guard refuses). */
+  const pages: {
+    what: string;
+    load: () => Promise<{ loader: unknown }>;
+    params: Record<string, string>;
+    path: string;
+  }[] = [
+    {
+      what: "the channels index",
+      load: () => import("@/routes/channels-index"),
+      params: {},
+      path: "/channels",
+    },
+    {
+      what: "a channel's history",
+      load: () => import("@/routes/channel-history"),
+      params: { channel: "everyone" },
+      path: "/channels/everyone/history",
+    },
+    {
+      what: "the new-channel page",
+      load: () => import("@/routes/channel-new"),
+      params: {},
+      path: "/channels/new",
+    },
+    {
+      what: "a channel's settings",
+      load: () => import("@/routes/channel-settings"),
+      params: { channel: "everyone" },
+      path: "/channels/everyone/settings",
+    },
+    {
+      what: "an MCP server's connect page",
+      load: () => import("@/routes/mcp-connect"),
+      params: { server: "deepwiki" },
+      path: "/mcp/deepwiki/connect",
+    },
+    {
+      what: "the add-an-MCP-server page",
+      load: () => import("@/routes/mcp-new"),
+      params: {},
+      path: "/mcp/new",
+    },
+    {
+      what: "the profile page",
+      load: () => import("@/routes/profile"),
+      params: {},
+      path: "/profile",
+    },
+    {
+      what: "a proposal's review page",
+      load: () => import("@/routes/proposal-review"),
+      params: { skill: "release-guide", versionId: "a".repeat(64) },
+      path: `/skills/release-guide/proposals/${"a".repeat(64)}`,
+    },
+    {
+      what: "the workspace sessions page",
+      load: () => import("@/routes/sessions"),
+      params: {},
+      path: "/settings/sessions",
+    },
+    {
+      what: "the import-from-GitHub page",
+      load: () => import("@/routes/skill-import"),
+      params: {},
+      path: "/skills/import",
+    },
+    {
+      what: "a bundle's proposals",
+      load: () => import("@/routes/skill-proposals"),
+      params: { skill: "release-guide" },
+      path: "/skills/release-guide/proposals",
+    },
+    {
+      what: "a bundle's settings",
+      load: () => import("@/routes/skill-settings"),
+      params: { skill: "release-guide" },
+      path: "/skills/release-guide/settings",
+    },
+    {
+      what: "the visibility page",
+      load: () => import("@/routes/visibility"),
+      params: {},
+      path: "/visibility",
+    },
+    {
+      what: "the archive",
+      load: () => import("@/routes/workspace-archive"),
+      params: {},
+      path: "/settings/archive",
+    },
+    {
+      what: "the members page",
+      load: () => import("@/routes/workspace-members"),
+      params: {},
+      path: "/members",
+    },
+    {
+      what: "the workspace settings page",
+      load: () => import("@/routes/workspace-settings"),
+      params: {},
+      path: "/settings",
+    },
+  ];
+
+  async function probePage(
+    page: (typeof pages)[number],
+    ws: string,
+  ): Promise<{ status: number; body: string }> {
+    const { loader } = await page.load();
+    return outcome(() =>
+      (loader as RouteFn)({
+        request: pageRequest(`/${ws}${page.path}`),
+        params: { ws, ...page.params },
+      }),
+    );
+  }
+
+  for (const page of pages) {
+    it(`${page.what}: anonymous and stranger both get the 404, real slug and invented alike`, async () => {
+      session = null;
+      const anonReal = await probePage(page, "acme");
+      expect(anonReal.status).toBe(404);
+      expect(anonReal).toEqual(await probePage(page, "no-such-team"));
+
+      session = { user: { id: "u_stranger", name: "Stranger", email: "stranger@example.com" } };
+      const strangerReal = await probePage(page, "acme");
+      expect(strangerReal.status).toBe(404);
+      expect(strangerReal).toEqual(await probePage(page, "no-such-team"));
+      // …and the two visitors are indistinguishable from each other, which is the whole point.
+      expect(strangerReal).toEqual(anonReal);
+    });
+  }
+
+  it("answers every one of them with the SAME body — no page says more than another", async () => {
+    session = null;
+    const answers = await Promise.all(pages.map(async (page) => await probePage(page, "acme")));
+    for (const answer of answers) {
+      expect(answer).toEqual(answers[0]);
+    }
+  });
+});
+
+/**
+ * THE LAYER A SIGNED-OUT VISITOR ACTUALLY MEETS.
+ *
+ * Every page above sits under the signed-in shell, whose middleware runs BEFORE any loader. It
+ * used to bounce a cookie-less request to /login unconditionally, so the guards' answer was the
+ * one nobody ever saw: fixing the loaders alone would have changed nothing in a browser. The
+ * shell now gives the same answer its children do, and the fork is the address itself — a
+ * workspace page is a members-only address (the house 404), a person's own page has somewhere to
+ * send them.
+ */
+describe("the shell's signed-out refusal — the same answer its children give", () => {
+  const PERSONAL = new Set(["/account/sessions", "/new"]);
+
+  async function refuse(path: string): Promise<{ status: number; body: string }> {
+    const { refuseShellSignedOut } = await import("@/lib/auth/guards.server");
+    return outcome(async () => refuseShellSignedOut(pageRequest(path), PERSONAL));
+  }
+
+  it("answers a workspace page with the house 404, real slug and invented alike", async () => {
+    const real = await refuse("/acme/members");
+    expect(real.status).toBe(404);
+    expect(real).toEqual(await refuse("/no-such-team/members"));
+    expect(real).toEqual(await refuse("/acme/skills/release-guide/history"));
+  });
+
+  it("keeps the /login bounce for a page that is a person's, not a workspace's", async () => {
+    expect(await refuse("/account/sessions")).toEqual({ status: 302, body: "/login\n" });
+    expect(await refuse("/new")).toEqual({ status: 302, body: "/login\n" });
+  });
+
+  it("reads the DESTINATION path, so a client-side arrival is the same page", async () => {
+    // React Router's single fetch asks for `<path>.data`; the person is opening `<path>`.
+    expect(await refuse("/account/sessions.data")).toEqual({ status: 302, body: "/login\n" });
+    expect((await refuse("/acme/members.data")).status).toBe(404);
   });
 });

--- a/web/tests/unit/workspace-scope-404.test.ts
+++ b/web/tests/unit/workspace-scope-404.test.ts
@@ -175,3 +175,69 @@ describe("a device-lane API route (/channels) — the uniform wire 404, status A
     expect(real).toEqual(await probe(WS_REAL));
   });
 });
+
+/**
+ * THE BUNDLE'S OWN SUB-PAGES — one address family, one answer.
+ *
+ * `/<ws>/skills/<bundle>` answered a signed-out visitor with the house 404, but its three
+ * siblings — a version, a file inside that version, and the history — bounced to /login instead.
+ * Every one of those was still existence-blind on its own (the bounce is constant), but the app
+ * had two different answers for one address family, and the bounce read as an invitation to sign
+ * in to a workspace the visitor has no seat in. They now answer exactly what the bundle page
+ * answers, to the byte.
+ */
+describe("a bundle's sub-pages — the same refusal the bundle page gives", () => {
+  const VERSION = "6ce009dd52c7";
+
+  const pages: [string, () => Promise<{ loader: unknown }>, Record<string, string>][] = [
+    ["the bundle page", () => import("@/routes/skill-current"), {}],
+    ["a version's files", () => import("@/routes/version-files"), { versionId: VERSION }],
+    [
+      "one file in a version",
+      () => import("@/routes/file-view"),
+      { versionId: VERSION, "*": "SKILL.md" },
+    ],
+    ["the history", () => import("@/routes/skill-history"), {}],
+  ];
+
+  async function probe(
+    load: () => Promise<{ loader: unknown }>,
+    ws: string,
+    extra: Record<string, string>,
+  ): Promise<{ status: number; body: string }> {
+    const { loader } = await load();
+    return outcome(() =>
+      (loader as RouteFn)({
+        request: pageRequest(`/${ws}/skills/release-guide`),
+        params: { ws, skill: "release-guide", ...extra },
+      }),
+    );
+  }
+
+  for (const [what, load, extra] of pages) {
+    it(`${what}: an ANONYMOUS visitor gets the 404 on a real slug and an invented one alike`, async () => {
+      session = null;
+      const real = await probe(load, "acme", extra);
+      const unknown = await probe(load, "no-such-team", extra);
+      expect(real.status).toBe(404);
+      expect(real).toEqual(unknown);
+    });
+
+    it(`${what}: a signed-in NON-MEMBER gets that same 404`, async () => {
+      session = { user: { id: "u_stranger", name: "Stranger", email: "stranger@example.com" } };
+      const real = await probe(load, "acme", extra);
+      expect(real.status).toBe(404);
+      expect(real).toEqual(await probe(load, "no-such-team", extra));
+    });
+  }
+
+  it("answers all four addresses with the SAME body — no shape says more than another", async () => {
+    session = null;
+    const answers = await Promise.all(
+      pages.map(async ([, load, extra]) => await probe(load, "acme", extra)),
+    );
+    for (const answer of answers) {
+      expect(answer).toEqual(answers[0]);
+    }
+  });
+});


### PR DESCRIPTION
Round 4 (web), from the founder's rulings on the production journeys:

- Every workspace page answers a signed-out visitor the same 404 (real or invented workspace, byte-identical) — the shell middleware, not the loaders, had been bouncing to `/login`; personal pages (`/account/sessions`, `/new`) keep the bounce.
- The MCP server page's Usage is one row per machine (calls, `N ok · M failed (kinds)`, tools, first/last call), paged at 25, and the pager keeps the rest of the address.
- The Sessions list is headed "Sessions" (the counts line qualifies it).
- A version page keeps the id spelling the visitor arrived with in its links.
- `/verify`: an empty submit is refused in the form; the code field stops at a code's length; a code typed without its hyphen or with a space is the same code.

Gates: web check, unit (1329), build, bundle scan, Playwright (164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
