### PR TITLE
update: the reset preview reads what lands; -g names the version it replaced

### DIFF
--- a/bins/topos/src/ops/diff.rs
+++ b/bins/topos/src/ops/diff.rs
@@ -107,19 +107,23 @@ pub(crate) fn diff(
     diff_resolved(ctx, &layout, &id, &lock, r#ref, budget, sel)
 }
 
-/// WHICH WAY a bare draft ↔ current diff reads — the two verbs that print one want opposite
-/// orders, and a unified diff only means something when `a` is the state that goes away.
+/// WHICH READ a bare draft diff makes: the DIRECTION it prints, and the VERSION it measures
+/// against. Two verbs print one, and they want opposite orders over different rulers — a unified
+/// diff only means something when `a` is the state that goes away, and a preview only means
+/// something when the other side is the state that arrives. One enum carries both because the two
+/// choices are not independent: read in the reset's direction against a version the reset does not
+/// land, the body describes changes `--yes` will never make.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DiffSides {
-    /// `topos diff`: `a` is the team's current, `b` is your copy — so the `+` lines are YOUR
-    /// edits, which is what "show me my change" means.
-    CurrentToDraft,
-    /// The `--reset` preview: `a` is your copy (what goes away), `b` is the team's version (what
-    /// lands). A reset REPLACES your copy with the team's, so the preview has to read the way the
-    /// apply runs. Printed in the other order it said the opposite of what `--yes` does: the
-    /// team's incoming lines rendered as deletions and the edits about to be destroyed as
-    /// additions.
-    DraftToCurrent,
+pub(crate) enum BareDiff {
+    /// `topos diff`: `a` is the team's LIVE current, `b` is your copy — so the `+` lines are YOUR
+    /// edits, which is what "show me my change" means, measured against what the team runs now.
+    Diff,
+    /// The `--reset` preview: `a` is your copy (what goes away), `b` is the version that LANDS —
+    /// the applied base this copy records, which is exactly what the reset re-materializes.
+    /// Printed in the other order it said the opposite of what `--yes` does: the incoming lines
+    /// rendered as deletions and the edits about to be destroyed as additions. Measured against
+    /// the live current instead, it listed changes the reset never makes.
+    ResetPreview,
 }
 
 /// [`diff`] over an ALREADY-RESOLVED copy — the shape [`reset_preview_diff`] shares, so a loss
@@ -144,7 +148,7 @@ fn diff_resolved(
     let sp = layout.published(id);
 
     let Some(reference) = r#ref else {
-        return diff_draft_vs_current(&sctx, &sp, lock, budget, sel, DiffSides::CurrentToDraft);
+        return diff_draft_vs_current(&sctx, &sp, lock, budget, sel, BareDiff::Diff);
     };
 
     // Parse the ref: `<a>..<b>` is a range; otherwise a single endpoint compared against `current` (so a
@@ -174,13 +178,19 @@ fn diff_resolved(
     })
 }
 
-/// The `--reset` preview's LOSS diff over an already-resolved copy: the same bare draft ↔ current
-/// read `diff` makes, in the direction a reset runs ([`DiffSides::DraftToCurrent`]) — `a` is the
-/// copy about to be discarded, `b` is the version about to land.
+/// The `--reset` preview's LOSS diff over an already-resolved copy, read the way a reset runs
+/// ([`BareDiff::ResetPreview`]): `a` is the copy about to be discarded, `b` is the version about
+/// to land — the applied base this copy records, rendered from its own store.
+///
+/// It is the APPLIED BASE and not the workspace's live current on purpose: a reset re-materializes
+/// `lock.base_commit` (see `sync_engine::reset_to_base`), so that is the only version whose delta
+/// describes what `--yes` will do. Wherever the two differ — a project lock pinning an older
+/// version, a revert that moved the current out from under this copy — a preview measured against
+/// the live current printed a body of changes the reset would never make, directly under a header
+/// naming the version it does land.
 ///
 /// # Errors
