### PR TITLE
v0.1.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plane-store"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3959,7 +3959,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "topos"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "base64",
  "clap",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "sha2",
  "unicode-normalization",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "topos-e2e"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "axum",
  "plane-store",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "topos-gitstore"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "diffy",
  "flate2",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "topos-harness"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "hex",
  "jsonc-parser",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "topos-plane"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "anyhow",
  "axum",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "topos-types"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.58" # members inherit via `version.workspace = true`; bump to match the tag before tagging
+version = "0.1.59" # members inherit via `version.workspace = true`; bump to match the tag before tagging
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   plane:
     # Pinned to one release (see the header). Override with TOPOS_VERSION, or build from source with
     # the docker-compose.build.yml override.
-    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.58}
+    image: ghcr.io/topos-sh/topos-plane:${TOPOS_VERSION:-v0.1.59}
     restart: unless-stopped
     mem_limit: 1g
     # NO `ports:` — the plane is internal-only. The web app reaches it at http://plane:8787 over the
@@ -186,7 +186,7 @@ services:
   gateway:
     # The same release as the other two — one TOPOS_VERSION moves all three, and they are only ever
     # tested together.
-    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.58}
+    image: ghcr.io/topos-sh/topos-gateway:${TOPOS_VERSION:-v0.1.59}
     restart: unless-stopped
     mem_limit: 1g
     # WHAT THIS BOUNDS IS CONCURRENT MCP STREAMS, NOT MEMORY (mem_limit above is the memory
@@ -253,7 +253,7 @@ services:
   web:
     # The same release as the plane and the gateway — one TOPOS_VERSION moves all three, and they are
     # only ever tested together.
-    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.58}
+    image: ghcr.io/topos-sh/topos-web:${TOPOS_VERSION:-v0.1.59}
     restart: unless-stopped
     mem_limit: 1g
     depends_on:

--- a/web/app/lib/plane/contract/version.ts
+++ b/web/app/lib/plane/contract/version.ts
@@ -4,7 +4,7 @@
  */
 
 /** The release version of the build serving this app — what the protocol card declares. */
-export const SERVER_RELEASE_VERSION = "0.1.58";
+export const SERVER_RELEASE_VERSION = "0.1.59";
 
 /** The wire contract's version — stamped on every document this tier emits. */
 export const WIRE_SCHEMA_VERSION = 2;


### PR DESCRIPTION
Version bump for the pick-and-paths increment (#101): workspace version, compose image pins on all three services, and the app's declared protocol version.

Contents since v0.1.58: a project's pick is independent of the machine pick; topos names the installed agents and the `topos init -a <agent>` command and exits 2 instead of prompting; Codex project skills move to `.codex/skills`; OpenCode project MCP config moves to `.opencode/opencode.json`; Claude Code MCP servers move to `~/.claude.json` (per-checkout slot for a project, top-level for `-g`) keeping their plain names, retiring the plugin folder and leaving the project root clean.

Floors unmoved (`MIN_SERVER_VERSION` / `MIN_CLI_VERSION` stay 0.1.42): additive on the wire. The harness table's engine version moved 3 → 4 in #101, so CLIs older than this release keep their bundled table instead of the served one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)