### PR TITLE
The lock records what the copy holds; counter, reset preview, log on unapplied bundles (v0.1.54)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3959,7 +3959,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "topos"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "base64",
  "clap",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "sha2",
  "unicode-normalization",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "axum",
  "plane-store",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "diffy",
  "flate2",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "hex",
  "jsonc-parser",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "anyhow",
  "axum",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.53" # members inherit via `version.workspace = true`; bump to match the tag before tagging
+version = "0.1.54" # members inherit via `version.workspace = true`; bump to match the tag before tagging
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/bins/topos/src/error.rs
+++ b/bins/topos/src/error.rs
@@ -328,19 +328,28 @@ fn already_tracked_message(name: &str, dir: &str, claim: &Option<TrackedBy>) -> 
     }
 }
 
-/// The [`ClientError::NotAppliedHere`] sentence: the bundle, the update that would apply it, and
-/// why the verb still cannot act. Spelled for the scope whose `update` owns the row, because that
-/// is the command that changes anything — the machine's row is only ever applied by `-g`.
-fn not_applied_here_message(name: &str, global: bool) -> String {
+/// The SHARED clause every "this scope carries a row for it, and no copy behind it" line opens
+/// with: the bundle, where, and the update that lands it. Spelled for the scope whose `update`
+/// owns the row, because that is the command that changes anything — the machine's row is only
+/// ever applied by `-g`. Named as a runnable command, so the envelope's `next_actions` mirror it.
+pub(crate) fn not_applied_clause(name: &str, global: bool) -> String {
     let (where_, flag) = if global {
         ("on this machine", " -g")
     } else {
         ("here", "")
     };
-    format!(
-        "{name} is not applied {where_} yet — `topos update{flag}` applies it; revert acts on an \
-         applied copy"
-    )
+    format!("{name} is not applied {where_} yet — `topos update{flag}` applies it")
+}
+
+/// The [`ClientError::NotAppliedHere`] sentence: the shared clause, plus (where the door has one)
+/// the clause naming what THIS verb wanted and this state has not got.
+fn not_applied_here_message(name: &str, global: bool, needs: &str) -> String {
+    let clause = not_applied_clause(name, global);
+    if needs.is_empty() {
+        clause
+    } else {
+        format!("{clause}; {needs}")
+    }
 }
 
 /// The [`ClientError::NoTrackedBundle`] sentence: nothing of this name is tracked, and the one
@@ -640,18 +649,30 @@ pub(crate) enum ClientError {
     /// A name resolved to more than one tracked skill; the caller must disambiguate by id.
     #[error("the name '{name}' is ambiguous across {count} tracked skills")]
     AmbiguousName { name: String, count: usize },
-    /// No tracked skill matches the given name.
-    #[error("no tracked skill named '{name}'")]
+    /// No tracked bundle matches the given name — the bare resolution miss every by-name verb
+    /// answers with. The noun is `bundle`: a workspace shares skills, MCP servers and more, and a
+    /// refusal that calls all of them skills is telling a person about a vocabulary this CLI
+    /// stopped using.
+    #[error("no tracked bundle named '{name}'")]
     NoSuchSkill { name: String },
     /// The scope DOES carry a row for this name — `list` prints it — but no `update` has applied
     /// it here yet, so there is no copy for a version verb to act on. Its own state, because it
     /// has its own next step: the one command that turns the row into a copy, which the listing
     /// already spells beside the row. `global` picks the scope the update names (`-g`).
-    #[error("{}", not_applied_here_message(.name, *.global))]
-    NotAppliedHere { name: String, global: bool },
+    #[error("{}", not_applied_here_message(.name, *.global, .needs))]
+    NotAppliedHere {
+        name: String,
+        global: bool,
+        /// What THIS verb wanted and this state has not got — `"revert acts on an applied copy"`.
+        /// One state, several doors: each says what it was after, and an empty clause closes the
+        /// sentence after the shared one.
+        needs: &'static str,
+    },
     /// The scope tracks nothing of this name at all — the honest miss, pointing at the listing
-    /// that says what it DOES track. The name-oriented sibling of [`ClientError::NotAppliedHere`];
-    /// both wear `NO_SUCH_SKILL` on the wire, so an agent branches exactly as it always has.
+    /// that says what it DOES track. The name-oriented sibling of [`ClientError::NotAppliedHere`],
+    /// and the one that wears `NO_SUCH_SKILL`: the two states are not the same answer, and an
+    /// agent that met one code for both had to parse prose to tell "run the update" apart from
+    /// "this name is nowhere".
     #[error("{}", no_tracked_bundle_message(.name, *.global))]
     NoTrackedBundle { name: String, global: bool },
     /// `add <skill>` resolved a name against discovery and found nothing adoptable — no untracked skill of
@@ -1268,13 +1289,16 @@ impl ClientError {
             ClientError::AmbiguousName { .. } | ClientError::AmbiguousSource { .. } => {
                 "AMBIGUOUS_NAME"
             }
-            // One wire code for the whole "this scope has no copy of that name" family: the plain
-            // miss, the better-worded miss, and the demanded-but-unapplied row. The MESSAGE tells
-            // them apart for a reader; an agent branches on the code it always has (and on the
-            // `next_actions` the unapplied one carries).
-            ClientError::NoSuchSkill { .. }
-            | ClientError::NoTrackedBundle { .. }
-            | ClientError::NotAppliedHere { .. } => "NO_SUCH_SKILL",
+            // A name this scope has no copy of, and never asked for: the plain miss and the
+            // better-worded miss are the same answer, so they share the code an agent has always
+            // branched on.
+            ClientError::NoSuchSkill { .. } | ClientError::NoTrackedBundle { .. } => {
+                "NO_SUCH_SKILL"
+            }
+            // A DEMANDED row with no copy behind it is a different answer with a different fix —
+            // `list` prints the row and ONE command turns it into a copy — so it carries its own
+            // code rather than making an agent read prose to tell it from a miss.
+            ClientError::NotAppliedHere { .. } => "NOT_APPLIED",
             ClientError::NoUntrackedSkill { .. } => "NO_UNTRACKED_SKILL",
             // The name-oriented twins of AlreadyTracked share its code (agents branch the same on
             // any) — including a claim over a folder another record already holds, which is that

--- a/bins/topos/src/ops/diff.rs
+++ b/bins/topos/src/ops/diff.rs
@@ -91,16 +91,31 @@ pub(crate) fn diff(
     diff_resolved(ctx, &layout, &id, &lock, r#ref, budget, sel)
 }
 
-/// [`diff`] over an ALREADY-RESOLVED copy — the entry the reset describe uses, so the loss it
-/// discloses is measured against exactly the store the discard will act on (a second, independent
-/// resolution could land on the other scope's copy and describe bytes nobody is about to lose).
-/// Every store/doc/scan read rides the OWNING layout; the plane and follow seams are machine-level
-/// and stay as they are.
+/// WHICH WAY a bare draft ↔ current diff reads — the two verbs that print one want opposite
+/// orders, and a unified diff only means something when `a` is the state that goes away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiffSides {
+    /// `topos diff`: `a` is the team's current, `b` is your copy — so the `+` lines are YOUR
+    /// edits, which is what "show me my change" means.
+    CurrentToDraft,
+    /// The `--reset` preview: `a` is your copy (what goes away), `b` is the team's version (what
+    /// lands). A reset REPLACES your copy with the team's, so the preview has to read the way the
+    /// apply runs. Printed in the other order it said the opposite of what `--yes` does: the
+    /// team's incoming lines rendered as deletions and the edits about to be destroyed as
+    /// additions.
+    DraftToCurrent,
+}
+
+/// [`diff`] over an ALREADY-RESOLVED copy — the shape [`reset_preview_diff`] shares, so a loss
+/// disclosure is measured against exactly the store the discard will act on (a second,
+/// independent resolution could land on the other scope's copy and describe bytes nobody is about
+/// to lose). Every store/doc/scan read rides the OWNING layout; the plane and follow seams are
+/// machine-level and stay as they are.
 /// The `-a`/`--dest` selector narrows the RIGHT-HAND side only. The left side stays what it always
 /// is — the applied base — so two `--dest` runs answer against the same ruler and are directly
 /// comparable, which is what makes them a substitute for the copy-vs-copy grammar this deliberately
 /// does not invent.
-pub(crate) fn diff_resolved(
+fn diff_resolved(
     ctx: &Ctx<'_>,
     layout: &sidecar::Layout,
     id: &crate::id::SkillId,
@@ -113,7 +128,7 @@ pub(crate) fn diff_resolved(
     let sp = layout.published(id);
 
     let Some(reference) = r#ref else {
-        return diff_draft_vs_current(&sctx, &sp, lock, budget, sel);
+        return diff_draft_vs_current(&sctx, &sp, lock, budget, sel, DiffSides::CurrentToDraft);
     };
 
     // Parse the ref: `<a>..<b>` is a range; otherwise a single endpoint compared against `current` (so a
@@ -141,6 +156,26 @@ pub(crate) fn diff_resolved(
         dest: None,
         skill: None,
     })
+}
+
+/// The `--reset` preview's LOSS diff over an already-resolved copy: the same bare draft ↔ current
+/// read `diff` makes, in the direction a reset runs ([`DiffSides::DraftToCurrent`]) — `a` is the
+/// copy about to be discarded, `b` is the version about to land.
+///
+/// # Errors
+/// As [`diff_resolved`]: a scan/store failure, a placement freeze, or a transport fault reading
+/// the workspace's live current.
+pub(crate) fn reset_preview_diff(
+    ctx: &Ctx<'_>,
+    layout: &sidecar::Layout,
+    id: &crate::id::SkillId,
+    lock: &Lock,
+    budget: DiffBudget,
+    sel: &super::Selection,
+) -> Result<DiffData, ClientError> {
+    let sctx = super::pull::ctx_with_layout(ctx, layout);
+    let sp = layout.published(id);
+    diff_draft_vs_current(&sctx, &sp, lock, budget, sel, DiffSides::DraftToCurrent)
 }
 
 /// Apply a byte budget to per-file diff sections: emit LEADING whole sections while the running
@@ -192,6 +227,7 @@ fn diff_draft_vs_current(
     lock: &Lock,
     budget: DiffBudget,
     sel: &super::Selection,
+    sides: DiffSides,
 ) -> Result<DiffData, ClientError> {
     let map: PlacementMap = doc::read_map(ctx.fs, &sp.map)?
         .ok_or_else(|| ClientError::Corrupt("missing placement map".to_owned()))?;
@@ -259,7 +295,13 @@ fn diff_draft_vs_current(
             bytes: &f.bytes,
         })
         .collect();
-    let sections = unified_diff_sections(&base_files, &draft_files);
+    // `a` is always the side that GOES AWAY: for `diff` that is the team's current (your edits
+    // read as `+`), for the reset preview it is your copy (your edits read as `-`, and the
+    // version that lands reads as `+`).
+    let sections = match sides {
+        DiffSides::CurrentToDraft => unified_diff_sections(&base_files, &draft_files),
+        DiffSides::DraftToCurrent => unified_diff_sections(&draft_files, &base_files),
+    };
     let (diff, truncated, files) = apply_budget(sections, budget);
 
     Ok(DiffData {

--- a/bins/topos/src/ops/diff.rs
+++ b/bins/topos/src/ops/diff.rs
@@ -80,7 +80,23 @@ pub(crate) fn diff(
     // about THAT copy — not a same-named machine twin, and not a not-found. `-g` names the machine
     // copy instead, so a person standing in a project can read the twin the other scope holds
     // without leaving the folder (the same escape `list`/`status`/`update` offer).
-    let (layout, id, lock) = super::resolve_skill_in_scope(ctx, skill, None, store)?;
+    let (layout, id, lock) = match super::resolve_skill_in_scope(ctx, skill, None, store) {
+        Ok(found) => found,
+        // A name this scope has no copy of is TWO states, and `diff` wore one sentence for both.
+        // A row this scope DEMANDS with no update behind it is one command from being a copy —
+        // and `diff` reads a copy, so unlike `log` there is nothing to answer with but the
+        // refusal that names that command. The classification is the one `revert` uses, so a
+        // machine cannot say two things about one row.
+        Err(ClientError::NoSuchSkill { .. }) => {
+            return Err(super::unapplied_or_unknown(
+                ctx,
+                skill,
+                store,
+                "diff reads an applied copy",
+            ));
+        }
+        Err(e) => return Err(e),
+    };
     if !sel.is_empty() && r#ref.is_some() {
         return Err(ClientError::InvalidArgument(
             "`--dest`/`-a` names the copy of YOUR edits a diff reads, and a version-to-version \

--- a/bins/topos/src/ops/log.rs
+++ b/bins/topos/src/ops/log.rs
@@ -25,7 +25,7 @@ use crate::resolve::{self, Resolution, ResourceKind};
 use crate::{identity, logfile, sessions, sidecar::Layout, sync_status};
 use topos_core::digest::to_hex;
 use topos_types::requests::{WireLogProposal, WireLogVersion};
-use topos_types::results::{LogData, SyncFault};
+use topos_types::results::{LogData, NotApplied, SyncFault};
 
 /// The seam `log` needs — the per-session transports read the plane-side history.
 pub(crate) struct LogConnectors<'a> {
@@ -54,11 +54,12 @@ pub(crate) fn log(
     // came from), so this arm resolves nothing and reads no other login.
     let (layout, id, lock) = match super::resolve_skill_here(ctx, skill, None) {
         Ok(found) => found,
-        // Nothing here answers to that name. It may be a CHANNEL — whose curation history is a web
-        // surface — in the workspace this machine acts on: ONE workspace, never a scan of every
-        // login.
-        Err(absent @ ClientError::NoSuchSkill { .. }) => {
-            return Err(channel_refusal(ctx, connectors, skill, workspace)?.unwrap_or(absent));
+        // Nothing HERE answers to that name — which is not the end of the question. It may be a
+        // CHANNEL (whose curation history is a web surface), or a bundle a recipe row in this
+        // scope demands with no update behind it yet — whose history is the workspace's and needs
+        // no local copy at all.
+        Err(ClientError::NoSuchSkill { .. }) => {
+            return unresolved_history(ctx, connectors, skill, workspace, page);
         }
         Err(e) => return Err(e),
     };
@@ -157,13 +158,7 @@ pub(crate) fn log(
 
     // The row page, applied AFTER assembly (the assembled order is deterministic, so consecutive
     // pages tile the same list). An inactive page keeps the exact prior shape (no marker fields).
-    let (page_applied, truncated, total) = if page.is_active() {
-        let (_, total) = page.apply(&mut events);
-        let end = page.offset.saturating_add(events.len());
-        (true, end < total, total)
-    } else {
-        (false, false, events.len())
-    };
+    let (page_applied, truncated, total) = apply_page(&mut events, page);
 
     // Whether the workspace this copy is delivered from landed its LAST exchange with this machine.
     // The freshness cache is a MACHINE fact, like the device id above — one per install, whatever
@@ -178,51 +173,133 @@ pub(crate) fn log(
         truncated,
         total: page_applied.then_some(total as u64),
         sync_fault,
+        // An applied copy: this history is the copy's own.
+        not_applied: None,
     })
 }
 
-/// The refusal a name that is a CHANNEL earns: a channel's curation history lives on the web, not
-/// in `topos log`. Asked of ONE workspace — the one the machine acts on (`--workspace` →
-/// `TOPOS_WORKSPACE` → the starred default → the sole login) — because a lookup that scanned every
-/// login dialed workspaces that hold nothing by that name, and narrated each one.
+/// The row page over an assembled event list: `(a page was applied, more lies past it, the total
+/// before paging)`. An inactive page keeps the exact prior shape (no marker fields).
+fn apply_page(events: &mut Vec<Value>, page: super::RowPage) -> (bool, bool, usize) {
+    if !page.is_active() {
+        return (false, false, events.len());
+    }
+    let (_, total) = page.apply(events);
+    let end = page.offset.saturating_add(events.len());
+    (true, end < total, total)
+}
+
+/// A name NOTHING in this scope's stores answers to — resolved as far as this machine honestly
+/// can, and READ where there is something to read.
 ///
-/// `Ok(None)` = not a channel there (or this machine is signed into nothing), which leaves the
-/// caller's own "no such bundle" answer standing.
+/// Two things such a name can still be, asked of ONE workspace — the one the machine acts on
+/// (`--workspace` → `TOPOS_WORKSPACE` → the starred default → the sole login) — because a lookup
+/// that scanned every login dialed workspaces that hold nothing by that name and narrated each
+/// one:
+///
+/// - a CHANNEL, whose curation history is a web surface: the refusal says so;
+/// - a bundle a recipe row in THIS SCOPE demands with no update behind it yet. `list` prints that
+///   row, `revert` names the update that lands it, and `log` answered `no tracked skill named
+///   '<name>'` — the same machine contradicting its own listing, in a noun this CLI stopped using,
+///   with no next step. A history is a LOOKUP, not a local verb: the versions live in the
+///   workspace, so they are read and printed, and `not_applied` says which state answered.
+///
+/// A name nothing asks for earns no lookup at all: the classification refusal
+/// ([`super::unapplied_or_unknown`]) is the whole answer.
 ///
 /// # Errors
-/// The typed workspace-selection refusal when several logins are joined and none is the default.
-fn channel_refusal(
+/// The typed workspace-selection refusal when several logins are joined and none is the default;
+/// the channel refusal; the not-applied / plain-miss refusal; a transport fault on the read.
+fn unresolved_history(
     ctx: &Ctx<'_>,
     connectors: &LogConnectors<'_>,
     skill: &str,
     workspace: Option<&str>,
-) -> Result<Option<ClientError>, ClientError> {
+    page: super::RowPage,
+) -> Result<LogData, ClientError> {
     let su = match super::connect::acting_universe(ctx, connectors.session, workspace) {
-        Ok(Some(su)) => su,
-        Ok(None) => return Ok(None),
+        Ok(su) => su,
         // The PICK is the person's to make and has to be said out loud. A server that did not
         // answer is a different thing entirely: the probe is best-effort, so the local
         // "no bundle by that name" stands, exactly as it did before this probe existed.
         Err(e @ (ClientError::WorkspaceSelection(_) | ClientError::SessionRequired { .. })) => {
             return Err(e);
         }
-        Err(_) => return Ok(None),
+        Err(_) => None,
     };
-    let Ok(parsed) = resolve::parse_target(skill) else {
-        return Ok(None);
-    };
-    let Ok(Some(Resolution::Resource {
+    let found = su.as_ref().and_then(|su| {
+        let parsed = resolve::parse_target(skill).ok()?;
+        resolve::resolve_one(&su.universe, &parsed, resolve::KindScope::SUBSCRIBABLE)
+            .ok()
+            .flatten()
+    });
+    if let Some(Resolution::Resource {
         kind: ResourceKind::Channel,
         name,
         ..
-    })) = resolve::resolve_one(&su.universe, &parsed, resolve::KindScope::CHANNELS)
-    else {
-        return Ok(None);
+    }) = &found
+    {
+        return Err(ClientError::InvalidArgument(format!(
+            "'{name}' is a channel — a channel's curation history lives on the web, not in `topos \
+             log` (which shows a bundle's version history)"
+        )));
+    }
+    // Only a DEMANDED row earns the workspace read.
+    let Some(global) = super::demanded_but_unapplied(ctx, skill, super::StoreScope::Here) else {
+        return Err(super::unapplied_or_unknown(
+            ctx,
+            skill,
+            super::StoreScope::Here,
+            "",
+        ));
     };
-    Ok(Some(ClientError::InvalidArgument(format!(
-        "'{name}' is a channel — a channel's curation history lives on the web, not in `topos \
-         log` (which shows a skill's version history)"
-    ))))
+    // Demanded, but nothing here can read the workspace's copy of the answer: the shared clause
+    // alone — there is no second thing to say that a `log` reader would act on.
+    let unapplied = || ClientError::NotAppliedHere {
+        name: skill.to_owned(),
+        global,
+        needs: "",
+    };
+    let (
+        Some(su),
+        Some(Resolution::Resource {
+            kind: ResourceKind::Skill,
+            workspace_id,
+            name,
+            skill_id: Some(skill_id),
+            ..
+        }),
+    ) = (su.as_ref(), found)
+    else {
+        // Demanded, but this run cannot name it in the workspace (signed into nothing, offline,
+        // or the workspace shares nothing by that name): the refusal that names the update is
+        // the honest answer, and it is the same one `revert` gives about this very state.
+        return Err(unapplied());
+    };
+    let Some(directory) = su.directory_for(&workspace_id) else {
+        return Err(unapplied());
+    };
+    let plane = directory.skill_log(&workspace_id, &skill_id)?;
+    let archived_successor = plane
+        .base_name
+        .as_ref()
+        .map(|base| format!("{base} is archived as {}", plane.name));
+    let mut events: Vec<Value> = plane.versions.iter().map(plane_version_event).collect();
+    events.extend(plane.proposals.iter().map(plane_proposal_event));
+    let mut events = order_newest_first(events);
+    let (page_applied, truncated, total) = apply_page(&mut events, page);
+    Ok(LogData {
+        events,
+        team: None,
+        archived_successor,
+        truncated,
+        total: page_applied.then_some(total as u64),
+        sync_fault: recorded_fault(ctx, &workspace_id),
+        not_applied: Some(NotApplied {
+            bundle: name,
+            global,
+        }),
+    })
 }
 
 /// The fault recorded for `workspace_id`'s last exchange, named the way a person addresses the

--- a/bins/topos/src/ops/mod.rs
+++ b/bins/topos/src/ops/mod.rs
@@ -558,7 +558,12 @@ fn resolve_followed_skill_in_scope(
 /// `r2-smoke  (not applied here yet — \`topos update -g\` applies it)` was told `no tracked skill
 /// named 'r2-smoke'` — the same machine contradicting itself, with no next step even though ONE
 /// command turns the row into a copy. So the demand is asked about before a miss is claimed.
-pub(crate) fn unapplied_or_unknown(ctx: &Ctx<'_>, name: &str, scope: StoreScope) -> ClientError {
+pub(crate) fn unapplied_or_unknown(
+    ctx: &Ctx<'_>,
+    name: &str,
+    scope: StoreScope,
+    needs: &'static str,
+) -> ClientError {
     // A manifest this build REFUSES is not "nothing is tracked here": it is a file with one bad
     // line in it, and `list` names the line. Swallowing that read and answering the miss sent a
     // person hunting for a missing bundle when the fix was a row in a file the verb had already
@@ -572,6 +577,7 @@ pub(crate) fn unapplied_or_unknown(ctx: &Ctx<'_>, name: &str, scope: StoreScope)
         Some(global) => ClientError::NotAppliedHere {
             name: name.to_owned(),
             global,
+            needs,
         },
         None => ClientError::NoTrackedBundle {
             name: name.to_owned(),
@@ -588,7 +594,7 @@ pub(crate) fn unapplied_or_unknown(ctx: &Ctx<'_>, name: &str, scope: StoreScope)
 /// folder is GONE is excluded, because no `update` will ever apply that one either. Best-effort:
 /// an unreadable manifest or store answers `None` and the plain miss stands, rather than a
 /// half-fact promising a command that would not help.
-fn demanded_but_unapplied(ctx: &Ctx<'_>, name: &str, scope: StoreScope) -> Option<bool> {
+pub(crate) fn demanded_but_unapplied(ctx: &Ctx<'_>, name: &str, scope: StoreScope) -> Option<bool> {
     let (all, cache) = inventory::read_sources(ctx).ok()?;
     let resolved = inventory::resolve(ctx, &all, &cache).ok()?;
     let unapplied = |section: &inventory::ScopeResolution| {

--- a/bins/topos/src/ops/mod.rs
+++ b/bins/topos/src/ops/mod.rs
@@ -93,7 +93,7 @@ pub(crate) use builtin::{
     ensure_with as builtin_ensure_with, marker_in_frontmatter as builtin_marker_in_frontmatter,
     remove_builtin as builtin_remove,
 };
-pub(crate) use diff::{DiffBudget, diff, diff_resolved};
+pub(crate) use diff::{DiffBudget, diff, reset_preview_diff};
 pub(crate) use fmt::fmt_manifest;
 pub(crate) use init::init;
 pub(crate) use inventory::ScopeView;

--- a/bins/topos/src/ops/pull.rs
+++ b/bins/topos/src/ops/pull.rs
@@ -21,7 +21,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::path::Path;
 
 use topos_types::persisted::SyncState;
-use topos_types::results::{ExchangeFault, PullData, ResetData};
+use topos_types::results::{ExchangeFault, PullData, PullSkill, ResetData};
 
 use crate::ctx::Ctx;
 use crate::error::ClientError;
@@ -421,6 +421,8 @@ pub(crate) fn pull(ctx: &Ctx<'_>, scope: PullScope) -> Result<PullOutcome, Clien
             // The go-back and the `--keep-mine` escape are documented plane-independent (the escape is
             // the offline no-deadlock guarantee) — neither spends a network call on the proposals count.
             let plane_independent = matches!(mode, TargetMode::GoBack(_) | TargetMode::KeepMine);
+            // Whether the LOCK follows this invocation — decided before `mode` is consumed below.
+            let went_back = matches!(mode, TargetMode::GoBack(_));
             let mut row = match mode {
                 TargetMode::GoBack(vref) => sync_engine::go_back(&sctx, &skill_id, &vref)?,
                 // The escape consults NO follow state: it finishes a stopped merge from the local
@@ -448,12 +450,23 @@ pub(crate) fn pull(ctx: &Ctx<'_>, scope: PullScope) -> Result<PullOutcome, Clien
             // Stamp the row's workspace provenance from the follow-state (a retained-but-paused entry still
             // resolves; a purely local go-back / tracked-only skill is honestly `None`).
             row.workspace_id = super::followed_workspace(ctx, skill_id.as_str());
+            // THE LOCK RECORDS WHAT THE COPY HOLDS. A go-back inside a checkout replaces that
+            // checkout's copy with an earlier version — and left `topos.lock` naming the team's,
+            // so the file a project COMMITS said the project runs a version no folder there held,
+            // and `install --frozen` would have rebuilt exactly the copy the go-back replaced.
+            // The entry moves the way a publish or a revert moves it (a pin still holds, and says
+            // so), and the receipt names the file.
+            let lock_lines: Vec<topos_types::Message> = went_back
+                .then(|| go_back_lock_line(ctx, &layout, &skill_id, &row))
+                .flatten()
+                .into_iter()
+                .collect();
             let proposals_awaiting = if plane_independent {
                 0
             } else {
                 sum_open_proposals(ctx)
             };
-            Ok(PullOutcome::plain(
+            let mut out = PullOutcome::plain(
                 PullData {
                     skills: vec![row],
                     proposals_awaiting,
@@ -465,9 +478,68 @@ pub(crate) fn pull(ctx: &Ctx<'_>, scope: PullScope) -> Result<PullOutcome, Clien
                 },
                 Vec::new(),
                 BTreeSet::new(),
-            ))
+            );
+            out.disclosures = lock_lines;
+            Ok(out)
         }
     }
+}
+
+/// The cwd project's `topos.lock`, moved to the version a landed GO-BACK now holds — and the line
+/// the receipt says it with. `None` when the go-back acted on a store this checkout does not own,
+/// when there is no project lock entry to move, or when the copy is not a workspace bundle a lock
+/// records.
+///
+/// Best-effort, exactly like the publish/revert rail it shares: the bytes have already landed, and
+/// a lock this run could not move is said on stderr and converged by the next `topos update`.
+fn go_back_lock_line(
+    ctx: &Ctx<'_>,
+    layout: &sidecar::Layout,
+    skill_id: &crate::id::SkillId,
+    row: &PullSkill,
+) -> Option<topos_types::Message> {
+    // ONLY the checkout whose OWN copy just moved. A go-back acts on one store: run from inside a
+    // project with `-g`, it is the MACHINE's copy that went back, and moving the project's lock
+    // then would put a version in the committed file that the checkout's own folder does not hold
+    // — the very thing this rail exists to stop.
+    let root = layout.project_root()?;
+    let roots = ctx.roots.as_ref()?;
+    let cwd = roots.cwd.as_deref()?;
+    let nearest = crate::manifest::scopes::nearest_manifest_dir(ctx.fs, cwd, Some(&roots.home))?;
+    if nearest != root {
+        return None;
+    }
+    // The version the copy HOLDS after the go-back — read from the store the go-back wrote, never
+    // from the ref the person typed (a short ref resolved to it; the record is what landed).
+    let lock =
+        doc::read_doc::<topos_types::persisted::Lock>(ctx.fs, &layout.published(skill_id).lock)
+            .ok()
+            .flatten()?;
+    let ws = super::followed_workspace(ctx, skill_id.as_str())
+        .and_then(|id| super::workspace_ref(ctx, &id))?;
+    let moved =
+        super::advance_project_lock(ctx, &row.skill, &lock.base_commit, &ws.host, &ws.name)?;
+    let short = crate::render::short(&moved.version);
+    Some(if moved.held {
+        crate::message::disclosure(
+            "LOCK_HELD",
+            format!(
+                "{} pins {}, so it keeps {short} — this copy holds {} until the pin changes",
+                crate::manifest::MANIFEST_FILE,
+                row.skill,
+                crate::render::short(&lock.base_commit),
+            ),
+        )
+    } else {
+        crate::message::disclosure(
+            "LOCK_MOVED",
+            format!(
+                "{} now records {}@{short} — the version this copy holds",
+                crate::manifest::lock::LOCK_FILE,
+                row.skill,
+            ),
+        )
+    })
 }
 
 /// `update --reset <skill>...` — the loss-led two-phase discard. Refuses without a named skill (a reset

--- a/bins/topos/src/ops/pull.rs
+++ b/bins/topos/src/ops/pull.rs
@@ -543,16 +543,17 @@ pub(crate) fn reset(
         };
         // The draft delta vs current — the exact bytes a reset drops, read from the copy resolved
         // above (never re-resolved: a second pass could answer with the other scope's copy and
-        // describe a loss nobody is about to take). DIVERGENT copies cannot render one diff (that
-        // freeze is exactly what `--reset` is the named way out of), so the loss is disclosed as
-        // the frozen set instead of failing the reset. UNCAPPED deliberately: a loss disclosure
-        // must never truncate what would be discarded.
-        let drop_diff = match super::diff_resolved(
+        // describe a loss nobody is about to take). Read in the direction the RESET runs: `a` is
+        // this copy (what goes away), `b` is the version that lands — a preview that read the
+        // other way told a person the opposite of what `--yes` was about to do. DIVERGENT copies
+        // cannot render one diff (that freeze is exactly what `--reset` is the named way out of),
+        // so the loss is disclosed as the frozen set instead of failing the reset. UNCAPPED
+        // deliberately: a loss disclosure must never truncate what would be discarded.
+        let drop_diff = match super::reset_preview_diff(
             ctx,
             layout,
             id,
             lock,
-            None,
             super::DiffBudget::unlimited(),
             sel,
         ) {

--- a/bins/topos/src/ops/reconcile.rs
+++ b/bins/topos/src/ops/reconcile.rs
@@ -494,6 +494,11 @@ struct Sweep {
     /// Bundles whose harvested lock value came from a TOML PIN — the write-back lets these win
     /// over a standing entry (the pin is intent; recording it is filling, not moving).
     lock_pin_overrides: std::collections::BTreeSet<String>,
+    /// Lock entries that must STAND where they are, with the clause saying why — a bundle whose
+    /// merge STOPPED, whose copy therefore still holds the version it held before. The write-back
+    /// takes no harvest for these and discloses the reason instead of the "could not re-resolve"
+    /// line, which would name the wrong cause.
+    lock_stands: BTreeMap<String, String>,
     /// Feed ADDRESSES whose empty serve is already disclosed. A feed may be adopted by more than
     /// one recipe; the fact is the workspace's, not a scope's, so it is said once per run.
     empty_feeds: HashSet<String>,
@@ -2437,6 +2442,12 @@ pub(crate) fn manifest_update(
                 // An update that could not re-resolve a still-demanded entry KEEPS it — say so.
                 if update {
                     for (name, kept) in &newdoc.skills {
+                        // A STOPPED MERGE has its own line below, naming the real cause: this
+                        // one would say the workspace could not be re-read, which is not what
+                        // happened.
+                        if sweep.lock_stands.contains_key(name) {
+                            continue;
+                        }
                         if !sweep.lock_harvest.skills.contains_key(name) {
                             pin_lines.push(crate::message::disclosure(
                                 "LOCK_KEPT",
@@ -2512,6 +2523,16 @@ pub(crate) fn manifest_update(
                     }
                 }
             }
+            // An entry the lock KEEPS because the copy still holds it — said whether or not the
+            // file itself changed, because "nothing moved" is exactly the fact worth stating over
+            // a bundle whose update was expected to move it.
+            let stood: Vec<Message> = sweep
+                .lock_stands
+                .iter()
+                .filter(|(name, _)| newdoc.skills.contains_key(*name))
+                .map(|(_, why)| crate::message::disclosure("LOCK_STANDS", why.clone()))
+                .collect();
+            sweep.disclosures.extend(stood);
             newdoc.workspace = plan.workspace.as_ref().map(|(h, w)| format!("{h}/{w}"));
             let has_entries =
                 !(newdoc.skills.is_empty() && newdoc.mcp.is_empty() && newdoc.channels.is_empty());
@@ -3001,20 +3022,20 @@ fn reconcile_thing<'a>(
             let row_pin = row.pin();
             let pin_from_row = row_pin.is_some();
             let pin = row_pin.or_else(|| sc.lock_pin(bundle));
-            if sc.lock.is_some() {
-                // A toml PIN is intent — the lock reconciles TO it (an exact resolution is a
-                // fill, not a move), so the write-back must let this harvest value win.
-                if pin_from_row {
-                    sweep.lock_pin_overrides.insert(bundle.clone());
-                }
-                sweep.lock_harvest.skills.insert(
+            // A toml PIN is intent — the lock reconciles TO it (an exact resolution is a fill,
+            // not a move), so the write-back must let this harvest value win.
+            if sc.lock.is_some() && pin_from_row {
+                sweep.lock_pin_overrides.insert(bundle.clone());
+            }
+            let lock_entry = sc.lock.is_some().then(|| {
+                (
                     bundle.clone(),
                     LockSkill {
                         version: Some(pin.clone().unwrap_or_else(|| target.version_id.clone())),
                         ..LockSkill::default()
                     },
-                );
-            }
+                )
+            });
             let st = SyncTarget {
                 target,
                 pin,
@@ -3023,6 +3044,7 @@ fn reconcile_thing<'a>(
                 // A skill row's dest is its frozen placement plan.
                 dest: row.fields().dest,
                 counted: true,
+                lock_entry,
             };
             sync_workspace_skill(env, sc, run, &st, sweep);
         }
@@ -3792,16 +3814,16 @@ fn reconcile_set<'a>(
             };
             let display = entry.name.clone();
             let pin = sc.lock_pin(&entry.name);
-            if sc.lock.is_some() {
-                sweep.lock_harvest.skills.insert(
+            let lock_entry = sc.lock.is_some().then(|| {
+                (
                     entry.name.clone(),
                     LockSkill {
                         version: Some(pin.clone().unwrap_or_else(|| entry.version_id.clone())),
                         via: Some(channel.clone()),
                         ..LockSkill::default()
                     },
-                );
-            }
+                )
+            });
             let st = SyncTarget {
                 target: CatalogTarget::from_entry(entry, kind),
                 pin,
@@ -3809,6 +3831,7 @@ fn reconcile_set<'a>(
                 display,
                 dest: row.fields().dest,
                 counted: true,
+                lock_entry,
             };
             sync_workspace_skill(env, sc, run, &st, sweep);
         }
@@ -3931,6 +3954,8 @@ fn reconcile_feed<'a>(
                     // A feed item has no row — no dest, no narrowing: the default placement.
                     dest: None,
                     counted: true,
+                    // A feed is person-scope by nature, and the person scope has no lock.
+                    lock_entry: None,
                 };
                 sync_workspace_skill(env, sc, run, &st, sweep);
             }
@@ -4159,9 +4184,18 @@ struct SyncTarget {
     /// per entry, detection ignored). `None` = no dest: today's default placement, every agent.
     dest: Option<Vec<String>>,
     /// Whether this bundle takes a number in the run's activity counter — what turns the line into
-    /// "updating docs (2 of 7)". `false` for a lone explicit row, which is a batch of one and says
-    /// so by not counting.
+    /// "updating docs (2 of 7)". `false` only for the offline converge, which runs after the
+    /// counting pass has returned.
     counted: bool,
+    /// The `topos.lock` entry this row WOULD record, under the key it records it by — `None` when
+    /// the scope has no lock at all.
+    ///
+    /// Harvested only once the sync has said what the copy HOLDS (see [`sync_workspace_skill`]).
+    /// Recorded up front, it recorded the version the row RESOLVED to whatever became of it: a
+    /// bundle whose merge conflicted kept the person's own bytes on disk while the lock advanced
+    /// to the team's, and a bundle whose fetch failed put a version in the committed file that no
+    /// folder in the checkout held.
+    lock_entry: Option<(String, LockSkill)>,
 }
 
 /// What one lane said about a connected server — the facts its record is written from. Both lanes
@@ -4533,6 +4567,28 @@ fn sync_workspace_skill<'a>(
             if !sweep.warnings.contains(&line) {
                 sweep.warnings.push(line);
             }
+        }
+    }
+    // THE LOCK RECORDS WHAT THE COPY HOLDS. The harvest is taken HERE, from the outcome, and not
+    // from the version the row resolved to before anything was fetched: a merge that STOPPED
+    // leaves the person's own bytes in every folder, and a sync that failed leaves whatever stood
+    // there — in both cases the version this row resolved to is one no folder in the checkout
+    // holds, and writing it into a committed file is the reproducibility lie the lock exists to
+    // prevent. A stopped merge KEEPS the standing entry (said out loud); a failure harvests
+    // nothing, which is the state the write-back's "could not re-resolve" line already describes.
+    if let Some((key, entry)) = &st.lock_entry {
+        match &outcome {
+            Ok(row) if row.action == PullAction::Conflicted => {
+                let why = format!(
+                    "{}: the merge here has stopped — topos.lock keeps the version this copy holds",
+                    st.display
+                );
+                sweep.lock_stands.insert(key.clone(), why);
+            }
+            Ok(_) => {
+                sweep.lock_harvest.skills.insert(key.clone(), entry.clone());
+            }
+            Err(_) => {}
         }
     }
     let mut row_index = None;

--- a/bins/topos/src/ops/reconcile.rs
+++ b/bins/topos/src/ops/reconcile.rs
@@ -2856,7 +2856,7 @@ fn reconcile_thing<'a>(
                                 // it does on the ordinary arm — the row must not read as a
                                 // healthy install when nothing was placed.
                                 unreachable: narrowing.unreachable,
-                                counted: false,
+                                counted: true,
                             },
                             sweep,
                         );
@@ -2942,7 +2942,7 @@ fn reconcile_thing<'a>(
                         delivered: Some(delivered),
                         reach: narrowing.filter,
                         unreachable: narrowing.unreachable,
-                        counted: false,
+                        counted: true,
                     },
                     sweep,
                 );
@@ -3022,7 +3022,7 @@ fn reconcile_thing<'a>(
                 display: display.clone(),
                 // A skill row's dest is its frozen placement plan.
                 dest: row.fields().dest,
-                counted: false,
+                counted: true,
             };
             sync_workspace_skill(env, sc, run, &st, sweep);
         }
@@ -4304,8 +4304,13 @@ impl RunSteps {
 }
 
 impl Step {
-    /// The activity label for `display` at this position — or the uncounted form when the item came
-    /// from a lone row.
+    /// The activity label for `display` at this position — or the uncounted form for the ONE arm
+    /// that takes no number: the offline converge, which walks the local store after the counting
+    /// pass has already returned. Every row the run CHECKS is counted, whichever source names it
+    /// (an explicit `[skills]`/`[mcp]` row, a channel member, a feed item), so the counter's total
+    /// and the summary's `Checked N bundles` are the same number. They were not: a standalone row
+    /// printed `updating github` with no position, ahead of a `(1 of 7)…(7 of 7)` run that then
+    /// summed `Checked 8 bundles`.
     fn label(step: Option<Self>, display: &str, verb: &str) -> String {
         match step {
             Some(Self { index, total }) => format!("{verb} {display} ({index} of {total})"),

--- a/bins/topos/src/ops/revert.rs
+++ b/bins/topos/src/ops/revert.rs
@@ -104,7 +104,12 @@ pub(crate) fn revert(
         match resolve_followed_skill_in_scope(ctx, skill_name, workspace, scope) {
             Ok(hit) => hit,
             Err(ClientError::NoSuchSkill { name }) => {
-                return Err(super::unapplied_or_unknown(ctx, &name, scope));
+                return Err(super::unapplied_or_unknown(
+                    ctx,
+                    &name,
+                    scope,
+                    "revert acts on an applied copy",
+                ));
             }
             Err(e) => return Err(e),
         };

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -2179,6 +2179,15 @@ pub(crate) fn log_tty(data: &LogData) -> String {
             crate::ops::StaleReason::from(f.kind).clause()
         ));
     }
+    // A history read from the WORKSPACE because no copy is applied here: say which state answered,
+    // and name the one command that turns the row into a copy. Without it the rows below read as
+    // this machine's own history of a bundle it has never held.
+    if let Some(n) = &data.not_applied {
+        out.push_str(&format!(
+            "note: {} — the history below is the workspace's\n",
+            crate::error::not_applied_clause(&n.bundle, n.global)
+        ));
+    }
     if data.events.is_empty() {
         return if out.is_empty() {
             "No history.".to_owned()
@@ -9983,6 +9992,7 @@ mod tests {
             truncated: false,
             total: None,
             sync_fault: None,
+            not_applied: None,
         };
         let out = log_tty(&data);
         assert!(
@@ -10040,6 +10050,7 @@ mod tests {
             truncated: false,
             total: None,
             sync_fault: None,
+            not_applied: None,
         };
         let out = log_tty(&data);
         // Columns: human timestamp, action, name, short id.

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -2029,6 +2029,10 @@ fn agent_view_tty(view: &AgentView) -> String {
 /// The sentence states the loss plainly and stops — the delta printed under it is the argument,
 /// and a shouted word above a diff a person is already reading only makes the surface sound
 /// anxious. The receipt below reads in the same voice.
+///
+/// It names BOTH halves of the swap, because the diff under it does: a reset takes your copy away
+/// and puts the team's version there, so the line says which way it runs rather than naming only
+/// the version — over a diff whose `-` lines are yours and whose `+` lines are the team's.
 pub(crate) fn reset_describe_tty(
     items: &[topos_types::results::ResetData],
     yes_argv: &[String],
@@ -2037,12 +2041,12 @@ pub(crate) fn reset_describe_tty(
     for item in items {
         match &item.dest {
             Some(dest) => s.push_str(&format!(
-                "Reset '{}' in {dest} — discard local edits to {}:\n",
+                "Reset '{}' in {dest} — your edits go away, the team's {} lands:\n",
                 item.skill,
                 short(&item.to_version)
             )),
             None => s.push_str(&format!(
-                "Reset '{}' — discard local edits to {}:\n",
+                "Reset '{}' — your edits go away, the team's {} lands:\n",
                 item.skill,
                 short(&item.to_version)
             )),
@@ -10800,6 +10804,66 @@ mod tests {
         assert!(
             resolution_next_actions(&data(vec![row_with(None)])).is_empty(),
             "a merge that was never stopped had no exit to finish it"
+        );
+    }
+
+    /// The `--reset` PREVIEW reads the way the apply runs. A reset replaces your copy with the
+    /// team's version, so the header names both halves of that swap and the delta under it puts
+    /// your edits on the `-` side and the landing version on the `+` side. It used to print
+    /// `discard local edits to <v>` over a diff whose deletions were the team's incoming lines
+    /// and whose additions were the edits about to be destroyed — the preview saying the opposite
+    /// of what `--yes` does.
+    #[test]
+    fn the_reset_preview_reads_the_way_the_apply_runs() {
+        let item = |dest: Option<&str>| topos_types::results::ResetData {
+            skill: "r2-smoke".to_owned(),
+            workspace_id: None,
+            workspace: None,
+            to_version: "233c617a96d2".to_owned() + &"0".repeat(52),
+            // `a` is this copy (what goes away); `b` is the version that lands.
+            drop_diff: "--- a/nonce.txt\n+++ b/nonce.txt\n@@ -1,1 +1,1 @@\n-090e320e048f99d7\n\
+                        +bab8474e7087d628\n"
+                .to_owned(),
+            applied: false,
+            dest: dest.map(str::to_owned),
+            others_kept: Vec::new(),
+            global: false,
+            hand_merge: None,
+            merge: None,
+        };
+        let argv = ["topos", "update", "r2-smoke", "--reset", "--yes"]
+            .map(str::to_owned)
+            .to_vec();
+
+        let whole = super::reset_describe_tty(&[item(None)], &argv);
+        assert!(
+            whole.starts_with(
+                "Reset 'r2-smoke' — your edits go away, the team's 233c617a96d2 \
+                               lands:\n"
+            ),
+            "{whole}"
+        );
+        // The direction, stated as the diff itself states it.
+        let dropped: Vec<&str> = whole
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with('-') && !l.starts_with("---"))
+            .collect();
+        let landing: Vec<&str> = whole
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with('+') && !l.starts_with("+++"))
+            .collect();
+        assert_eq!(dropped, ["-090e320e048f99d7"], "{whole}");
+        assert_eq!(landing, ["+bab8474e7087d628"], "{whole}");
+        // A narrowed reset says the same thing about the one folder it takes.
+        let one = super::reset_describe_tty(&[item(Some("~/.claude/skills/r2-smoke"))], &argv);
+        assert!(
+            one.starts_with(
+                "Reset 'r2-smoke' in ~/.claude/skills/r2-smoke — your edits go away, the team's \
+                 233c617a96d2 lands:\n"
+            ),
+            "{one}"
         );
     }
 

--- a/bins/topos/src/resolve.rs
+++ b/bins/topos/src/resolve.rs
@@ -373,7 +373,10 @@ impl KindScope {
         channels: true,
         skills: true,
     };
-    /// Channels only (`--channel` selectors; channel curation).
+    /// Channels only (`--channel` selectors; channel curation) — a kind scope the shipped verbs
+    /// no longer narrow to (`log`'s channel probe reads both kinds in one pass, so a name that is
+    /// both is an ambiguity rather than a silent miss), kept for the resolver's own tests.
+    #[cfg(test)]
     pub(crate) const CHANNELS: KindScope = KindScope {
         workspaces: false,
         channels: true,

--- a/bins/topos/src/tests/manifest_reconcile/copies.rs
+++ b/bins/topos/src/tests/manifest_reconcile/copies.rs
@@ -847,6 +847,13 @@ fn zz_a_per_copy_reset_drops_one_copys_edits_and_leaves_the_other_alone() {
         "the loss shown is THIS copy's: {}",
         items[0].drop_diff
     );
+    // …and it reads the way the reset RUNS: this copy is `a` (it goes away), the version that
+    // lands is `b`. Printed the other way the preview said the opposite of what `--yes` does.
+    assert!(
+        items[0].drop_diff.contains("-native edit") && items[0].drop_diff.contains("+base"),
+        "your edits are the deletions, the landing version the additions: {}",
+        items[0].drop_diff
+    );
     // The SENTENCES around that delta say the same thing it does. The consent surface names the
     // one folder it takes and states, in the same breath, that the other copy keeps its edits —
     // a describe claiming the whole bundle's edits would be asking for the wrong yes.
@@ -863,11 +870,12 @@ fn zz_a_per_copy_reset_drops_one_copys_edits_and_leaves_the_other_alone() {
     let described_tty = crate::render::reset_describe_tty(items, yes_argv);
     assert!(
         described_tty.starts_with(
-            "Reset 'coolify-deploy' in ~/.claude/skills/coolify-deploy — discard \
-             local edits to "
+            "Reset 'coolify-deploy' in ~/.claude/skills/coolify-deploy — your edits go away, \
+             the team's "
         ),
         "{described_tty}"
     );
+    assert!(described_tty.contains(" lands:\n"), "{described_tty}");
     assert!(!described_tty.contains("DISCARDS"), "{described_tty}");
     assert!(
         described_tty

--- a/bins/topos/src/tests/manifest_reconcile/rig.rs
+++ b/bins/topos/src/tests/manifest_reconcile/rig.rs
@@ -11,8 +11,8 @@ use std::sync::{Arc, Mutex};
 use topos_core::digest::{self, FileMode, ManifestEntry};
 use topos_core::identity::Commit;
 use topos_types::requests::{
-    WireChannelEntry, WireChannelIndex, WireChannelSkill, WireMe, WireProposalIndex,
-    WireSkillIndex, WireSkillIndexEntry, WireSkillLog,
+    WireChannelEntry, WireChannelIndex, WireChannelSkill, WireLogVersion, WireMe,
+    WireProposalIndex, WireSkillIndex, WireSkillIndexEntry, WireSkillLog,
 };
 use topos_types::results::ExchangeFault;
 
@@ -459,6 +459,14 @@ pub(in crate::tests) struct FakeDirectory {
     /// Empty is a workspace that serves none — which is also every server older than the lane.
     pub(super) mcp_revisions: Vec<topos_types::requests::WireMcpIndexEntry>,
     pub(super) channels: Vec<WireChannelEntry>,
+    /// The workspace's ADDRESS name, when this fake answers `me` at all. `None` keeps the
+    /// original refusal (the publish path's best-effort read just omits its invite line); `Some`
+    /// makes the fake resolvable, which is what a NAME LOOKUP needs — the resolver universe is
+    /// built from `me` + the two indexes.
+    pub(super) me_name: Option<String>,
+    /// The PLANE history this workspace serves per skill id (`skill_id → versions`). Empty for a
+    /// bundle nothing published — the fake's default, which leaves a local log exactly as it was.
+    pub(super) logs: std::collections::BTreeMap<String, Vec<WireLogVersion>>,
     /// When set, the index reads fail (a transport fault) — the freeze suites flip it.
     pub(super) unavailable: Arc<Mutex<bool>>,
 }
@@ -473,8 +481,27 @@ impl FakeDirectory {
             mcp_servers: Vec::new(),
             mcp_revisions: Vec::new(),
             channels,
+            me_name: None,
+            logs: std::collections::BTreeMap::new(),
             unavailable: Arc::new(Mutex::new(false)),
         }
+    }
+
+    /// The same fake, ANSWERING `me` under `WS_NAME` — what a by-name LOOKUP needs, because the
+    /// resolver universe is built from `me` plus the two indexes.
+    pub(in crate::tests) fn resolvable(mut self) -> Self {
+        self.me_name = Some(WS_NAME.to_owned());
+        self
+    }
+
+    /// The same fake, serving `skill_id`'s PLANE history — the versions a `log` read prints.
+    pub(in crate::tests) fn with_log(
+        mut self,
+        skill_id: &str,
+        versions: Vec<WireLogVersion>,
+    ) -> Self {
+        self.logs.insert(skill_id.to_owned(), versions);
+        self
     }
 
     /// The same fake, serving one connected SERVER beside whatever file bundles it already has.
@@ -536,9 +563,23 @@ pub(in crate::tests) fn catalog_entry(
     }
 }
 impl DirectorySource for FakeDirectory {
-    fn me(&self, _ws: &str) -> Result<WireMe, ClientError> {
-        // A publish's best-effort post-landing read: absent here (the invite line just omits).
-        Err(ClientError::Plane("no me in this fake".into()))
+    fn me(&self, ws: &str) -> Result<WireMe, ClientError> {
+        // A publish's best-effort post-landing read: absent by default (the invite line just
+        // omits). `resolvable()` turns this fake into one a NAME LOOKUP can build a universe over.
+        let Some(name) = self.me_name.clone() else {
+            return Err(ClientError::Plane("no me in this fake".into()));
+        };
+        self.check_reachable()?;
+        Ok(WireMe {
+            workspace_id: ws.to_owned(),
+            display_name: name.clone(),
+            address: format!("{HOST}/{name}"),
+            name,
+            principal: "someone@acme.test".to_owned(),
+            role: "member".to_owned(),
+            invited_by: None,
+            session_status: Some("active".to_owned()),
+        })
     }
     fn channels_index(&self, _ws: &str) -> Result<WireChannelIndex, ClientError> {
         self.check_reachable()?;
@@ -570,17 +611,23 @@ impl DirectorySource for FakeDirectory {
         unreachable!()
     }
     fn skill_log(&self, _ws: &str, skill_id: &str) -> Result<WireSkillLog, ClientError> {
-        // A catalog with no PLANE history: `log`'s plane half reaches this fake now that it takes
-        // the bundle's own workspace lane instead of building the whole session universe (whose
-        // `me` read this fake refuses). An empty history leaves the local log exactly as it was.
+        // A catalog with no PLANE history by default: `log`'s plane half reaches this fake now
+        // that it takes the bundle's own workspace lane instead of building the whole session
+        // universe (whose `me` read this fake refuses). An empty history leaves the local log
+        // exactly as it was; `with_log` serves one.
         self.check_reachable()?;
         Ok(WireSkillLog {
             skill_id: skill_id.to_owned(),
-            name: String::new(),
+            name: self
+                .skills
+                .iter()
+                .find(|e| e.skill_id == skill_id)
+                .map(|e| e.name.clone())
+                .unwrap_or_default(),
             kind: "skill".to_owned(),
             status: "active".to_owned(),
             base_name: None,
-            versions: Vec::new(),
+            versions: self.logs.get(skill_id).cloned().unwrap_or_default(),
             proposals: Vec::new(),
         })
     }

--- a/bins/topos/src/tests/manifest_reconcile/scope_verbs.rs
+++ b/bins/topos/src/tests/manifest_reconcile/scope_verbs.rs
@@ -6,6 +6,7 @@
 
 use std::sync::{Arc, Mutex};
 
+use topos_types::requests::WireLogVersion;
 use topos_types::results::{ExchangeFault, PullAction};
 
 use crate::ctx::Ctx;
@@ -1496,7 +1497,7 @@ fn two_same_named_mcp_bundles_in_one_scope_each_keep_their_own_states() {
 }
 
 /// A machine whose `list -g` prints `r2-smoke  (not applied here yet — `topos update -g` applies
-/// it)` answered `revert` with `no tracked skill named 'r2-smoke'` — the same machine
+/// it)` answered `revert` with `no tracked bundle named 'r2-smoke'` — the same machine
 /// contradicting its own listing, and no next step for a state that is ONE command from being
 /// real. The row is asked about before a miss is claimed, and each of the two states says what it
 /// is: the demanded row names the update that would apply it (as prose AND as a runnable
@@ -1568,8 +1569,10 @@ fn revert_tells_a_demanded_unapplied_row_apart_from_a_name_it_never_heard_of() {
          machine tracks",
         "{unknown:?}"
     );
-    // Both still branch as the one refusal an agent already knows.
-    assert_eq!(demanded.code(), "NO_SUCH_SKILL");
+    // And they branch APART: one code says "run the update", the other says "this name is
+    // nowhere". Sharing `NO_SUCH_SKILL` made an agent parse prose to tell a one-command state
+    // from a dead end.
+    assert_eq!(demanded.code(), "NOT_APPLIED");
     assert_eq!(unknown.code(), "NO_SUCH_SKILL");
 }
 
@@ -1660,6 +1663,128 @@ fn an_untracked_name_refuses_with_the_pick_and_dials_nothing() {
     );
 }
 
+/// A bundle this machine's FEED row demands and no update has applied yet. `topos log` answered
+/// `no tracked skill named 'r2-smoke'` — the retired noun, no next step, and a claim the machine
+/// had no way to make: `revert` about the very same state names the update that lands it. A
+/// history is a LOOKUP, not a local verb — the versions live in the workspace — so the read
+/// answers with the workspace's history and says which state it answered from.
+#[test]
+fn log_reads_the_workspace_history_for_a_demanded_unapplied_bundle() {
+    let rig = Rig::new("zq-log-unapplied");
+    rig.seed_session();
+    // The ordinary machine recipe after a login: the feed row, and nothing applied behind it.
+    rig.seed_feed();
+    let ctx = rig.ctx_at(None);
+    let v = one_file(b"# deploy\n");
+    let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+    let plane = FakePlane::new(log);
+    let version = |id: &str, message: &str, current: bool| WireLogVersion {
+        version_id: id.repeat(64 / id.len()),
+        author: Some("robert@topos.sh".to_owned()),
+        message: Some(message.to_owned()),
+        at: Some(1_700_000_000_000),
+        current,
+        purged_at: None,
+        purged_by: None,
+    };
+    let dir = FakeDirectory::new(vec![catalog_entry("s_deploy", "deploy", &v)], Vec::new())
+        .resolvable()
+        .with_log(
+            "s_deploy",
+            vec![
+                version("ab", "deploy v2", true),
+                version("cd", "deploy v1", false),
+            ],
+        );
+    let sessions = connect(&plane, &dir);
+    let connectors = ops::LogConnectors { session: &sessions };
+
+    let data = ops::log(&ctx, &connectors, "deploy", None, ops::RowPage::unlimited())
+        .expect("the workspace's history is readable with no local copy");
+    let messages: Vec<&str> = data
+        .events
+        .iter()
+        .filter_map(|e| e.get("message").and_then(serde_json::Value::as_str))
+        .collect();
+    assert_eq!(messages, ["deploy v2", "deploy v1"], "{data:?}");
+    // The state the read answered from, as data AND as the line a person sees — with the one
+    // command that turns the row into a copy, spelled for the scope the row lives in.
+    let not_applied = data
+        .not_applied
+        .clone()
+        .expect("the read says it answered from the workspace");
+    assert_eq!(not_applied.bundle, "deploy");
+    assert!(not_applied.global, "the row lives in the machine recipe");
+    let tty = crate::render::log_tty(&data);
+    assert!(
+        tty.starts_with(
+            "note: deploy is not applied on this machine yet — `topos update -g` applies it — \
+             the history below is the workspace's\n"
+        ),
+        "{tty}"
+    );
+}
+
+/// `diff` meets the SAME state, and unlike `log` has nothing to answer with: it reads a copy, and
+/// there is none. So it refuses with the same classification `revert` uses — the update that
+/// lands the row, as prose and as a runnable next action — instead of the bare not-found.
+#[test]
+fn diff_names_the_update_for_a_demanded_unapplied_bundle() {
+    let rig = Rig::new("zq-diff-unapplied");
+    rig.seed_session();
+    rig.write_global(&format!(
+        "[skills]\n\"{HOST}/{WS_NAME}/deploy\" = \"latest\"\n"
+    ));
+    let ctx = rig.ctx_at(None);
+
+    let err = ops::diff(
+        &ctx,
+        "deploy",
+        None,
+        ops::DiffBudget::unlimited(),
+        &ops::Selection::default(),
+        ops::StoreScope::Machine,
+    )
+    .expect_err("no applied copy to diff");
+    assert_eq!(
+        err.to_string(),
+        "deploy is not applied on this machine yet — `topos update -g` applies it; diff reads an \
+         applied copy",
+        "{err:?}"
+    );
+    assert_eq!(err.code(), "NOT_APPLIED");
+    assert_eq!(
+        scope_ways_out("diff", &["diff", "deploy", "-g"], &err),
+        vec![(
+            "UPDATE_SKILLS".to_owned(),
+            vec![
+                "topos".to_owned(),
+                "update".to_owned(),
+                "-g".to_owned(),
+                "--json".to_owned(),
+            ],
+        )],
+        "the fix rides as a runnable argv, spelled for the scope the row lives in",
+    );
+    // A name nothing demands stays the honest miss — in the bundle vocabulary.
+    let unknown = ops::diff(
+        &ctx,
+        "never-heard-of-it",
+        None,
+        ops::DiffBudget::unlimited(),
+        &ops::Selection::default(),
+        ops::StoreScope::Machine,
+    )
+    .expect_err("nothing of that name is tracked");
+    assert_eq!(
+        unknown.to_string(),
+        "no tracked bundle named 'never-heard-of-it' here — `topos list -g` shows what this \
+         machine tracks",
+        "{unknown:?}"
+    );
+    assert_eq!(unknown.code(), "NO_SUCH_SKILL");
+}
+
 /// The SAME untracked name with the workspace named: the pick is made, so exactly that workspace
 /// is read — the flag beats the missing default rather than widening the search.
 #[test]
@@ -1685,9 +1810,10 @@ fn an_untracked_name_with_a_named_workspace_reads_only_that_one() {
     )
     .expect_err("the name still resolves to nothing");
     assert!(
-        matches!(err, ClientError::NoSuchSkill { .. }),
+        matches!(err, ClientError::NoTrackedBundle { .. }),
         "the answer is the not-found, not a workspace pick: {err:?}"
     );
+    assert_eq!(err.code(), "NO_SUCH_SKILL", "{err:?}");
     assert_eq!(
         *seen.lock().unwrap(),
         vec!["w_ops".to_owned()],

--- a/bins/topos/src/tests/manifest_reconcile/scope_verbs.rs
+++ b/bins/topos/src/tests/manifest_reconcile/scope_verbs.rs
@@ -1879,6 +1879,113 @@ fn the_activity_counter_runs_once_across_every_workspace() {
     );
 }
 
+/// An EXPLICITLY-ADDED row takes a number too. `update -g` over a machine recipe holding one
+/// `[skills]` row and two feeds printed `topos: updating github` — no position, ahead of the
+/// counter — then `(1 of 7)…(7 of 7)`, and summed `Checked 8 bundles`: the counting pass walked
+/// the feed and channel arms and skipped the standalone-row arm, so the run's denominator was
+/// one short of what it checked and the first item read as something outside the run.
+#[test]
+fn the_activity_counter_numbers_an_explicitly_added_row_too() {
+    let rig = Rig::new("ws-counter-explicit-row");
+    rig.seed_session();
+    rig.seed_other_session("w_ops", "ops");
+    // The MCP row needs somewhere to land — a detected config file — or it reaches nobody and
+    // there is nothing to count.
+    std::fs::create_dir_all(rig.home.0.join(".cursor")).unwrap();
+    // Two EXPLICIT rows, one of each kind (the arm that skipped the counter is the standalone-row
+    // arm, and there is one per kind), beside the two feeds.
+    let feeds =
+        format!("[workspaces]\n\"{HOST}/{WS_NAME}\" = \"latest\"\n\"{HOST}/ops\" = \"latest\"\n");
+    let rows = format!("\n[skills]\n\"{HOST}/{WS_NAME}/zeta\" = \"latest\"\n");
+    let servers =
+        format!("\n[mcp]\n\"{HOST}/{WS_NAME}/eta\" = {{ dest = [\"~/.cursor/mcp.json\"] }}\n");
+    rig.write_global(&(feeds + &rows + &servers));
+
+    let v = one_file(b"# body\n");
+    let log: CallLog = Arc::new(Mutex::new(Vec::new()));
+    let first = ["alpha", "beta"];
+    let second = ["gamma", "delta", "epsilon"];
+    let mut plane_a = FakePlane::new(Arc::clone(&log)).with_version("s_zeta", &v);
+    let mut plane_b = FakePlane::new(log);
+    for name in first {
+        plane_a = plane_a.with_version(&format!("s_{name}"), &v);
+    }
+    for name in second {
+        plane_b = plane_b.with_version(&format!("s_{name}"), &v);
+    }
+    plane_a.serves(
+        first
+            .iter()
+            .map(|n| delivered(&format!("s_{n}"), n, &v))
+            .collect(),
+    );
+    plane_b.serves(
+        second
+            .iter()
+            .map(|n| delivered(&format!("s_{n}"), n, &v))
+            .collect(),
+    );
+    // The explicit rows resolve through the CATALOG, not the feed.
+    let dir = FakeDirectory::new(vec![catalog_entry("s_zeta", "zeta", &v)], Vec::new())
+        .with_server(catalog_server("s_eta", "eta", "https://mcp.example/eta"));
+    let lanes = |s: &Session| ops::SessionTransports {
+        plane: if s.workspace_id == WS {
+            Box::new(plane_a.clone())
+        } else {
+            Box::new(plane_b.clone())
+        },
+        directory: Box::new(dir.clone()),
+        contribute: Box::new(NoContribute),
+        governance: Box::new(NoGovernance),
+    };
+
+    let progress = crate::progress::captured();
+    let ctx = rig.ctx_with_progress(Some(&rig.work.0), &progress);
+    let out = ops::manifest_update(
+        &ctx,
+        &lanes,
+        None,
+        &ops::ManifestUpdateOpts {
+            lock: ops::LockMode::Update,
+            scope: ops::UpdateScope::Machine,
+            ..ops::ManifestUpdateOpts::default()
+        },
+    )
+    .unwrap();
+    assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    assert_eq!(
+        out.data.skills.len(),
+        7,
+        "the run converged all seven: {out:?}"
+    );
+
+    let lines = crate::progress::captured_lines(&progress);
+    let updating: Vec<&String> = lines.iter().filter(|l| l.contains("updating ")).collect();
+    // EVERY item the run checks carries a position, in ONE numbering — the explicit rows included,
+    // and its total equals the number of bundles the summary reports.
+    let positions: Vec<String> = updating
+        .iter()
+        .map(|l| {
+            l[l.rfind('(')
+                .unwrap_or_else(|| panic!("a counter: {updating:?}"))..]
+                .to_owned()
+        })
+        .collect();
+    assert_eq!(
+        positions,
+        [
+            "(1 of 7)", "(2 of 7)", "(3 of 7)", "(4 of 7)", "(5 of 7)", "(6 of 7)", "(7 of 7)"
+        ],
+        "one counter over both explicit rows and both feeds: {updating:?}"
+    );
+    for named in ["updating zeta (", "updating eta ("] {
+        assert!(
+            updating.iter().any(|l| l.contains(named)),
+            "the explicitly-added rows are numbered like every other item: {updating:?}"
+        );
+    }
+}
+
 /// A machine whose recipe is a FEED row — "adopt everything northwind assigns me" — and which has
 /// never swept. `topos add r2-smoke -g` answers "northwind's feed already delivers 'r2-smoke'
 /// here", and `revert -g r2-smoke` answered `no tracked bundle named 'r2-smoke' here`: the machine

--- a/contracts/schemas/log-data.schema.json
+++ b/contracts/schemas/log-data.schema.json
@@ -16,6 +16,17 @@
       "type": "array",
       "items": true
     },
+    "not_applied": {
+      "description": "Present when this history came from the WORKSPACE because no copy is applied in the scope\nthe command ran in: a recipe row here demands the bundle and no update has landed it yet.\nA history is a LOOKUP — the versions live in the workspace — so the read still answers,\nand this says which state it answered from. Absent for every applied copy. **INFERRED**\n(additive).",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/NotApplied"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "sync_fault": {
       "description": "The delivering workspace's LAST exchange with this machine, when it did not land — this\nhistory was read from state nothing has refreshed since. Absent when that exchange landed,\nand for a copy no workspace delivers. **INFERRED** (additive).",
       "anyOf": [
@@ -71,6 +82,24 @@
           "type": "string",
           "const": "malformed"
         }
+      ]
+    },
+    "NotApplied": {
+      "description": "A bundle a recipe row in this scope DEMANDS with no applied copy behind it. **INFERRED**\n(additive).",
+      "type": "object",
+      "properties": {
+        "bundle": {
+          "description": "The bundle, as the workspace catalogs it.",
+          "type": "string"
+        },
+        "global": {
+          "description": "`true` when the row lives in the MACHINE recipe — the update that lands it is spelled\n`-g`. The refusal-side twin of this fact carries the `NOT_APPLIED` code.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "bundle",
+        "global"
       ]
     },
     "SyncFault": {

--- a/crates/topos-types/src/results.rs
+++ b/crates/topos-types/src/results.rs
@@ -1817,6 +1817,25 @@ pub struct LogData {
     /// and for a copy no workspace delivers. **INFERRED** (additive).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sync_fault: Option<SyncFault>,
+    /// Present when this history came from the WORKSPACE because no copy is applied in the scope
+    /// the command ran in: a recipe row here demands the bundle and no update has landed it yet.
+    /// A history is a LOOKUP — the versions live in the workspace — so the read still answers,
+    /// and this says which state it answered from. Absent for every applied copy. **INFERRED**
+    /// (additive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_applied: Option<NotApplied>,
+}
+
+/// A bundle a recipe row in this scope DEMANDS with no applied copy behind it. **INFERRED**
+/// (additive).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "contract-derives", derive(schemars::JsonSchema))]
+pub struct NotApplied {
+    /// The bundle, as the workspace catalogs it.
+    pub bundle: String,
+    /// `true` when the row lives in the MACHINE recipe — the update that lands it is spelled
+    /// `-g`. The refusal-side twin of this fact carries the `NOT_APPLIED` code.
+    pub global: bool,
 }
 
 /// A workspace's last exchange with this machine, recorded because it did not land. **INFERRED**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   plane:
     # Pinned to one release (see the header). Override with TOPOS_VERSION, or build from source with
     # the docker-compose.build.yml override.
-    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.53}
+    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.54}
     restart: unless-stopped
     mem_limit: 1g
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
@@ -186,7 +186,7 @@ services:
   gateway:
     # The same release as the other two — one TOPOS_VERSION moves all three, and they are only ever
     # tested together.
-    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.53}
+    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.54}
     restart: unless-stopped
     mem_limit: 1g
     # WHAT THIS BOUNDS IS CONCURRENT MCP STREAMS, NOT MEMORY (mem_limit above is the memory
@@ -253,7 +253,7 @@ services:
   web:
     # The same release as the plane and the gateway — one TOPOS_VERSION moves all three, and they are
     # only ever tested together.
-    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.53}
+    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.54}
     restart: unless-stopped
     mem_limit: 1g
     depends_on:

--- a/tests/tests/current_truth_e2e.rs
+++ b/tests/tests/current_truth_e2e.rs
@@ -850,14 +850,24 @@ fn a_revert_from_a_project_needs_no_machine_wide_copy() {
         "{preview}"
     );
 
-    // `-g` names the machine outright — which holds nothing, and says so.
+    // `-g` names the machine outright — which holds no copy, and says so. The login wrote this
+    // machine's own feed row, so the honest answer is not "never heard of it": one command would
+    // make the copy real, and the refusal carries it as prose AND as a runnable argv.
     let refused = reviewer
         .run_in(
             &checkout,
             &["revert", "-g", BUNDLE, "--to", short, "--json"],
         )
-        .refusal("a machine-scope revert over an untracked bundle");
-    assert_eq!(refused["error"]["code"], "NO_SUCH_SKILL", "{refused}");
+        .refusal("a machine-scope revert over a bundle no update has applied there");
+    assert_eq!(refused["error"]["code"], "NOT_APPLIED", "{refused}");
+    assert_eq!(
+        refused["error"]["context"]["message"],
+        format!(
+            "{BUNDLE} is not applied on this machine yet — {}",
+            "`topos update -g` applies it; revert acts on an applied copy"
+        ),
+        "{refused}"
+    );
 
     // Applied from the checkout: the team moves back, THIS copy converges onto the restored
     // content, and the checkout's lock records the forward commit.

--- a/tests/tests/project_lock_e2e.rs
+++ b/tests/tests/project_lock_e2e.rs
@@ -1,0 +1,368 @@
+//! **THE LOCK RECORDS WHAT THE COPY HOLDS** — end to end over the composed stack: the real `topos`
+//! binary against the real web app in front of the in-process vault.
+//!
+//! `topos.lock`'s own header calls it "the exact versions this project runs — commit it", and the
+//! whole point of committing it is that `topos install --frozen` rebuilds the same folders on the
+//! next machine. Two states put a version in it that no folder in the checkout held:
+//!
+//! - a LOCAL GO-BACK (`topos update <bundle>@<version>`) replaced the checkout's copy with an
+//!   earlier version and left the lock naming the team's — so the committed file said the project
+//!   runs a version nothing there holds, and `--frozen` would have rebuilt exactly the copy the
+//!   go-back replaced;
+//! - a STOPPED MERGE left every folder holding this person's own bytes while the lock advanced to
+//!   the team's version, and publishing was blocked — the file claiming the project runs the very
+//!   version the person had refused.
+//!
+//! Both arms read the same three surfaces against each other: what `topos.lock` records, what the
+//! bytes on disk are, and what `list` says about the copy.
+//!
+//! Like the store suite this drives the REAL CLI BINARY as a subprocess over a fake `$HOME` — the
+//! placement dirs resolve against the environment, so only a real process proves what landed where.
+//! The fixture rig owns the browser login the machine inherits.
+
+mod common;
+
+use std::path::{Path, PathBuf};
+
+use common::{CliOut, OWNER_EMAIL, Session, Stack, cli_binary, run_cli, start_stack};
+use serde_json::Value;
+use topos::test_support::SessionInstall;
+
+const BUNDLE: &str = "lock-truth";
+
+/// The bundle's one file, with the step that every side of the scenario rewrites.
+fn body(step_one: &str) -> String {
+    format!("# {BUNDLE}\n\n1. {step_one}\n2. run the deploy\n")
+}
+
+fn write_bundle(dir: &Path, text: &str) {
+    std::fs::create_dir_all(dir).expect("create the bundle dir");
+    std::fs::write(dir.join("SKILL.md"), text).expect("write SKILL.md");
+}
+
+fn placed_text(dir: &Path) -> String {
+    std::fs::read_to_string(dir.join("SKILL.md")).unwrap_or_else(|e| {
+        panic!("read the placed copy at {}: {e}", dir.display());
+    })
+}
+
+// ── the machine ─────────────────────────────────────────────────────────────────────────────────
+
+struct Machine {
+    rig: SessionInstall,
+    bin: PathBuf,
+}
+
+impl Machine {
+    fn new(tag: &str) -> Self {
+        let rig = SessionInstall::new(tag);
+        let home = rig.root().join("home");
+        std::fs::create_dir_all(home.join(".claude")).expect("seed a harness detect dir");
+        Self {
+            rig,
+            bin: cli_binary(),
+        }
+    }
+
+    fn root(&self) -> &Path {
+        self.rig.root()
+    }
+
+    fn home(&self) -> PathBuf {
+        self.rig.root().join("home")
+    }
+
+    fn topos_home(&self) -> PathBuf {
+        self.rig.root().join(".topos")
+    }
+
+    fn run_in(&self, cwd: &Path, args: &[&str]) -> CliOut {
+        run_cli(&self.bin, &self.home(), &self.topos_home(), cwd, args)
+    }
+}
+
+fn login(stack: &Stack, machine: &Machine, approver: &Session) {
+    stack.login_begin_and_approve(&machine.rig, approver);
+    let granted = machine.rig.login(None).expect("the login resume");
+    assert_eq!(granted.session_status, "active");
+}
+
+/// The project's `topos.lock` entry for the bundle.
+fn locked_version(project: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(project.join("topos.lock")).ok()?;
+    let mut in_block = false;
+    for line in text.lines() {
+        if line.trim() == format!("[skills.{BUNDLE}]") {
+            in_block = true;
+            continue;
+        }
+        if line.starts_with('[') {
+            in_block = false;
+        }
+        if in_block && let Some(rest) = line.trim().strip_prefix("version = ") {
+            return Some(rest.trim_matches('"').to_owned());
+        }
+    }
+    None
+}
+
+fn row<'a>(data: &'a Value, name: &str) -> &'a Value {
+    data["skills"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|r| r["skill"] == name)
+        .unwrap_or_else(|| panic!("no {name} row in the receipt: {data}"))
+}
+
+/// Every `code` the envelope's typed message channel carries.
+fn message_codes(envelope: &Value) -> Vec<String> {
+    envelope["messages"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|m| m["code"].as_str())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// The one message with `code`, as the text a person reads.
+fn message_text<'a>(envelope: &'a Value, code: &str) -> &'a str {
+    envelope["messages"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|m| m["code"] == code)
+        .and_then(|m| m["text"].as_str())
+        .unwrap_or_else(|| panic!("no {code} message: {envelope}"))
+}
+
+fn version_of(receipt: &Value) -> String {
+    receipt["version_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("the publish landed a version id: {receipt}"))
+        .to_owned()
+}
+
+/// Stand a machine up with the bundle published machine-wide at `first`, and a project whose
+/// `topos.toml` asks for it by name and whose first `update` places the copy and writes the lock.
+/// Returns `(the machine source dir, the project dir, the placed copy, the genesis version)`.
+fn published_into_a_project(
+    stack: &Stack,
+    machine: &Machine,
+    owner: &Session,
+    first: &str,
+) -> (PathBuf, PathBuf, PathBuf, String) {
+    login(stack, machine, owner);
+    let root = machine.root().canonicalize().expect("canonical root");
+    let src = root.join("src").join(BUNDLE);
+    write_bundle(&src, &body(first));
+    machine
+        .run_in(
+            &root,
+            &["add", "-g", src.to_str().expect("utf-8 path"), "--json"],
+        )
+        .data("the bundle is adopted machine-wide");
+    let genesis = machine
+        .run_in(&root, &["publish", BUNDLE, "--yes", "-m", "v1", "--json"])
+        .data("the genesis publish");
+    let v1 = version_of(&genesis);
+
+    let project = root.join("proj");
+    std::fs::create_dir_all(&project).expect("create the project dir");
+    machine
+        .run_in(&project, &["init", "--json"])
+        .data("the project's topos init");
+    machine
+        .run_in(&project, &["add", BUNDLE, "--json"])
+        .data("the project asks for the bundle by name");
+    let placed_row = machine
+        .run_in(&project, &["update", "--json"])
+        .data("the project's first update");
+    let copy = row(&placed_row, BUNDLE)["destinations"][0]
+        .as_str()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| project.join(".claude").join("skills").join(BUNDLE));
+    let copy = if copy.is_absolute() {
+        copy
+    } else {
+        project.join(copy)
+    };
+    assert_eq!(placed_text(&copy), body(first), "{placed_row}");
+    assert_eq!(locked_version(&project).as_deref(), Some(v1.as_str()));
+    (src, project, copy, v1)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// ① A LOCAL GO-BACK: the lock records the version the go-back put back, so `--frozen` reproduces
+//    the folder that stands there.
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn a_go_back_records_the_version_the_copy_now_holds() {
+    let stack = start_stack("lock-truth-goback");
+    let owner = stack.claim_owner(OWNER_EMAIL);
+    let machine = Machine::new("lock-truth-goback");
+    let (src, project, copy, v1) =
+        published_into_a_project(&stack, &machine, &owner, "check the region");
+
+    // The team moves on, and the project takes it: the lock records v2 and the copy holds it.
+    write_bundle(&src, &body("check the region and the account"));
+    let v2 = version_of(
+        &machine
+            .run_in(
+                machine.root(),
+                &["publish", BUNDLE, "--yes", "-m", "v2", "--json"],
+            )
+            .data("v2"),
+    );
+    assert_ne!(v1, v2);
+    machine
+        .run_in(&project, &["update", "--json"])
+        .data("the project takes v2");
+    assert_eq!(locked_version(&project).as_deref(), Some(v2.as_str()));
+    assert_eq!(placed_text(&copy), body("check the region and the account"));
+
+    // A `-g` go-back run from INSIDE the checkout takes the MACHINE's copy back, and this
+    // checkout's own folder is untouched — so its lock must be too. The rule is not "a go-back
+    // moves the nearest lock", it is "the lock records what THIS copy holds".
+    let short = &v1[..12];
+    machine
+        .run_in(
+            &project,
+            &["update", "-g", &format!("{BUNDLE}@{short}"), "--json"],
+        )
+        .envelope("the machine-scope go-back, run from inside the checkout");
+    assert_eq!(
+        locked_version(&project).as_deref(),
+        Some(v2.as_str()),
+        "a machine-scope go-back leaves the checkout's lock alone"
+    );
+    assert_eq!(placed_text(&copy), body("check the region and the account"));
+
+    // ── the go-back: the documented machine-only rollback, run inside the checkout ──────────────
+    let went_back = machine
+        .run_in(
+            &project,
+            &["update", &format!("{BUNDLE}@{short}"), "--json"],
+        )
+        .envelope("the go-back");
+    assert_eq!(
+        row(&went_back["data"], BUNDLE)["action"],
+        "held",
+        "{went_back}"
+    );
+    // The BYTES moved back…
+    assert_eq!(placed_text(&copy), body("check the region"));
+    // …and so did the file the project commits, which is the whole point of committing it.
+    assert_eq!(
+        locked_version(&project).as_deref(),
+        Some(v1.as_str()),
+        "the lock records the version the copy holds, not the one it left"
+    );
+    assert!(
+        message_codes(&went_back).contains(&"LOCK_MOVED".to_owned()),
+        "the receipt names the lock it moved: {went_back}"
+    );
+    assert_eq!(
+        message_text(&went_back, "LOCK_MOVED"),
+        format!(
+            "topos.lock now records {BUNDLE}@{} — the version this copy holds",
+            &v1[..12]
+        ),
+        "{went_back}"
+    );
+
+    // The proof that the record is worth anything: a FROZEN install reproduces exactly this copy
+    // rather than rebuilding the version the go-back replaced.
+    machine
+        .run_in(&project, &["install", "--frozen", "--json"])
+        .data("a frozen install over the go-back's lock");
+    assert_eq!(
+        placed_text(&copy),
+        body("check the region"),
+        "--frozen reproduces what the lock records"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// ② A STOPPED MERGE: every folder keeps this person's bytes, so the lock keeps the version it had.
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn a_stopped_merge_leaves_the_lock_at_the_version_the_copy_holds() {
+    let stack = start_stack("lock-truth-conflict");
+    let owner = stack.claim_owner(OWNER_EMAIL);
+    let machine = Machine::new("lock-truth-conflict");
+    let (src, project, copy, v1) =
+        published_into_a_project(&stack, &machine, &owner, "check the region");
+
+    // This person edits the project copy; the team changes the SAME line and publishes.
+    let mine = body("check the region twice");
+    std::fs::write(copy.join("SKILL.md"), &mine).expect("edit the project copy");
+    write_bundle(&src, &body("check the region and the account"));
+    let v2 = version_of(
+        &machine
+            .run_in(
+                machine.root(),
+                &["publish", BUNDLE, "--yes", "-m", "v2", "--json"],
+            )
+            .data("the team's v2"),
+    );
+    assert_ne!(v1, v2);
+
+    // The ordinary update merges — and STOPS.
+    let swept = machine
+        .run_in(&project, &["update", "--json"])
+        .envelope("the merging update");
+    assert_eq!(
+        row(&swept["data"], BUNDLE)["action"],
+        "conflicted",
+        "{swept}"
+    );
+    // The copy an agent reads still holds this person's own bytes…
+    assert_eq!(placed_text(&copy), mine);
+    // …so the committed file still records the version this project runs, not the one it refused.
+    assert_eq!(
+        locked_version(&project).as_deref(),
+        Some(v1.as_str()),
+        "the lock never records a version no folder here holds: {swept}"
+    );
+    assert!(
+        message_codes(&swept).contains(&"LOCK_STANDS".to_owned()),
+        "the receipt says the lock stood, and why: {swept}"
+    );
+    assert_eq!(
+        message_text(&swept, "LOCK_STANDS"),
+        format!(
+            "{BUNDLE}: the merge here has stopped — topos.lock keeps the version this copy holds"
+        ),
+        "{swept}"
+    );
+
+    // The third surface agrees with the other two: the copy is not at the team's version.
+    let listed = machine
+        .run_in(&project, &["list", BUNDLE, "--json"])
+        .data("the listing over the blocked bundle");
+    assert!(
+        !serde_json::to_string(&listed)
+            .unwrap_or_default()
+            .contains(&v2),
+        "nothing here claims the copy runs the team's version: {listed}"
+    );
+
+    // Resolving it the team's way moves BOTH together — the rule is not "never move", it is
+    // "move with the copy".
+    machine
+        .run_in(&project, &["update", BUNDLE, "--reset", "--yes", "--json"])
+        .data("take the team's version");
+    assert_eq!(placed_text(&copy), body("check the region and the account"));
+    machine
+        .run_in(&project, &["update", "--json"])
+        .data("the update after the reset");
+    assert_eq!(
+        locked_version(&project).as_deref(),
+        Some(v2.as_str()),
+        "once the copy holds the team's version, so does the lock"
+    );
+}

--- a/web/app/lib/plane/contract/version.ts
+++ b/web/app/lib/plane/contract/version.ts
@@ -4,7 +4,7 @@
  */
 
 /** The release version of the build serving this app — what the protocol card declares. */
-export const SERVER_RELEASE_VERSION = "0.1.53";
+export const SERVER_RELEASE_VERSION = "0.1.54";
 
 /** The wire contract's version — stamped on every document this tier emits. */
 export const WIRE_SCHEMA_VERSION = 2;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1310,6 +1310,7 @@ fn fixtures() -> Vec<(&'static str, String)> {
             total: None,
             // The delivering workspace's last exchange landed (a local-only skill has none at all).
             sync_fault: None,
+            not_applied: None,
         })
         .expect("LogData serializes"),
         warnings: vec![],
@@ -2025,6 +2026,7 @@ fn fixtures() -> Vec<(&'static str, String)> {
             truncated: true,
             total: Some(3),
             sync_fault: None,
+            not_applied: None,
         })
         .expect("LogData serializes"),
         warnings: vec![],


### PR DESCRIPTION
Round 5 (CLI), from the production journey on v0.1.53, plus the v0.1.54 bump:

- `topos.lock` records only what the copy holds: a machine-only go-back (`update <bundle>@<version>`) moves the checkout's own lock entry to the version now on disk (and `install --frozen` reproduces it); a stopped merge keeps the lock at the version the copy holds and says so; a failed sync harvests nothing.
- `update`'s activity counter numbers explicitly-added rows too, so the counter's total equals the receipt's bundle count.
- The `update --reset` preview reads the way the reset runs: your edits go away, the team's version lands.
- `topos log` on a bundle the workspace assigns but this machine never applied reads the workspace's history and says so (`NOT_APPLIED`, next action `topos update -g`); `diff` refuses in the same terms; no "skill" noun in these refusals.

Gates: `cargo xtask ci` 8/8, `cargo test -p topos` (1399), `cargo test -p topos-e2e` (11 binaries incl. the new project-lock suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