-/// As [`diff_resolved`]: a scan/store failure, a placement freeze, or a transport fault reading
-/// the workspace's live current.
+/// As [`diff_resolved`]: a scan/store failure, a placement freeze, or an unreadable applied base.
 pub(crate) fn reset_preview_diff(
     ctx: &Ctx<'_>,
     layout: &sidecar::Layout,
@@ -191,7 +201,7 @@ pub(crate) fn reset_preview_diff(
 ) -> Result<DiffData, ClientError> {
     let sctx = super::pull::ctx_with_layout(ctx, layout);
     let sp = layout.published(id);
-    diff_draft_vs_current(&sctx, &sp, lock, budget, sel, DiffSides::DraftToCurrent)
+    diff_draft_vs_current(&sctx, &sp, lock, budget, sel, BareDiff::ResetPreview)
 }
 
 /// Apply a byte budget to per-file diff sections: emit LEADING whole sections while the running
@@ -234,7 +244,7 @@ fn apply_budget(
     }
 }
 
-/// The bare draft ↔ current diff (current = the on-machine base commit). `ctx` is the OWNING
+/// The bare draft diff, in the direction and against the base `read` names. `ctx` is the OWNING
 /// store's (see [`diff`]): the store, the placement map, and the drift scan all belong to whichever
 /// scope holds this bundle's custody.
 fn diff_draft_vs_current(
@@ -243,7 +253,7 @@ fn diff_draft_vs_current(
     lock: &Lock,
     budget: DiffBudget,
     sel: &super::Selection,
-    sides: DiffSides,
+    read: BareDiff,
 ) -> Result<DiffData, ClientError> {
     let map: PlacementMap = doc::read_map(ctx.fs, &sp.map)?
         .ok_or_else(|| ClientError::Corrupt("missing placement map".to_owned()))?;
@@ -264,19 +274,24 @@ fn diff_draft_vs_current(
         return Err(refusal);
     }
     let store = Store::open(&sp.store)?;
-    // THE SERVER'S CURRENT IS THE TRUTH: the left side is the workspace's LIVE current, read
-    // here, never the sidecar's cached base. A revert run elsewhere moves `current` without
-    // touching this store, and a diff against the cached base then answered "no changes" over
-    // a copy that differs from what the team runs. The cached base stands only where there is
-    // no live current to read (a bundle no workspace delivers here) or where it IS the current.
-    let (version_id, base_files) = match live_current(ctx, lock, &store)? {
-        Some(live) => live,
-        None => {
-            let version_id = parse_hex32(&lock.base_commit)?;
-            let bundle_digest = parse_hex32(&lock.bundle_digest)?;
-            let base = store.render_verified(version_id, bundle_digest)?;
-            (lock.base_commit.clone(), rendered_files(base))
-        }
+    // WHICH VERSION the copy is measured against — and the two reads answer differently.
+    //
+    // For `diff`, THE SERVER'S CURRENT IS THE TRUTH: the other side is the workspace's LIVE
+    // current, read here, never the sidecar's cached base. A revert run elsewhere moves `current`
+    // without touching this store, and a diff against the cached base then answered "no changes"
+    // over a copy that differs from what the team runs. The applied base stands only where there
+    // is no live current to read (a bundle no workspace delivers here) or where it IS the current.
+    //
+    // For the RESET PREVIEW it is the APPLIED BASE, always: the reset puts that version back, so
+    // it is the only ruler whose delta is the loss the preview promises (see
+    // [`reset_preview_diff`]). The live current is not read at all — a version this reset does not
+    // land has nothing to say about what it discards.
+    let (version_id, base_files) = match read {
+        BareDiff::ResetPreview => applied_base(&store, lock)?,
+        BareDiff::Diff => match live_current(ctx, lock, &store)? {
+            Some(live) => live,
+            None => applied_base(&store, lock)?,
+        },
     };
     // The draft side is the WORK TREE — the single edited copy when one exists (draft-anywhere),
     // else the first placement; several divergent copies freeze typed. A `-a`/`--dest` selection
@@ -314,9 +329,9 @@ fn diff_draft_vs_current(
     // `a` is always the side that GOES AWAY: for `diff` that is the team's current (your edits
     // read as `+`), for the reset preview it is your copy (your edits read as `-`, and the
     // version that lands reads as `+`).
-    let sections = match sides {
-        DiffSides::CurrentToDraft => unified_diff_sections(&base_files, &draft_files),
-        DiffSides::DraftToCurrent => unified_diff_sections(&draft_files, &base_files),
+    let sections = match read {
+        BareDiff::Diff => unified_diff_sections(&base_files, &draft_files),
+        BareDiff::ResetPreview => unified_diff_sections(&draft_files, &base_files),
     };
     let (diff, truncated, files) = apply_budget(sections, budget);
 
@@ -334,6 +349,18 @@ fn diff_draft_vs_current(
         skill: dest.as_ref().map(|_| lock.name.clone()),
         dest,
     })
+}
+
+/// The version this store APPLIED — `lock.base_commit` rendered from the local store and
+/// re-verified against the digest the lock records: `(version id, its files)`.
+///
+/// # Errors
+/// A malformed id/digest in the lock, or a store read that fails verify-on-read.
+fn applied_base(store: &Store, lock: &Lock) -> Result<(String, Vec<DiffFileOwned>), ClientError> {
+    let version_id = parse_hex32(&lock.base_commit)?;
+    let bundle_digest = parse_hex32(&lock.bundle_digest)?;
+    let base = store.render_verified(version_id, bundle_digest)?;
+    Ok((lock.base_commit.clone(), rendered_files(base)))
 }
 
 /// The workspace's LIVE `current` for a followed bundle, when it is NOT the version this store

--- a/bins/topos/src/ops/pull.rs
+++ b/bins/topos/src/ops/pull.rs
@@ -617,7 +617,10 @@ pub(crate) fn reset(
         // above (never re-resolved: a second pass could answer with the other scope's copy and
         // describe a loss nobody is about to take). Read in the direction the RESET runs: `a` is
         // this copy (what goes away), `b` is the version that lands — a preview that read the
-        // other way told a person the opposite of what `--yes` was about to do. DIVERGENT copies
+        // other way told a person the opposite of what `--yes` was about to do. And measured
+        // against exactly the version `to_version` names below — `lock.base_commit`, what
+        // `reset_to_base` puts back — never the workspace's live current: where a pin or a revert
+        // left the two apart, the body listed changes `--yes` would never make. DIVERGENT copies
         // cannot render one diff (that freeze is exactly what `--reset` is the named way out of),
         // so the loss is disclosed as the frozen set instead of failing the reset. UNCAPPED
         // deliberately: a loss disclosure must never truncate what would be discarded.

--- a/bins/topos/src/ops/reconcile.rs
+++ b/bins/topos/src/ops/reconcile.rs
@@ -4546,6 +4546,17 @@ impl Step {
     }
 }
 
+/// The version a scope's copy of `sid` HOLDS right now — `lock.base_commit`, the id every other
+/// surface reports for it. `None` when there is no lock yet, or when it carries the never-received
+/// baseline's empty id (nothing is held, so nothing can be replaced).
+fn held_version(ctx: &Ctx<'_>, sid: &SkillId) -> Option<String> {
+    doc::read_doc::<Lock>(ctx.fs, &ctx.layout.published(sid).lock)
+        .ok()
+        .flatten()
+        .map(|l| l.base_commit)
+        .filter(|v| !v.is_empty())
+}
+
 /// Sync ONE workspace bundle toward its served (or pinned) version, at the resolved scope.
 fn sync_workspace_skill<'a>(
     env: &Env<'a>,
@@ -4743,6 +4754,10 @@ fn sync_workspace_skill<'a>(
                     .collect()
             })
             .unwrap_or_default();
+    // The version this scope HOLDS going in — the half of the replaced-version disclosure below
+    // that stops existing the moment the engine writes, so it is read here, from the same store
+    // the sync is about to move. Empty = a never-received baseline (nothing was replaced).
+    let held_before = held_version(&run_ctx, &sid);
     let outcome = sync_engine::sync_one_planned(
         &run_ctx,
         &sid,
@@ -4818,6 +4833,27 @@ fn sync_workspace_skill<'a>(
                 sweep
                     .disclosures
                     .push(draft_synced_line(&target.name, row.synced_placements));
+            }
+            // WHICH VERSION THIS COPY REPLACED. A project scope says it from `topos.lock` — the
+            // `LOCK_MOVED` line the write-back builds from the old and the new document — and the
+            // machine has no lock, so a `-g` sweep printed `fast-forwarded` and never named
+            // either end of the move. The lock did not move here; the COPY did, and the copy is
+            // what the line is about. Same wording, same channel, same place in the receipt.
+            if matches!(sc.scope, ResolvedScope::Person)
+                && row.action == PullAction::FastForwarded
+                && let Some(before) = held_before.as_deref()
+                && let Some(after) = held_version(&run_ctx, &sid)
+                && before != after
+            {
+                sweep.disclosures.push(crate::message::disclosure(
+                    "COPY_MOVED",
+                    format!(
+                        "{}: {} → {}",
+                        st.display,
+                        crate::render::short(before),
+                        crate::render::short(&after)
+                    ),
+                ));
             }
             // Disclose a delivery the naming ladder had to place BESIDE a same-named occupant the
             // record does not own (the never-clobber outcome) — and a project placement a

--- a/bins/topos/src/tests/manifest_reconcile/scope.rs
+++ b/bins/topos/src/tests/manifest_reconcile/scope.rs
@@ -1177,3 +1177,141 @@ fn a_target_from_the_other_scope_refuses_naming_the_scope_it_searched() {
     );
     assert!(msg.contains("`topos add -g api`"), "{msg}");
 }
