### PR TITLE
Login-path code fields opt out of password managers (v0.1.56 web)

### DIFF
--- a/web/app/components/ui.tsx
+++ b/web/app/components/ui.tsx
@@ -68,6 +68,28 @@ export function BusyFields({
   );
 }
 
+/**
+ * "NOT YOURS" — spread onto a text field that is not a credential.
+ *
+ * Password managers ignore `autocomplete="off"` by design, read a lone text field in a form as a
+ * sign-in field, and mount their own inline menu over it. The menu then takes the first keypress,
+ * so the first Enter after a page load goes to the menu instead of the form: nothing leaves the
+ * browser, nothing appears in the page, and only a second attempt gets through — which reads as
+ * "it refused what I typed". A login-approval code, a recovery code, a workspace name: none of
+ * them is anything a manager has saved, and none of them should cost a person a second try.
+ *
+ * These are the opt-outs 1Password, LastPass, and Bitwarden each document. They go BESIDE an
+ * honest `autoComplete` (`one-time-code` for a single-use code, `organization` for a company
+ * name), never instead of it — the platform hint says what the field IS, and these say who it
+ * is not for. Never spread this onto an email or password field: filling those is the whole
+ * point of a password manager.
+ */
+export const NOT_A_CREDENTIAL = {
+  "data-1p-ignore": "true",
+  "data-lpignore": "true",
+  "data-bwignore": "true",
+} as const;
+
 /** A short identifier (version hash, fingerprint) in mono, self-labeling as truncated. */
 export function ShortId({ value, length = 12 }: { value: string; length?: number }) {
   return (

--- a/web/app/routes/recovery.tsx
+++ b/web/app/routes/recovery.tsx
@@ -8,7 +8,7 @@ import {
   redirect,
   useActionData,
 } from "react-router";
-import { BusyFields, buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses, NOT_A_CREDENTIAL } from "@/components/ui";
 import { notFound } from "@/lib/auth/guards.server";
 import { consumeRecoveryCode } from "@/lib/auth/recovery.server";
 import { useSubmittingIntent } from "@/lib/pending";
@@ -88,7 +88,8 @@ export default function RecoveryPage() {
               type="text"
               name="code"
               required
-              autoComplete="off"
+              autoComplete="one-time-code"
+              {...NOT_A_CREDENTIAL}
               spellCheck={false}
               className={`${INPUT} font-mono`}
               placeholder="paste the code"

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -539,12 +539,26 @@ function CodeLookup() {
               submit has one answer — the action's line, in the app's words, in the same place
               every other refusal on this page appears. The maxlength is the FULL spelling, so
               typing the code without its hyphen (or with a space) still fits; the action puts the
-              hyphen back. */}
+              hyphen back.
+
+              AND THE FIELD SAYS WHAT IT IS. A login-approval code is read off another screen
+              seconds after it appeared; nothing has it saved, so no password manager has
+              anything to offer here. `autocomplete="off"` does not say that — every password
+              manager ignores that hint by design, reads a lone text field in a form as a sign-in
+              field, and mounts its own menu over it. The menu then takes the first keypress, so
+              the first Enter after a page load goes to the menu instead of the form: nothing
+              leaves the browser, nothing appears in the page, and only a second attempt gets
+              through — which reads as "the code was refused". `one-time-code` is what this field
+              actually is (and is what the platform's own code autofill listens for); the three
+              `data-*` attributes are the opt-out each common manager documents. */}
           <input
             type="text"
             name="code"
             maxLength={USER_CODE_LENGTH}
-            autoComplete="off"
+            autoComplete="one-time-code"
+            data-1p-ignore="true"
+            data-lpignore="true"
+            data-bwignore="true"
             spellCheck={false}
             className={`${INPUT} font-mono uppercase`}
             placeholder="AB29-CD34"

--- a/web/app/routes/verify.tsx
+++ b/web/app/routes/verify.tsx
@@ -10,7 +10,7 @@ import {
   useFetcher,
   useLoaderData,
 } from "react-router";
-import { BusyFields, buttonClasses } from "@/components/ui";
+import { BusyFields, buttonClasses, NOT_A_CREDENTIAL } from "@/components/ui";
 import { composition } from "@/composition.server";
 import {
   actorFromSession,
@@ -556,9 +556,7 @@ function CodeLookup() {
             name="code"
             maxLength={USER_CODE_LENGTH}
             autoComplete="one-time-code"
-            data-1p-ignore="true"
-            data-lpignore="true"
-            data-bwignore="true"
+            {...NOT_A_CREDENTIAL}
             spellCheck={false}
             className={`${INPUT} font-mono uppercase`}
             placeholder="AB29-CD34"
@@ -1005,7 +1003,8 @@ function CreateFields({
         <input
           type="text"
           name="displayName"
-          autoComplete="off"
+          autoComplete="organization"
+          {...NOT_A_CREDENTIAL}
           spellCheck={false}
           placeholder="Acme Engineering"
           maxLength={100}
@@ -1027,6 +1026,7 @@ function CreateFields({
           type="text"
           name="slug"
           autoComplete="off"
+          {...NOT_A_CREDENTIAL}
           spellCheck={false}
           placeholder="acme-engineering"
           pattern="[a-z0-9][a-z0-9-]*"

--- a/web/app/routes/workspace-new.tsx
+++ b/web/app/routes/workspace-new.tsx
@@ -12,7 +12,14 @@ import {
   useLocation,
   useNavigation,
 } from "react-router";
-import { BusyFields, buttonClasses, Card, PageHeader, SectionHeading } from "@/components/ui";
+import {
+  BusyFields,
+  buttonClasses,
+  Card,
+  NOT_A_CREDENTIAL,
+  PageHeader,
+  SectionHeading,
+} from "@/components/ui";
 import { actorFromSession, notFound, requireSession, safeNextPath } from "@/lib/auth/guards.server";
 import { getAuth } from "@/lib/auth/server";
 import { announceCeremony } from "@/lib/ceremony-event";
@@ -287,7 +294,8 @@ function CreateForm({
                   type="text"
                   name="displayName"
                   required
-                  autoComplete="off"
+                  autoComplete="organization"
+                  {...NOT_A_CREDENTIAL}
                   spellCheck={false}
                   placeholder="Acme Engineering"
                   maxLength={100}
@@ -304,6 +312,7 @@ function CreateForm({
                   name="slug"
                   required
                   autoComplete="off"
+                  {...NOT_A_CREDENTIAL}
                   spellCheck={false}
                   placeholder="acme-engineering"
                   pattern="[a-z0-9][a-z0-9-]*"

--- a/web/tests/e2e/verify.spec.ts
+++ b/web/tests/e2e/verify.spec.ts
@@ -85,16 +85,62 @@ test.describe("signed out", () => {
   });
 });
 
+/** The lookups this page posted — one per submission that actually left the browser. */
+function countLookups(page: Page): () => number {
+  let posts = 0;
+  page.on("request", (request) => {
+    if (request.method() === "POST" && new URL(request.url()).pathname.startsWith("/verify")) {
+      posts += 1;
+    }
+  });
+  return () => posts;
+}
+
 test("ENTER in the code field looks the request up — exactly as the button does", async ({
   page,
 }) => {
   // The keyboard is how a code gets typed: hands are already on it. Enter must be the Look up
-  // click, not a second, emptier page.
+  // click, not a second, emptier page. ONE Enter, on a page loaded moments ago: the first
+  // submission has to be the one that lands — a person who has to type a code twice has already
+  // been told, wrongly, that the code was refused.
+  const lookups = countLookups(page);
   const flow = await startLoginFlow(page, "e2e-keyboard");
   await page.goto("/verify");
   await page.getByLabel("Code").fill(flow.user_code);
   await page.getByLabel("Code").press("Enter");
   await expect(page.getByText("\u201ce2e-keyboard\u201d", { exact: true })).toBeVisible();
+  expect(lookups()).toBe(1);
+});
+
+test("ONE Enter on a freshly loaded page answers a code that names nothing", async ({ page }) => {
+  // The same first-submission rule on the arm a mistyped code takes: one Enter, one lookup, and
+  // the answer in the page. The field keeps what was typed, so a correction is an edit rather
+  // than a re-type.
+  const lookups = countLookups(page);
+  await page.goto("/verify");
+  await page.getByLabel("Code").fill("ZZ99-ZZ99");
+  await page.getByLabel("Code").press("Enter");
+  await expect(page.getByText("No pending request for that code")).toBeVisible();
+  expect(lookups()).toBe(1);
+  expect(await page.getByLabel("Code").inputValue()).toBe("ZZ99-ZZ99");
+});
+
+test("the code field declares itself, so a password manager leaves it alone", async ({ page }) => {
+  // A login-approval code is typed off ANOTHER screen seconds after it appeared — it is not a
+  // saved credential, and no password manager has anything to offer for it. `autocomplete="off"`
+  // does not say that: password managers ignore the hint by design, read a lone text field in a
+  // form as a sign-in field, and mount their own menu over it. That menu then takes the first
+  // keypress, so the first Enter after a page load goes to the menu instead of the form: nothing
+  // leaves the browser, nothing appears in the page, and only a second try gets through.
+  //
+  // These four attributes are the whole vocabulary for saying "not yours": the platform hint for
+  // what the field IS, and the opt-out each of the three common managers documents.
+  await page.goto("/verify");
+  const field = page.getByLabel("Code");
+  await expect(field).toHaveAttribute("autocomplete", "one-time-code");
+  await expect(field).toHaveAttribute("data-1p-ignore", "true");
+  await expect(field).toHaveAttribute("data-lpignore", "true");
+  await expect(field).toHaveAttribute("data-bwignore", "true");
 });
 
 test("an unknown code is an honest in-page state, never a 404", async ({ page }) => {

--- a/web/tests/unit/login-path-fields.test.ts
+++ b/web/tests/unit/login-path-fields.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * WHO EACH FIELD ON THE LOGIN PATH IS FOR.
+ *
+ * Password managers ignore `autocomplete="off"` by design: they read a lone text field in a form
+ * as a sign-in field and mount their own inline menu over it. The menu takes the first keypress,
+ * so the first Enter after a page load never reaches the form — nothing leaves the browser,
+ * nothing appears in the page, and only a second attempt gets through, which reads as "it refused
+ * what I typed". On the login path that lands on the one page a person reaches with a waiting
+ * terminal beside them.
+ *
+ * So every field there has to say which kind it is, and the two kinds are opposites:
+ *
+ *  - NOT a credential (a login-approval code, a recovery code, a workspace name or address):
+ *    an honest `autoComplete` for what it IS, plus `NOT_A_CREDENTIAL` — the opt-out 1Password,
+ *    LastPass, and Bitwarden each document.
+ *  - A credential (email, password): untouched. Filling those is the whole point of a password
+ *    manager, and opting one out would be a worse bug than the one this guards.
+ *
+ * Read from source rather than a rendered page because the create-workspace fields (on /verify's
+ * chooser and on /new) exist only in MULTI tenancy, which the single-tenancy e2e cannot reach.
+ * verify.spec.ts proves the rendered attributes on the one field the browser suite can see.
+ */
+
+const APP = resolve(__dirname, "..", "..", "app");
+
+/** The one VISIBLE `<input …/>` carrying `name="<name>"` in a route file, as source text. */
+function inputNamed(file: string, name: string): string {
+  const source = readFileSync(resolve(APP, file), "utf8");
+  const found = source
+    .split("<input")
+    .slice(1)
+    .map((chunk) => chunk.slice(0, chunk.indexOf("/>")))
+    .filter((chunk) => chunk.includes(`name="${name}"`) && !chunk.includes('type="hidden"'));
+  expect(found, `${file} renders exactly one visible field named "${name}"`).toHaveLength(1);
+  return found[0] as string;
+}
+
+describe("the login path's fields say who they are for", () => {
+  it.each([
+    ["routes/verify.tsx", "code", "one-time-code"],
+    ["routes/verify.tsx", "displayName", "organization"],
+    // No platform hint describes a workspace address, so `off` stands — the opt-out beside it is
+    // what actually keeps a manager's menu off the field.
+    ["routes/verify.tsx", "slug", "off"],
+    ["routes/workspace-new.tsx", "displayName", "organization"],
+    ["routes/workspace-new.tsx", "slug", "off"],
+    ["routes/recovery.tsx", "code", "one-time-code"],
+  ])("%s field %s is declared %s and opted out", (file, name, hint) => {
+    const field = inputNamed(file, name);
+    expect(field).toContain(`autoComplete="${hint}"`);
+    expect(field).toContain("{...NOT_A_CREDENTIAL}");
+  });
+
+  it.each([
+    ["routes/login.tsx", "email", "email"],
+    ["routes/login.tsx", "password", null],
+    ["routes/claim.tsx", "email", "email"],
+    ["routes/claim.tsx", "password", "new-password"],
+    ["routes/invite-redeem.tsx", "password", "new-password"],
+  ])("%s field %s stays a password manager's business", (file, name, hint) => {
+    const field = inputNamed(file, name);
+    expect(field).not.toContain("NOT_A_CREDENTIAL");
+    expect(field).not.toContain("data-1p-ignore");
+    if (hint !== null) {
+      expect(field).toContain(`autoComplete="${hint}"`);
+    }
+  });
+});
+
+describe("NOT_A_CREDENTIAL", () => {
+  it("carries the opt-out each of the three common managers documents", async () => {
+    const { NOT_A_CREDENTIAL } = await import("@/components/ui");
+    expect(NOT_A_CREDENTIAL).toEqual({
+      "data-1p-ignore": "true",
+      "data-lpignore": "true",
+      "data-bwignore": "true",
+    });
+  });
+});


### PR DESCRIPTION
Round 7 (web), from the production journey on v0.1.55:

- The first `/verify` submit after a fresh page load was swallowed for users of a password manager: a lone text field with `autocomplete="off"` gets the manager's inline menu (ignored hint, by design), and the menu takes the first keypress — nothing leaves the browser, nothing renders, no console error. The code field is now declared as what it is (`one-time-code`) and opts out of the three common managers; the same treatment covers the other non-credential fields on the login path (workspace name and address on `/verify` and `/new`, the `/recovery` code). Real email/password fields are untouched — a contract test guards both directions.

Proven by loading the real 1Password extension into Chromium against the production build; the verify e2e asserts exactly one POST per submit.

Gates: web check, unit (1343), build, bundle scan, Playwright (168; verify spec 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
