### PR TITLE
install --frozen on a fresh clone; v0.1.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3959,7 +3959,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "topos"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "base64",
  "clap",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "sha2",
  "unicode-normalization",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "axum",
  "plane-store",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "diffy",
  "flate2",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "hex",
  "jsonc-parser",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "anyhow",
  "axum",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.54" # members inherit via `version.workspace = true`; bump to match the tag before tagging
+version = "0.1.55" # members inherit via `version.workspace = true`; bump to match the tag before tagging
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/bins/topos/src/error.rs
+++ b/bins/topos/src/error.rs
@@ -580,6 +580,14 @@ pub(crate) enum ClientError {
     /// what the user needs. Sidecar-document parse failures stay [`ClientError::Corrupt`].
     #[error("{0}")]
     InvalidArgument(String),
+    /// `--frozen` could not stage every version `topos.lock` names, so nothing was placed. NOT an
+    /// argument error: the argv was right and the lock was right — the run could not obtain what
+    /// they name (the local store, the filesystem, or the server answering for a version). The
+    /// message is this code's own words — a manifest name plus an already-redacted summary
+    /// ([`crate::render::safe_message`]) — so it is shown VERBATIM, and it names the command to
+    /// run again, which a refused frozen install always leaves safe.
+    #[error("{0}")]
+    FrozenStageFailed(String),
     /// A write-side git store failure.
     #[error("the local skill store reported an error — {0}")]
     Gitstore(#[from] GitstoreError),
@@ -1356,6 +1364,10 @@ impl ClientError {
             // set (which is closed on the client side; agents branch on `outcome`/`retryable`).
             ClientError::Io(_) | ClientError::IoKind { .. } => "IO_ERROR",
             ClientError::InvalidArgument(_) => "INVALID_ARGUMENT",
+            // A run that could not obtain the bytes the lock names is a local/remote FAULT, not a
+            // wrong argv — it takes the filesystem family's code so an agent branches on the same
+            // word it does for every other "this machine could not get at it".
+            ClientError::FrozenStageFailed(_) => "IO_ERROR",
             ClientError::Gitstore(_) => "GIT_STORE_ERROR",
             ClientError::Verify(_) => "INTEGRITY_ERROR",
             ClientError::UnknownSchemaVersion { .. } => "UPGRADE_REQUIRED",
@@ -1523,6 +1535,9 @@ impl ClientError {
             ClientError::Io(_)
             | ClientError::Gitstore(GitstoreError::Io(_))
             | ClientError::Plane(_) => TerminalOutcome::RetryableFailure,
+            // The frozen preflight refuses BEFORE the first placement, so the same command is
+            // exactly what runs next — the retryable class, and the message says so out loud.
+            ClientError::FrozenStageFailed(_) => TerminalOutcome::RetryableFailure,
             // With the OS kind in hand, permanence is decidable: permission-denied, a read-only
             // filesystem, and disk-full will NOT heal on a retry — the retryable bit is the load-bearing
             // part of the machine contract, so it must not steer the agent into a loop. Everything else

--- a/bins/topos/src/ops/reconcile.rs
+++ b/bins/topos/src/ops/reconcile.rs
@@ -1869,6 +1869,16 @@ pub(crate) fn manifest_update(
                             unstageable.push(format!("{name} (malformed id)"));
                             continue;
                         };
+                        // TEACH THE LANE THE PAIR IT JUST RESOLVED. The read lane routes every
+                        // per-skill request by a skill → workspace map it is BORN with, seeded
+                        // from the offline delivery cache — and a genuine clone's store has no
+                        // delivery record for anything, because the whole `.topos/` is gitignored.
+                        // Unbound, `fetch_version` answers `NotFound` for a version the server
+                        // serves perfectly well, and the preflight refused the run.
+                        run.transports
+                            .plane
+                            .as_plane()
+                            .bind_skill(&run.session.workspace_id, &skill_id);
                         let run_ctx = super::pull::ctx_with_store(
                             ctx,
                             &store_layout,
@@ -1883,8 +1893,17 @@ pub(crate) fn manifest_update(
                 }
             }
             if !unstageable.is_empty() {
-                return Err(ClientError::InvalidArgument(format!(
-                    "--frozen: could not stage {} — nothing was placed",
+                // The preflight refuses BEFORE the first placement, so the state this names is
+                // the state the checkout is in: nothing here is half-installed, and the same
+                // command is what runs next.
+                let noun = if unstageable.len() == 1 {
+                    "bundle"
+                } else {
+                    "bundles"
+                };
+                return Err(ClientError::FrozenStageFailed(format!(
+                    "--frozen: could not stage {noun} {} — nothing was placed, so `topos install \
+                     --frozen` is safe to run again",
                     unstageable.join(", ")
                 )));
             }

--- a/bins/topos/src/ops/sync_engine.rs
+++ b/bins/topos/src/ops/sync_engine.rs
@@ -1641,12 +1641,56 @@ pub(crate) fn prefetch_version(
     skill_id: &crate::id::SkillId,
     version_hex: &str,
 ) -> Result<(), ClientError> {
-    let sp = ctx.layout.published(skill_id);
-    // Open the standing store, or birth one — the fresh-checkout case is exactly what a
-    // preflight meets first.
-    let store = match Store::open(&sp.store) {
+    // A bundle this scope ALREADY holds prefetches straight into its own store: the objects land
+    // where the arm below reads them, and nothing else about the run changes.
+    if ctx.fs.exists(&ctx.layout.skill_dir(skill_id)) {
+        return prefetch_into(
+            ctx,
+            &ctx.layout.published(skill_id).store,
+            skill_id,
+            version_hex,
+        );
+    }
+    // A bundle it has NEVER held has no store yet — the ordinary state of a genuine clone, whose
+    // `.topos/` is gitignored whole and so never travels. The proof still has to run, but it must
+    // not mint the PUBLISHED directory: the arm's never-received baseline keys off that
+    // directory's absence, and a store-only directory there would make it skip the sidecar
+    // documents it lays, leaving the rest of the run reading state nobody wrote. So the proof
+    // runs in the scope's staging namespace and is torn down again; what survives it is the
+    // machine-wide blob cache the arm's own fetch then reads — `npm ci` fills a cache and
+    // installs out of it the same way.
+    let (scratch, sp) = ctx.layout.staging(skill_id);
+    if ctx.fs.exists(&scratch) {
+        ctx.fs.remove_dir_all(&scratch)?;
+    }
+    let proved = prefetch_into(ctx, &sp.store, skill_id, version_hex);
+    // Torn down whichever way the proof went: a refused `--frozen` run promises the checkout AND
+    // the store behind it are exactly as it found them.
+    let _ = ctx.fs.remove_dir_all(&scratch);
+    proved
+}
+
+/// Fetch + digest-verify one version into the bare store at `store_dir`, birthing the store when it
+/// is not there yet.
+///
+/// # Errors
+/// The store/plane failure that stopped the fetch, or the integrity failure that stopped the verify.
+fn prefetch_into(
+    ctx: &Ctx<'_>,
+    store_dir: &std::path::Path,
+    skill_id: &crate::id::SkillId,
+    version_hex: &str,
+) -> Result<(), ClientError> {
+    // Open the standing store, or birth one. `Store::init` is `init_bare`: it creates the store
+    // directory itself and NOT the directories above it, so a scope whose store tree does not
+    // exist at all — every genuine clone — needs those laid first. Without that the preflight met
+    // its own first customer with "the local skill store reported an error".
+    let store = match Store::open(store_dir) {
         Ok(store) => store,
-        Err(_) => Store::init(&sp.store)?,
+        Err(_) => {
+            ctx.fs.create_dir_all(store_dir)?;
+            Store::init(store_dir)?
+        }
     };
     let commit = super::parse_hex32(version_hex)?;
     let mut written = WriteBatch::default();

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -606,6 +606,13 @@ const STATIC_PROSE_COMMANDS: &[(&str, &str, &[&str])] = &[
         &["topos", "update", "-g", "--json"],
     ),
     ("topos self-update", "UPDATE_CLI", &["topos", "self-update"]),
+    // The frozen install's own re-run. A `--frozen` refusal places nothing, so the command that
+    // refused is exactly the one to run again — the machine-readable half of saying so.
+    (
+        "topos install --frozen",
+        "RUN_COMMAND",
+        &["topos", "install", "--frozen", "--json"],
+    ),
 ];
 
 /// Mirror the STATIC `topos …` commands an error's shown PROSE names into structural next

--- a/bins/topos/src/render.rs
+++ b/bins/topos/src/render.rs
@@ -5295,7 +5295,7 @@ fn pull_action_row(s: &PullSkill, scope: &PullReceiptScope) -> (String, Vec<Stri
             extra.push(format!("  topos update{g} {name} --keep-mine"));
             extra.push("take the team's version instead, dropping yours:".to_owned());
             extra.push(format!("  topos update{g} {name} --reset"));
-            extra.push("you cannot publish this skill until you pick one".to_owned());
+            extra.push("you cannot publish this bundle until you pick one".to_owned());
             // WHY it stopped, in the reader's own terms — read off the RECORDED reason, exactly as
             // the by-hand line above is. Unrelated histories compared no line at all (there is no
             // fork point to compare from), so the lead may not say lines were changed twice; it
@@ -7304,7 +7304,7 @@ mod tests {
         );
         assert!(out.contains("  topos update api-notes --reset\n"), "{out}");
         assert!(
-            out.contains("you cannot publish this skill until you pick one"),
+            out.contains("you cannot publish this bundle until you pick one"),
             "{out}"
         );
         // Held says it is pinned by a local go-back and how to resume.
@@ -9457,7 +9457,7 @@ mod tests {
              \x20     topos update coolify-deploy --keep-mine\n\
              \x20   take the team's version instead, dropping yours:\n\
              \x20     topos update coolify-deploy --reset\n\
-             \x20   you cannot publish this skill until you pick one\n\
+             \x20   you cannot publish this bundle until you pick one\n\
              Checked 1 bundle: 1 waiting on you."
         );
 
@@ -9483,7 +9483,7 @@ mod tests {
              \x20     topos update -g coolify-deploy --keep-mine\n\
              \x20   take the team's version instead, dropping yours:\n\
              \x20     topos update -g coolify-deploy --reset\n\
-             \x20   you cannot publish this skill until you pick one\n\
+             \x20   you cannot publish this bundle until you pick one\n\
              Checked 1 bundle: 1 waiting on you."
         );
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   plane:
     # Pinned to one release (see the header). Override with TOPOS_VERSION, or build from source with
     # the docker-compose.build.yml override.
-    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.54}
+    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.55}
     restart: unless-stopped
     mem_limit: 1g
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
@@ -186,7 +186,7 @@ services:
   gateway:
     # The same release as the other two — one TOPOS_VERSION moves all three, and they are only ever
     # tested together.
-    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.54}
+    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.55}
     restart: unless-stopped
     mem_limit: 1g
     # WHAT THIS BOUNDS IS CONCURRENT MCP STREAMS, NOT MEMORY (mem_limit above is the memory
@@ -253,7 +253,7 @@ services:
   web:
     # The same release as the plane and the gateway — one TOPOS_VERSION moves all three, and they are
     # only ever tested together.
-    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.54}
+    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.55}
     restart: unless-stopped
     mem_limit: 1g
     depends_on:

--- a/tests/tests/project_lock_e2e.rs
+++ b/tests/tests/project_lock_e2e.rs
@@ -366,3 +366,142 @@ fn a_stopped_merge_leaves_the_lock_at_the_version_the_copy_holds() {
         "once the copy holds the team's version, so does the lock"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// ③ A FRESH CLONE: the two committed files are ALL a checkout has — `--frozen` builds the rest.
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+
+/// **THE `npm ci` PROPERTY, ON A REAL CLONE.** A project's own store is gitignored whole
+/// (`.topos/.gitignore` holds `*`), so what a teammate's `git clone` actually leaves on disk is
+/// exactly two topos files: `topos.toml` and `topos.lock`. A frozen install there has to create
+/// whatever local store it needs and place exactly the versions the lock names — the whole point
+/// of committing the file. It refuses only when the lock and the manifest disagree, or a locked
+/// version cannot be fetched.
+///
+/// The team publishes a newer version the clone's lock does not name, so "it installed something"
+/// is not enough to pass: the bytes that land must be the LOCKED ones.
+#[test]
+fn a_frozen_install_on_a_fresh_clone_places_the_locked_versions() {
+    let stack = start_stack("lock-truth-clone");
+    let owner = stack.claim_owner(OWNER_EMAIL);
+    let machine = Machine::new("lock-truth-clone");
+    let (src, project, copy, v1) =
+        published_into_a_project(&stack, &machine, &owner, "check the region");
+
+    // The team moves on WITHOUT this project — so the clone has something to be right about.
+    write_bundle(&src, &body("check the region and the account"));
+    let v2 = version_of(
+        &machine
+            .run_in(
+                machine.root(),
+                &["publish", BUNDLE, "--yes", "-m", "v2", "--json"],
+            )
+            .data("the team's v2"),
+    );
+    assert_ne!(v1, v2);
+    assert_eq!(
+        locked_version(&project).as_deref(),
+        Some(v1.as_str()),
+        "the project never took v2, so its committed lock still names v1"
+    );
+
+    // ── the clone: the two committed files, and nothing else ────────────────────────────────────
+    let manifest = std::fs::read_to_string(project.join("topos.toml")).expect("read topos.toml");
+    let lock = std::fs::read_to_string(project.join("topos.lock")).expect("read topos.lock");
+    let clone = machine
+        .root()
+        .canonicalize()
+        .expect("canonical root")
+        .join("clone");
+    std::fs::create_dir_all(clone.join(".git")).expect("a git-shaped checkout");
+    std::fs::write(clone.join("topos.toml"), &manifest).expect("the committed manifest");
+    std::fs::write(clone.join("topos.lock"), &lock).expect("the committed lock");
+    assert!(
+        !clone.join(".topos").exists(),
+        "a real clone carries no project store — that is the state under test"
+    );
+
+    let frozen = machine.run_in(&clone, &["install", "--frozen", "--json"]);
+    assert_eq!(
+        frozen.code, 0,
+        "a fresh clone is the state --frozen exists for: {} {}",
+        frozen.stdout, frozen.stderr
+    );
+    let placed_row = frozen.data("the frozen install on the fresh clone");
+
+    // The bytes: exactly what the lock records, byte-identical to the copy the author's checkout
+    // holds — not the version the workspace serves today.
+    let landed = row(&placed_row, BUNDLE)["destinations"][0]
+        .as_str()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| clone.join(".claude").join("skills").join(BUNDLE));
+    let landed = if landed.is_absolute() {
+        landed
+    } else {
+        clone.join(landed)
+    };
+    assert_eq!(
+        placed_text(&landed),
+        body("check the region"),
+        "--frozen places the version topos.lock names: {placed_row}"
+    );
+    assert_eq!(
+        placed_text(&landed),
+        placed_text(&copy),
+        "the clone reproduces the author's checkout byte for byte"
+    );
+
+    // The committed file is untouched: an install never moves a lock entry.
+    assert_eq!(
+        std::fs::read_to_string(clone.join("topos.lock")).expect("read the clone's lock"),
+        lock,
+        "--frozen never rewrites the file it was given"
+    );
+    assert_eq!(locked_version(&clone).as_deref(), Some(v1.as_str()));
+
+    // ── the refusal a genuine failure gets ──────────────────────────────────────────────────────
+    // A lock naming a version this workspace cannot hand over is the one thing `--frozen` is
+    // still right to refuse. What it owes the reader is a FAULT code (nothing about the argv was
+    // wrong), the word bundle, the state it left behind, and the command to run again.
+    let unserved: String = v1.chars().rev().collect();
+    let broken = machine
+        .root()
+        .canonicalize()
+        .expect("canonical root")
+        .join("clone-broken");
+    std::fs::create_dir_all(broken.join(".git")).expect("a git-shaped checkout");
+    std::fs::write(broken.join("topos.toml"), &manifest).expect("the committed manifest");
+    std::fs::write(broken.join("topos.lock"), lock.replace(&v1, &unserved))
+        .expect("a lock naming a version nobody serves");
+
+    let refused = machine
+        .run_in(&broken, &["install", "--frozen", "--json"])
+        .refusal("a lock naming an unserved version");
+    assert_eq!(
+        refused["error"]["code"], "IO_ERROR",
+        "a run that could not get the bytes is a fault, not a wrong argument: {refused}"
+    );
+    let text = refused["error"]["context"]["message"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        text.contains(&format!("could not stage bundle {BUNDLE}")),
+        "the refusal says bundle, and names it: {refused}"
+    );
+    assert!(
+        text.contains("nothing was placed, so `topos install --frozen` is safe to run again"),
+        "the refusal states the state it left, and the command to run: {refused}"
+    );
+    assert!(
+        refused["next_actions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|a| a["argv"] == serde_json::json!(["topos", "install", "--frozen", "--json"])),
+        "the same command rides as argv, not only as prose: {refused}"
+    );
+    assert!(
+        !broken.join(".claude").join("skills").join(BUNDLE).exists(),
+        "the refusal placed nothing"
+    );
+}

--- a/web/app/lib/plane/contract/version.ts
+++ b/web/app/lib/plane/contract/version.ts
@@ -4,7 +4,7 @@
  */
 
 /** The release version of the build serving this app — what the protocol card declares. */
-export const SERVER_RELEASE_VERSION = "0.1.54";
+export const SERVER_RELEASE_VERSION = "0.1.55";
 
 /** The wire contract's version — stamped on every document this tier emits. */
 export const WIRE_SCHEMA_VERSION = 2;


### PR DESCRIPTION
The v0.1.55 bump, plus the one P1 from the production journey on v0.1.54:

- `topos install --frozen` works on a genuine fresh clone. Two causes stacked: the project store's parent directories were never created (`Store::init` makes the store dir but not `skills/<id>/`), and the read lane was not bound before the frozen preflight, so a served version answered "not found". The preflight now proves a never-held bundle in the staging namespace and tears it down, leaving the arm's own baseline to lay the sidecar; a genuine failure answers `IO_ERROR`, names the bundle, and carries the safe re-run as a next action.
- A stopped merge's receipt says bundle, not skill.

Together with #91 (agents of choice) already on main, this is v0.1.55.

Gates: `cargo test -p topos` (1429), `cargo test -p topos-e2e` (10 binaries, 19 tests incl. the new fresh-clone frozen install), `cargo xtask ci` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