+
+// =================================================================================================
+// WHICH VERSION A COPY REPLACED — said at both scopes, once.
+// =================================================================================================
+
+/// The 12 chars every receipt spells a version id with.
+fn short12(v: &Version) -> String {
+    crate::render::short(&topos_core::digest::to_hex(&v.id)).to_owned()
+}
+
+/// The disclosure lines of one code, in order.
+fn coded<'a>(out: &'a ops::PullOutcome, code: &str) -> Vec<&'a str> {
+    out.disclosures
+        .iter()
+        .filter(|m| m.code.as_deref() == Some(code))
+        .map(|m| m.text.as_str())
+        .collect()
+}
+
+/// **A MACHINE-WIDE UPDATE NAMES THE VERSION IT REPLACED.** A project update says it from
+/// `topos.lock` (the old document against the new one); the machine has no lock, so `-g` printed
+/// `fast-forwarded` and named neither end of the move — leaving out the one id a person needs to
+/// type to put the old bytes back. The lock did not move here; the COPY did, and the copy is what
+/// the line is about: same wording, same channel, same `note:` place in the receipt. A FIRST
+/// receive replaced nothing and says nothing.
+#[test]
+fn a_machine_scope_update_discloses_the_version_it_replaced() {
+    let rig = Rig::new("g-replaced");
+    rig.seed_session();
+    let v1 = one_file(b"# v1\n");
+    let v2 = one_file(b"# v2\n");
+    let plane = FakePlane::new(Arc::new(Mutex::new(Vec::new())))
+        .with_version("s_deploy", &v1)
+        .with_version("s_deploy", &v2);
+    rig.write_global(&format!(
+        "[skills]\n\"{HOST}/{WS_NAME}/deploy\" = \"latest\"\n"
+    ));
+    let ctx = rig.ctx_at(Some(&rig.work.0));
+
+    // The first receive: bytes land, and nothing was replaced.
+    let dir = FakeDirectory::new(vec![catalog_entry("s_deploy", "deploy", &v1)], Vec::new());
+    let first = sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    assert_eq!(first.data.skills[0].action, PullAction::Installed);
+    assert!(
+        coded(&first, "COPY_MOVED").is_empty(),
+        "{:?}",
+        first.disclosures
+    );
+
+    // The team publishes; the machine's copy fast-forwards — and says off what.
+    let dir = FakeDirectory::new(vec![catalog_entry("s_deploy", "deploy", &v2)], Vec::new());
+    let out = sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    assert_eq!(out.data.skills[0].action, PullAction::FastForwarded);
+    assert_eq!(
+        coded(&out, "COPY_MOVED"),
+        vec![format!("deploy: {} → {}", short12(&v1), short12(&v2))],
+        "exactly one line, naming both ends: {:?}",
+        out.disclosures
+    );
+    let receipt = crate::render::pull_tty(
+        &out.data,
+        &out.decisions,
+        &out.warnings,
+        &out.advisories,
+        &out.disclosures,
+        out.failed_bundles.len(),
+        out.unplaced_bundles.len(),
+    );
+    assert_eq!(
+        receipt
+            .lines()
+            .filter(|l| l.starts_with("note: deploy: "))
+            .count(),
+        1,
+        "{receipt}"
+    );
+
+    // A sweep with nothing to move says nothing again.
+    let quiet = sweep_scoped(&ctx, &plane, &dir, ops::UpdateScope::Machine);
+    assert!(
+        coded(&quiet, "COPY_MOVED").is_empty(),
+        "old == new is not a move: {:?}",
+        quiet.disclosures
+    );
+}
+
+/// …and the project scope keeps saying it ONCE, through the lock it moves. The copy-level line is
+/// the machine's answer to having no lock — a project run that emitted both would print the same
+/// fact twice under two codes.
+#[test]
+fn a_project_scope_update_discloses_the_replaced_version_only_once() {
+    let rig = Rig::new("proj-replaced");
+    rig.seed_session();
+    let v1 = one_file(b"# v1\n");
+    let v2 = one_file(b"# v2\n");
+    let plane = FakePlane::new(Arc::new(Mutex::new(Vec::new())))
+        .with_version("s_deploy", &v1)
+        .with_version("s_deploy", &v2);
+    let proj = project(
+        "proj-replaced-checkout",
+        &format!("workspace = \"{HOST}/{WS_NAME}\"\n\n[skills]\ndeploy = \"latest\"\n"),
+    );
+    let ctx = rig.ctx_at(Some(&proj.0));
+
+    let dir = FakeDirectory::new(vec![catalog_entry("s_deploy", "deploy", &v1)], Vec::new());
+    sweep(&ctx, &plane, &dir);
+    let dir = FakeDirectory::new(vec![catalog_entry("s_deploy", "deploy", &v2)], Vec::new());
+    let out = sweep(&ctx, &plane, &dir);
+
+    assert_eq!(
+        coded(&out, "LOCK_MOVED"),
+        vec![format!("deploy: {} → {}", short12(&v1), short12(&v2))],
+        "{:?}",
+        out.disclosures
+    );
+    assert!(
+        coded(&out, "COPY_MOVED").is_empty(),
+        "the lock already said it: {:?}",
+        out.disclosures
+    );
+    let receipt = crate::render::pull_tty(
+        &out.data,
+        &out.decisions,
+        &out.warnings,
+        &out.advisories,
+        &out.disclosures,
+        out.failed_bundles.len(),
+        out.unplaced_bundles.len(),
+    );
+    assert_eq!(
+        receipt
+            .lines()
+            .filter(|l| l.starts_with("note: deploy: "))
+            .count(),
+        1,
+        "{receipt}"
+    );
+}

