### PR TITLE
v0.1.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3959,7 +3959,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "topos"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "base64",
  "clap",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "sha2",
  "unicode-normalization",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "axum",
  "plane-store",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "diffy",
  "flate2",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "hex",
  "jsonc-parser",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "anyhow",
  "axum",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.57" # members inherit via `version.workspace = true`; bump to match the tag before tagging
+version = "0.1.58" # members inherit via `version.workspace = true`; bump to match the tag before tagging
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   plane:
     # Pinned to one release (see the header). Override with TOPOS_VERSION, or build from source with
     # the docker-compose.build.yml override.
-    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.57}
+    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.58}
     restart: unless-stopped
     mem_limit: 1g
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
@@ -186,7 +186,7 @@ services:
   gateway:
     # The same release as the other two — one TOPOS_VERSION moves all three, and they are only ever
     # tested together.
-    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.57}
+    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.58}
     restart: unless-stopped
     mem_limit: 1g
     # WHAT THIS BOUNDS IS CONCURRENT MCP STREAMS, NOT MEMORY (mem_limit above is the memory
@@ -253,7 +253,7 @@ services:
   web:
     # The same release as the plane and the gateway — one TOPOS_VERSION moves all three, and they are
     # only ever tested together.
-    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.57}
+    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.58}
     restart: unless-stopped
     mem_limit: 1g
     depends_on:

--- a/web/app/lib/plane/contract/version.ts
+++ b/web/app/lib/plane/contract/version.ts
@@ -4,7 +4,7 @@
  */
 
 /** The release version of the build serving this app — what the protocol card declares. */
-export const SERVER_RELEASE_VERSION = "0.1.57";
+export const SERVER_RELEASE_VERSION = "0.1.58";
 
 /** The wire contract's version — stamped on every document this tier emits. */
 export const WIRE_SCHEMA_VERSION = 2;


### PR DESCRIPTION
Version bump to 0.1.58.

Carries #99 (`install --frozen` never asks; an unplaced bundle is reported as fetched) on top of v0.1.57 (#97: the `update --reset` preview reads the version that lands; a machine-scope update names the version it replaced).