--- a/bins/topos/src/tests/sync/pull.rs
+++ b/bins/topos/src/tests/sync/pull.rs
@@ -117,6 +117,88 @@ fn a_bare_diff_reads_against_the_live_current_not_the_cached_base() {
     );
 }
 
+/// **A RESET PREVIEW IS MEASURED AGAINST THE VERSION IT RESTORES.** `--reset` re-materializes the
+/// version this copy applied (`lock.base_commit`), and the describe's header names it. The body
+/// under that header used to be the bare `diff` read — the copy against the workspace's LIVE
+/// current — so the moment the two came apart (a revert landed on the server, a lock pins an
+/// older version) the preview listed changes `--yes` would never make, directly beneath a header
+/// naming the version it does land. `topos diff` is untouched: measuring YOUR change against what
+/// the team runs now is exactly what that verb is for.
+#[test]
+fn a_reset_preview_reads_against_the_version_it_restores_not_the_live_current() {
+    let rig = Rig::new("reset-preview-base");
+    let (id, name, genesis) = rig.adopt(BASE);
+    let v1 = mk_version(&[genesis], V1, "d_pub", "v1");
+
+    let mut plane = FixturePlane::default();
+    plane.add_version(&id, &v1);
+    plane.set_current(&id, served(WS, &id, v1.id, 1));
+    let foll = follow(&id);
+    assert_eq!(
+        only(&pull_data(&rig.ctx(&plane, &foll), ops::PullScope::AllFollowed).unwrap()).action,
+        PullAction::FastForwarded
+    );
+
+    // A revert run elsewhere puts the genesis bytes back as `current`. No sweep has run here
+    // since, so this copy still HOLDS v1 — and a reset here restores v1, not the revert.
+    let restored = mk_version(&[v1.id], BASE, "d_rev", "topos: revert");
+    plane.add_version(&id, &restored);
+    plane.set_current(&id, served(WS, &id, restored.id, 2));
+
+    // …and the copy is edited: one file rewritten over v1, the rest of v1 left alone.
+    write_tree(
+        &rig.placement(),
+        &[
+            ("SKILL.md", FileMode::Regular, b"# mine\n"),
+            ("run.sh", FileMode::Executable, b"#!/bin/sh\necho v1\n"),
+            ("ref/notes.md", FileMode::Regular, b"new in v1\n"),
+        ],
+    );
+
+    let ctx = rig.ctx(&plane, &foll);
+    let ops::ResetOutcome::Described { items, .. } = ops::reset(
+        &ctx,
+        std::slice::from_ref(&name),
+        false,
+        ops::StoreScope::Here,
+        &ops::Selection::default(),
+    )
+    .unwrap() else {
+        panic!("without `--yes` the reset describes");
+    };
+    assert_eq!(items[0].to_version, to_hex(&v1.id), "v1 is what lands");
+    let body = &items[0].drop_diff;
+    assert!(
+        body.contains("-# mine") && body.contains("+# v1"),
+        "the edit goes away and v1's line comes back: {body}"
+    );
+    assert!(
+        !body.contains("ref/notes.md") && !body.contains("echo v0"),
+        "the live current's bytes are not what `--yes` puts back: {body}"
+    );
+
+    // `topos diff` over the very same state still reads against the live current.
+    let d = ops::diff(
+        &ctx,
+        &name,
+        None,
+        ops::DiffBudget::unlimited(),
+        &ops::Selection::default(),
+        ops::StoreScope::Here,
+    )
+    .unwrap();
+    assert_eq!(
+        d.version_id,
+        to_hex(&restored.id),
+        "the server's current is the truth for `diff`"
+    );
+    assert!(
+        d.diff.contains("ref/notes.md"),
+        "the real difference against what the team runs: {}",
+        d.diff
+    );
+}
+
 /// By the merge model an unmodified copy fast-forwards, and it does so even when the served
 /// current UNDOES the version it holds (a revert restored older bytes). What the receipt then owes
 /// is the disclosure: which version it replaced, and the one command that brings it back. An


### PR DESCRIPTION
Two defects found by a by-hand run against a live server on v0.1.56.

## 1 — `update --reset <bundle>`: the preview body was measured against the wrong version

The describe's header named `lock.base_commit` (what `sync_engine::reset_to_base`
re-materializes — correct), while the body under it came from the bare `diff` read,
whose other side is the workspace's LIVE current. Wherever the two come apart — a
project lock pinning an older version, a revert landed on the server since this copy
last swept — the preview listed a file added, a file deleted and a mode flip that
`--yes` would never make, directly beneath a header naming the version it does land.

`ops::diff::BareDiff` (was `DiffSides`) now carries BOTH halves of the read, the
direction and the base, so the two cannot drift apart again:

- `BareDiff::Diff` — `topos diff`, unchanged: the other side is the live current, and
  the applied base stands only where there is no live current to read.
- `BareDiff::ResetPreview` — `lock.base_commit`, rendered and re-verified from the
  copy's own store. The live current is not read at all: a version this reset does not
  land has nothing to say about what it discards.

Files: `bins/topos/src/ops/diff.rs` (the enum at ~L110, `reset_preview_diff` ~L181,
the base selection in `diff_draft_vs_current` ~L276, the new `applied_base` helper
~L354); comment corrected at `bins/topos/src/ops/pull.rs` ~L617.

## 2 — machine-wide `update -g` omitted the replaced-version disclosure

Project scope names both ends of a move (`<bundle>: <old12> → <new12>`, the
`LOCK_MOVED` line built from the old `topos.lock` document against the new one), so
the id needed to put the old bytes back is on screen. The machine has no lock, and
the `-g` receipt row said only `fast-forwarded`.

The lock did not move there; the copy did — so the reconcile emits the same sentence
under its own code, `COPY_MOVED`, when a machine-scope copy actually changes version.
Same disclosure channel, same `note:` line in the receipt. Not emitted when old ==
new, not emitted on a first receive, and never beside `LOCK_MOVED` (project scope
still says the fact exactly once). The `update -g` counter line is unchanged, and the
silent hook sweep prints no disclosures, so nothing new appears at session start.

The message `code` vocabulary is documented as open (`docs/agents.mdx`) with no
enumerated list anywhere, so no docs regeneration was needed — the `cli reference`
drift gate confirms it.

Files: `bins/topos/src/ops/reconcile.rs` — `held_version` helper ~L4549,
pre-sync read ~L4757, the disclosure in `sync_workspace_skill`'s `Ok` arm ~L4837.

## Tests

- `bins/topos/src/tests/sync/pull.rs` —
  `a_reset_preview_reads_against_the_version_it_restores_not_the_live_current`: the
  copy holds v1, the plane's current is a revert onto the genesis bytes, the work tree
  is edited; asserts the preview's `to_version` is v1 and its body is the draft
  against v1 (v1's line comes back; the revert's bytes are absent), and that
  `topos diff` over the same state still reports the live current. Verified to fail
  before the fix.
- `bins/topos/src/tests/manifest_reconcile/scope.rs` —
  `a_machine_scope_update_discloses_the_version_it_replaced`: one `COPY_MOVED` line in
  the typed disclosures and one `note:` line in the rendered receipt; nothing on the
  first receive, nothing on an idle re-sweep.
- `bins/topos/src/tests/manifest_reconcile/scope.rs` —
  `a_project_scope_update_discloses_the_replaced_version_only_once`: `LOCK_MOVED`
  stands, `COPY_MOVED` is absent, one `note:` line in the receipt.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p topos` — 1435 + 63 + 2 + 3 + 6 passed, 0 failed
- `cargo xtask ci` — all 8 gates green (schemas, openapi, fixtures, cli reference,
  harness registry, layering)
- `cargo test -p topos-e2e` — 20 passed, 0 failed (after `bun install && bun run
  build` in `web/`, which the composed e2e requires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
